### PR TITLE
Use stable SHA-256 seeds for reproducible forecast fallbacks and cache signatures

### DIFF
--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -36,6 +36,7 @@ from config import (
     TAB_LABELS,
 )
 from data.redis_client import redis_get
+from hash_utils import stable_int_seed
 from personas.config import PERSONAS, get_persona, get_welcome_card
 
 log = structlog.get_logger()
@@ -135,7 +136,7 @@ def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region
         demand_sig = f"{_normalize_ts(demand_df['timestamp'].iloc[0])}_{_normalize_ts(demand_df['timestamp'].iloc[-1])}"
     if "timestamp" in weather_df.columns and len(weather_df) > 0:
         weather_sig = f"{_normalize_ts(weather_df['timestamp'].iloc[0])}_{_normalize_ts(weather_df['timestamp'].iloc[-1])}"
-    return hash((demand_sig, weather_sig, region))
+    return stable_int_seed(("callbacks_data_hash", demand_sig, weather_sig, region))
 
 
 def _confidence_half_width(horizon_hours: int) -> float:
@@ -2718,7 +2719,7 @@ def register_callbacks(app):
         hdd_delta = max(0, 65 - temp) - max(0, 65 - baseline_temp)
         temp_factor = 1 + (cdd_delta * 0.02 + hdd_delta * 0.015) / 65
 
-        seed = hash((region, temp, wind)) & 0xFFFFFFFF
+        seed = stable_int_seed(("scenario_simulation", region, temp, wind))
         rng = np.random.RandomState(seed)
         scenario = baseline * temp_factor + rng.normal(0, capacity * 0.005, len(baseline))
         scenario = np.maximum(scenario, 0)

--- a/hash_utils.py
+++ b/hash_utils.py
@@ -1,0 +1,31 @@
+"""Stable hashing utilities for reproducible seeds/signatures."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+
+
+def _normalize_seed_input(value: object) -> str:
+    """Normalize a value into a deterministic string representation."""
+    if isinstance(value, tuple):
+        return "|".join(_normalize_seed_input(item) for item in value)
+    if isinstance(value, list):
+        return "|".join(_normalize_seed_input(item) for item in value)
+    if isinstance(value, dict):
+        return "|".join(
+            f"{_normalize_seed_input(k)}:{_normalize_seed_input(v)}"
+            for k, v in sorted(value.items(), key=lambda kv: str(kv[0]))
+        )
+    if isinstance(value, set):
+        return "|".join(sorted(_normalize_seed_input(item) for item in value))
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        return "|".join(_normalize_seed_input(item) for item in value)
+    return str(value)
+
+
+def stable_int_seed(string_or_tuple: object) -> int:
+    """Return a stable unsigned int32 seed from arbitrary input."""
+    normalized = _normalize_seed_input(string_or_tuple)
+    digest = hashlib.sha256(normalized.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], byteorder="big", signed=False)

--- a/models/model_service.py
+++ b/models/model_service.py
@@ -21,6 +21,7 @@ import pandas as pd
 import structlog
 
 from config import MODEL_DIR
+from hash_utils import stable_int_seed
 
 log = structlog.get_logger()
 
@@ -164,7 +165,7 @@ def _predict_from_trained(
         except Exception as e:
             log.warning("model_predict_failed", model=name, error=str(e))
             # Fall back to simulated for this model
-            seed = hash(name) & 0xFFFFFFFF
+            seed = stable_int_seed(("model_fallback", name))
             rng = np.random.RandomState(seed)
             noise_scale = {"prophet": 0.025, "arima": 0.035, "xgboost": 0.018}.get(name, 0.025)
             all_preds[name] = actual * (1 + rng.normal(0, noise_scale, n))
@@ -206,7 +207,7 @@ def _simulate_forecasts(
     "model" outputs. This is consistent across page loads (no random flicker).
     """
     n = len(actual)
-    seed = hash(region) & 0xFFFFFFFF
+    seed = stable_int_seed(("simulate_forecasts", region))
     rng = np.random.RandomState(seed)
 
     # Model-specific noise levels (realistic relative accuracy)

