### PR TITLE
Protect cache correctness with versioned input signatures

### DIFF
--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -18,6 +18,8 @@ Sprint 4 changes:
 """
 
 import io
+import json
+import hashlib
 
 import dash_bootstrap_components as dbc
 import numpy as np
@@ -43,6 +45,7 @@ log = structlog.get_logger()
 import threading  # noqa: E402
 
 _cache_lock = threading.Lock()
+_CACHE_VERSION = 2
 
 _MODEL_CACHE: dict = {}  # {(region, model_name, horizon): (model, data_hash, timestamp)}
 _PREDICTION_CACHE: dict = {}  # {(region, horizon): (predictions, timestamps, data_hash, time)}
@@ -113,13 +116,14 @@ PERSONA_CONTROLLED_TAB_IDS = [
 ]
 
 
-def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region: str) -> int:
-    """Content-aware hash: uses date range + region for cache invalidation.
+def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region: str) -> str:
+    """Compute stable input signature for cache correctness.
 
-    Uses only start/end timestamps (not row count) so that minor row-count
-    drift between precompute and user load doesn't bust the cache.
-    Normalizes timestamps to tz-naive UTC strings so precompute (tz-aware)
-    and callbacks (JSON-deserialized, tz-naive) produce the same hash.
+    Signature includes:
+    - region
+    - row counts
+    - normalized start/end timestamps
+    - lightweight content checksums over key columns
     """
 
     def _normalize_ts(ts) -> str:
@@ -129,13 +133,47 @@ def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region
             t = t.tz_convert("UTC").tz_localize(None)
         return str(t)
 