--- a/tests/unit/test_stable_hash_reproducibility.py
+++ b/tests/unit/test_stable_hash_reproducibility.py
@@ -1,0 +1,60 @@
+"""Reproducibility tests for stable hashing used in cache signatures/seeds."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+
+
+def _run_python(code: str) -> str:
+    """Execute Python code in a fresh interpreter and return stdout."""
+    return subprocess.check_output([sys.executable, "-c", code], text=True).strip()
+
+
+def test_stable_int_seed_identical_across_processes():
+    code = textwrap.dedent("""
+        from hash_utils import stable_int_seed
+        print(stable_int_seed(("scenario_simulation", "ERCOT", 95, 14.2)))
+    """)
+    first = _run_python(code)
+    second = _run_python(code)
+    assert first == second
+
+
+def test_callbacks_data_hash_identical_across_processes():
+    code = textwrap.dedent("""
+        import json
+        import pandas as pd
+        from components.callbacks import _compute_data_hash
+
+        ts = pd.date_range("2024-01-01", periods=48, freq="h", tz="UTC")
+        demand = pd.DataFrame({"timestamp": ts, "demand_mw": range(48)})
+        weather = pd.DataFrame({"timestamp": ts, "temperature_2m": range(48)})
+        print(_compute_data_hash(demand, weather, "PJM"))
+    """)
+    first = _run_python(code)
+    second = _run_python(code)
+    assert first == second
+
+
+def test_simulated_forecasts_identical_across_processes():
+    code = textwrap.dedent("""
+        import json
+        import numpy as np
+        from models.model_service import _simulate_forecasts
+
+        actual = np.linspace(30000, 32000, 96)
+        result = _simulate_forecasts("CAISO", actual, models_shown=None)
+        payload = {
+            "prophet": [round(float(v), 6) for v in result["prophet"][:6]],
+            "arima": [round(float(v), 6) for v in result["arima"][:6]],
+            "xgboost": [round(float(v), 6) for v in result["xgboost"][:6]],
+            "ensemble": [round(float(v), 6) for v in result["ensemble"][:6]],
+        }
+        print(json.dumps(payload, sort_keys=True))
+    """)
+    first = json.loads(_run_python(code))
+    second = json.loads(_run_python(code))
+    assert first == second


### PR DESCRIPTION
### Motivation
- Replace use of Python's built-in `hash(...)` (which is process-randomized) for RNG seeds and cache signatures to ensure identical cache keys and pseudo-random fallbacks across process restarts. 
- Provide a single, auditable helper for deriving deterministic uint32 seeds from strings/tuples/iterables.

### Description
- Added `hash_utils.py` with `stable_int_seed(...)` that normalizes inputs and derives a deterministic unsigned int32 seed using SHA-256. 
- Replaced `hash(name)` and `hash(region)` usage in `models/model_service.py` with `stable_int_seed(...)` for per-model fallback seeding and simulated-forecast seeding. 
- Replaced the `hash(...)`-based `_compute_data_hash(...)` and scenario RNG seed in `components/callbacks.py` with `stable_int_seed(...)` to produce stable cache signatures and reproducible scenario outputs. 
- Added `tests/unit/test_stable_hash_reproducibility.py` that verifies `stable_int_seed`, `_compute_data_hash`, and `_simulate_forecasts` produce identical outputs when invoked in fresh Python interpreter processes.

### Testing
- Ran `python -m compileall hash_utils.py models/model_service.py components/callbacks.py tests/unit/test_stable_hash_reproducibility.py`, which succeeded. 
- Executed lightweight subprocess checks that call `stable_int_seed(...)` and `_simulate_forecasts(...)` in fresh interpreters and confirmed identical outputs across runs (manual subprocess comparisons succeeded). 
- Attempted targeted `pytest`, but test collection failed due to the environment using Python 3.10 while project code imports `datetime.UTC` (requires Python 3.11+), so the full test-suite could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ea946de08329afc25ae84bad8ac6)