-    demand_sig = ""
-    weather_sig = ""
-    if "timestamp" in demand_df.columns and len(demand_df) > 0:
-        demand_sig = f"{_normalize_ts(demand_df['timestamp'].iloc[0])}_{_normalize_ts(demand_df['timestamp'].iloc[-1])}"
-    if "timestamp" in weather_df.columns and len(weather_df) > 0:
-        weather_sig = f"{_normalize_ts(weather_df['timestamp'].iloc[0])}_{_normalize_ts(weather_df['timestamp'].iloc[-1])}"
-    return hash((demand_sig, weather_sig, region))
+    def _frame_sig(df: pd.DataFrame, key_cols: list[str]) -> dict:
+        frame_sig: dict[str, str | int] = {"rows": int(len(df)), "start": "", "end": "", "checksum": ""}
+        if df.empty:
+            return frame_sig
+
+        if "timestamp" in df.columns:
+            frame_sig["start"] = _normalize_ts(df["timestamp"].iloc[0])
+            frame_sig["end"] = _normalize_ts(df["timestamp"].iloc[-1])
+
+        cols = [c for c in key_cols if c in df.columns]
+        if not cols:
+            return frame_sig
+
+        sample = df.loc[:, cols].copy()
+        if "timestamp" in sample.columns:
+            ts = pd.to_datetime(sample["timestamp"], utc=True, errors="coerce").dt.tz_localize(None)
+            sample["timestamp"] = ts.astype("int64")
+        for col in cols:
+            if col != "timestamp" and pd.api.types.is_numeric_dtype(sample[col]):
+                sample[col] = sample[col].round(6)
+
+        hashed = pd.util.hash_pandas_object(sample.fillna(""), index=False).to_numpy(dtype=np.uint64)
+        frame_sig["checksum"] = f"{int(hashed.sum(dtype=np.uint64)):016x}"
+        return frame_sig
+
+    signature_payload = {
+        "region": region,
+        "demand": _frame_sig(demand_df, ["timestamp", "demand_mw"]),
+        "weather": _frame_sig(
+            weather_df,
+            [
+                "timestamp",
+                "temperature_2m",
+                "wind_speed_80m",
+                "shortwave_radiation",
+                "relative_humidity_2m",
+            ],
+        ),
+    }
+    signature_json = json.dumps(signature_payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(signature_json.encode("utf-8")).hexdigest()
 
 
 def _confidence_half_width(horizon_hours: int) -> float:
@@ -248,6 +286,8 @@ def _run_forecast_outlook(
             cached_sqlite is not None
             and isinstance(cached_sqlite, dict)
             and "predictions" in cached_sqlite
+            and cached_sqlite.get("cache_version") == _CACHE_VERSION
+            and cached_sqlite.get("data_hash") == data_hash
         ):
             cached_sqlite["timestamps"] = pd.to_datetime(cached_sqlite["timestamps"])
             cached_sqlite["predictions"] = np.array(cached_sqlite["predictions"])
@@ -484,6 +524,8 @@ def _run_forecast_outlook(
             sqlite_cache = get_cache()
             sqlite_key = f"forecast:{region}:{horizon_hours}:{model_name}"
             serializable = {
+                "cache_version": _CACHE_VERSION,
+                "data_hash": data_hash,
                 "timestamps": [str(t) for t in future_timestamps],
                 "predictions": predictions.tolist()
                 if hasattr(predictions, "tolist")
@@ -3961,6 +4003,8 @@ def _run_backtest_for_horizon(
             cached_sqlite is not None
             and isinstance(cached_sqlite, dict)
             and "actual" in cached_sqlite
+            and cached_sqlite.get("cache_version") == _CACHE_VERSION
+            and cached_sqlite.get("data_hash") == data_hash
         ):
             cached_sqlite["timestamps"] = pd.to_datetime(cached_sqlite["timestamps"]).values
             cached_sqlite["actual"] = np.array(cached_sqlite["actual"])
@@ -4094,6 +4138,8 @@ def _run_backtest_for_horizon(
         sqlite_cache = get_cache()
         sqlite_key = f"backtest:{region}:{horizon_hours}:{model_name}"
         serializable = {
+            "cache_version": _CACHE_VERSION,
+            "data_hash": data_hash,
             "timestamps": [str(t) for t in result["timestamps"]],
             "actual": result["actual"].tolist(),
             "predictions": result["predictions"].tolist(),

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -43,7 +43,7 @@ log = structlog.get_logger()
 import threading  # noqa: E402
 
 _cache_lock = threading.Lock()
-_CACHE_VERSION = 2
+_CACHE_VERSION = 3
 
 _MODEL_CACHE: dict = {}  # {(region, model_name, horizon): (model, data_hash, timestamp)}
 _PREDICTION_CACHE: dict = {}  # {(region, horizon): (predictions, timestamps, data_hash, time)}
@@ -139,8 +139,10 @@ def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region
             return frame_sig
 
         if "timestamp" in df.columns:
-            frame_sig["start"] = _normalize_ts(df["timestamp"].iloc[0])
-            frame_sig["end"] = _normalize_ts(df["timestamp"].iloc[-1])
+            ts_bounds = pd.to_datetime(df["timestamp"], utc=True, errors="coerce")
+            if ts_bounds.notna().any():
+                frame_sig["start"] = _normalize_ts(ts_bounds.min())
+                frame_sig["end"] = _normalize_ts(ts_bounds.max())
 
         cols = [c for c in key_cols if c in df.columns]
         if not cols:
@@ -148,13 +150,14 @@ def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region
 
         sample = df.loc[:, cols].copy()
         if "timestamp" in sample.columns:
-            ts = pd.to_datetime(sample["timestamp"], utc=True, errors="coerce").dt.tz_localize(None)
-            sample["timestamp"] = ts.astype("int64")
+            ts = pd.to_datetime(sample["timestamp"], utc=True, errors="coerce")
+            sample["timestamp"] = ts.view("int64").fillna(-1).astype("int64")
+            sample = sample.sort_values("timestamp", kind="mergesort")
         for col in cols:
             if col != "timestamp" and pd.api.types.is_numeric_dtype(sample[col]):
                 sample[col] = sample[col].round(6)
 
-        hashed = pd.util.hash_pandas_object(sample.fillna(""), index=False).to_numpy(dtype=np.uint64)
+        hashed = pd.util.hash_pandas_object(sample.fillna("<NA>"), index=False).to_numpy(dtype=np.uint64)
         frame_sig["checksum"] = f"{int(hashed.sum(dtype=np.uint64)):016x}"
         return frame_sig
 

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -18,8 +18,6 @@ Sprint 4 changes:
 """
 
 import io
-import json
-import hashlib
 
 import dash_bootstrap_components as dbc
 import numpy as np
@@ -125,6 +123,8 @@ def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region
     - normalized start/end timestamps
     - lightweight content checksums over key columns
     """
+    import hashlib
+    import json
 
     def _normalize_ts(ts) -> str:
         """Strip timezone to produce a stable string regardless of tz-aware vs tz-naive."""

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -135,7 +135,12 @@ def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region
         return str(t)
 
     def _frame_sig(df: pd.DataFrame, key_cols: list[str]) -> dict:
-        frame_sig: dict[str, str | int] = {"rows": int(len(df)), "start": "", "end": "", "checksum": ""}
+        frame_sig: dict[str, str | int] = {
+            "rows": int(len(df)),
+            "start": "",
+            "end": "",
+            "checksum": "",
+        }
         if df.empty:
             return frame_sig
 
@@ -158,7 +163,9 @@ def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region
             if col != "timestamp" and pd.api.types.is_numeric_dtype(sample[col]):
                 sample[col] = sample[col].round(6)
 
-        hashed = pd.util.hash_pandas_object(sample.fillna("<NA>"), index=False).to_numpy(dtype=np.uint64)
+        hashed = pd.util.hash_pandas_object(sample.fillna("<NA>"), index=False).to_numpy(
+            dtype=np.uint64
+        )
         frame_sig["checksum"] = f"{int(hashed.sum(dtype=np.uint64)):016x}"
         return frame_sig
 

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -157,7 +157,7 @@ def _compute_data_hash(demand_df: pd.DataFrame, weather_df: pd.DataFrame, region
         sample = df.loc[:, cols].copy()
         if "timestamp" in sample.columns:
             ts = pd.to_datetime(sample["timestamp"], utc=True, errors="coerce")
-            sample["timestamp"] = ts.view("int64").fillna(-1).astype("int64")
+            sample["timestamp"] = ts.astype("int64").fillna(-1).astype("int64")
             sample = sample.sort_values("timestamp", kind="mergesort")
         for col in cols:
             if col != "timestamp" and pd.api.types.is_numeric_dtype(sample[col]):

--- a/tests/unit/test_callbacks_helpers.py
+++ b/tests/unit/test_callbacks_helpers.py
@@ -209,20 +209,20 @@ class TestComputeDataHash:
 
         empty = pd.DataFrame(columns=["timestamp", "demand_mw"])
         h = _compute_data_hash(empty, empty, "PJM")
-        assert isinstance(h, int)
+        assert isinstance(h, str)
 
     def test_no_timestamp_column(self):
         from components.callbacks import _compute_data_hash
 
         df = pd.DataFrame({"value": [1, 2, 3]})
         h = _compute_data_hash(df, df, "MISO")
-        assert isinstance(h, int)
+        assert isinstance(h, str)
 
     def test_hash_returns_int(self, demand_df, weather_df):
         from components.callbacks import _compute_data_hash
 
         h = _compute_data_hash(demand_df, weather_df, "FPL")
-        assert isinstance(h, int)
+        assert isinstance(h, str)
 
     @pytest.mark.parametrize(
         "region", ["ERCOT", "CAISO", "PJM", "MISO", "NYISO", "FPL", "SPP", "ISONE"]
@@ -231,7 +231,7 @@ class TestComputeDataHash:
         from components.callbacks import _compute_data_hash
 
         h = _compute_data_hash(demand_df, weather_df, region)
-        assert isinstance(h, int)
+        assert isinstance(h, str)
 
     def test_tz_naive_vs_tz_aware_same_hash(self):
         """Timestamps with and without tz info should hash identically (by design)."""

--- a/tests/unit/test_callbacks_helpers.py
+++ b/tests/unit/test_callbacks_helpers.py
@@ -1379,9 +1379,16 @@ class TestRunBacktestForHorizon:
 
     @patch("data.cache.get_cache")
     def test_sqlite_cache_hit(self, mock_get_cache, demand_df, weather_df):
-        from components.callbacks import _run_backtest_for_horizon
+        from components.callbacks import (
+            _CACHE_VERSION,
+            _compute_data_hash,
+            _run_backtest_for_horizon,
+        )
 
+        data_hash = _compute_data_hash(demand_df, weather_df, "ERCOT")
         sqlite_result = {
+            "cache_version": _CACHE_VERSION,
+            "data_hash": data_hash,
             "actual": [30000, 31000, 29000],
             "predictions": [30100, 30900, 29100],
             "timestamps": ["2024-01-01", "2024-01-02", "2024-01-03"],

--- a/tests/unit/test_callbacks_module_helpers.py
+++ b/tests/unit/test_callbacks_module_helpers.py
@@ -115,7 +115,7 @@ class TestComputeDataHash:
         w = pd.DataFrame(columns=["timestamp"])
         # Should not raise
         result = _compute_data_hash(d, w, "PJM")
-        assert isinstance(result, int)
+        assert isinstance(result, str)
 
     def test_returns_int(self):
         from components.callbacks import _compute_data_hash
@@ -123,7 +123,7 @@ class TestComputeDataHash:
         d = _make_demand_df(10)
         w = _make_weather_df(10)
         result = _compute_data_hash(d, w, "MISO")
-        assert isinstance(result, int)
+        assert isinstance(result, str)
 
 
 # ===================================================================

--- a/tests/unit/test_callbacks_v1_paths.py
+++ b/tests/unit/test_callbacks_v1_paths.py
@@ -196,12 +196,15 @@ class TestRunForecastOutlook:
 
     def test_sqlite_cache_hit(self):
         """When in-memory cache misses but SQLite has data, return from SQLite."""
-        from components.callbacks import _run_forecast_outlook
+        from components.callbacks import _CACHE_VERSION, _compute_data_hash, _run_forecast_outlook
 
         demand = _demand_df(200)
         weather = _weather_df(200)
+        data_hash = _compute_data_hash(demand, weather, "FPL")
 
         sqlite_result = {
+            "cache_version": _CACHE_VERSION,
+            "data_hash": data_hash,
             "timestamps": ["2024-06-10T00:00:00"] * 24,
             "predictions": [40000.0] * 24,
         }
@@ -578,12 +581,19 @@ class TestRunBacktestForHorizon:
 
     def test_sqlite_cache_hit(self):
         """SQLite cache returns cached result."""
-        from components.callbacks import _run_backtest_for_horizon
+        from components.callbacks import (
+            _CACHE_VERSION,
+            _compute_data_hash,
+            _run_backtest_for_horizon,
+        )
 
         demand = _demand_df(200)
         weather = _weather_df(200)
+        data_hash = _compute_data_hash(demand, weather, "FPL")
 
         sqlite_result = {
+            "cache_version": _CACHE_VERSION,
+            "data_hash": data_hash,
             "timestamps": ["2024-06-10T00:00:00"] * 24,
             "actual": [40000.0] * 24,
             "predictions": [39000.0] * 24,


### PR DESCRIPTION
### Motivation
- Prevent stale or incorrect chart/table data by ensuring cached forecast/backtest payloads are validated against a stronger, content-aware input signature rather than just timestamp ranges.
- Reduce false cache hits caused by minor row drifts or partial updates by including row counts and a lightweight checksum of key columns in the signature.
- Provide a safe migration path for older cache payloads by versioning the cache schema so legacy payloads are treated as misses.

### Description
- Replaced the simple range-based hash with `_compute_data_hash` that returns a SHA-256 hex signature computed from a structured payload containing `region`, per-frame row counts, normalized start/end timestamps, and a compact checksum for selected demand/weather columns.
- Introduced `_CACHE_VERSION = 2` and updated both `_run_forecast_outlook` and `_run_backtest_for_horizon` to validate cached SQLite payloads by requiring `cache_version == _CACHE_VERSION` and `data_hash == _compute_data_hash(...)` before treating a read as a cache hit.
- When writing cache entries (forecast and backtest) the code now persists `cache_version` and `data_hash` alongside existing fields so subsequent reads can validate integrity.
- Kept in-memory caches (`_PREDICTION_CACHE`, `_BACKTEST_CACHE`, `_MODEL_CACHE`) behavior but populated them using the new `data_hash`; mismatches continue to be treated as cache misses.

### Testing
- Ran `python -m py_compile components/callbacks.py` and compilation succeeded with no syntax errors.
- No additional automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ea9952388329aa150ad88bbdb51f)