### PR TITLE
Support multi-model selection in Models tab and restrict Redis fast-path to ensemble-only

### DIFF
--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -841,12 +841,19 @@ def _weather_tab_from_redis(region):
     return fig_temp, fig_wind, fig_solar, fig_heatmap, fig_importance, fig_seasonal
 
 
-def _models_tab_from_redis(region):
+def _models_tab_from_redis(region, selected_models: list[str] | None = None):
     """Redis fast path for update_models_tab callback.
 
     Returns a 6-tuple (table, fig_resid_time, fig_resid_hist, fig_resid_pred,
     fig_heatmap, fig_shap) or None if cache miss.
     """
+    default_models = ["prophet", "arima", "xgboost", "ensemble"]
+    selected_models = selected_models or default_models
+    # Current Redis diagnostics payload is ensemble-only for residual charts.
+    # Keep this fast path only when callback explicitly requests ensemble-only.
+    if selected_models is not default_models and set(selected_models) != {"ensemble"}:
+        return None
+
     cached = redis_get(f"wattcast:diagnostics:{region}")
     if cached is None:
         return None
@@ -868,6 +875,8 @@ def _models_tab_from_redis(region):
     }
     rows = []
     for display_name, key in name_map.items():
+        if key not in selected_models:
+            continue
         m = metrics.get(key, {})
         rows.append(
             html.Tr(
@@ -931,17 +940,20 @@ def _models_tab_from_redis(region):
         **PLOT_LAYOUT, xaxis_title="Hour of Day", yaxis_title="Mean |Error| (MW)"
     )
 
-    fi_names = fi.get("names", [])
-    fi_vals = fi.get("values", [])
-    fig_shap = go.Figure(
-        go.Bar(
-            x=fi_vals[::-1],
-            y=fi_names[::-1],
-            orientation="h",
-            marker_color=COLORS["xgboost"],
+    if "xgboost" in selected_models:
+        fi_names = fi.get("names", [])
+        fi_vals = fi.get("values", [])
+        fig_shap = go.Figure(
+            go.Bar(
+                x=fi_vals[::-1],
+                y=fi_names[::-1],
+                orientation="h",
+                marker_color=COLORS["xgboost"],
+            )
         )
-    )
-    fig_shap.update_layout(**PLOT_LAYOUT, xaxis_title="Feature Importance")
+        fig_shap.update_layout(**PLOT_LAYOUT, xaxis_title="Feature Importance")
+    else:
+        fig_shap = _empty_figure("SHAP is available only for XGBoost. Select XGBoost above.")
 
     return table, fig_resid_time, fig_resid_hist, fig_resid_pred, fig_heatmap, fig_shap
 
@@ -2105,21 +2117,28 @@ def register_callbacks(app):
             Output("tab3-error-heatmap", "figure"),
             Output("tab3-shap", "figure"),
         ],
-        [Input("demand-store", "data"), Input("dashboard-tabs", "active_tab")],
+        [
+            Input("demand-store", "data"),
+            Input("dashboard-tabs", "active_tab"),
+            Input("tab3-model-selector", "value"),
+        ],
         [State("region-selector", "value")],
         prevent_initial_call=True,
     )
-    def update_models_tab(demand_json, active_tab, region):
+    def update_models_tab(demand_json, active_tab, selected_models, region):
         """Update Tab 3 model diagnostics using model service."""
         if active_tab != "tab-models":
             return [no_update] * 6
         if not demand_json:
             empty = _empty_figure("Loading...")
             return html.P("Loading..."), empty, empty, empty, empty, empty
+        if not selected_models:
+            empty = _empty_figure("Select at least one model to view diagnostics.")
+            return html.P("No model selected."), empty, empty, empty, empty, empty
 
-        # ── v2 Redis fast path ──────────────────────────────
+        # Redis fast path is valid only for ensemble-only diagnostics payloads.
         if region:
-            redis_result = _models_tab_from_redis(region)
+            redis_result = _models_tab_from_redis(region, selected_models)
             if redis_result is not None:
                 return redis_result
 
@@ -2130,8 +2149,10 @@ def register_callbacks(app):
 
         from models.model_service import get_forecasts
 
-        forecasts = get_forecasts(region, demand_df)
+        forecasts = get_forecasts(region, demand_df, selected_models)
         metrics = forecasts.get("metrics", {})
+        model_order = ["prophet", "arima", "xgboost", "ensemble"]
+        selected = [m for m in model_order if m in set(selected_models)]
 
         # Metrics table
         name_map = {
@@ -2142,6 +2163,8 @@ def register_callbacks(app):
         }
         rows = []
         for display_name, key in name_map.items():
+            if key not in selected:
+                continue
             m = metrics.get(key, {})
             rows.append(
                 html.Tr(
@@ -2162,70 +2185,123 @@ def register_callbacks(app):
             className="metrics-table",
         )
 
-        ensemble = forecasts.get("ensemble", actual)
-        if not isinstance(ensemble, np.ndarray):
-            ensemble = actual
-        residuals = actual - ensemble
         timestamps = demand_df["timestamp"]
+        model_labels = {
+            "prophet": "Prophet",
+            "arima": "SARIMAX",
+            "xgboost": "XGBoost",
+            "ensemble": "Ensemble",
+        }
+        model_colors = {
+            "prophet": COLORS["prophet"],
+            "arima": COLORS["arima"],
+            "xgboost": COLORS["xgboost"],
+            "ensemble": COLORS["ensemble"],
+        }
+        model_residuals: dict[str, np.ndarray] = {}
+        model_predictions: dict[str, np.ndarray] = {}
+        for model_key in selected:
+            pred = forecasts.get(model_key)
+            if isinstance(pred, np.ndarray) and len(pred) == len(actual):
+                model_predictions[model_key] = pred
+                model_residuals[model_key] = actual - pred
 
-        fig_resid_time = go.Figure(
-            go.Scatter(
-                x=timestamps,
-                y=residuals,
-                mode="lines",
-                line=dict(color=COLORS["arima"], width=1),
+        if not model_residuals:
+            empty = _empty_figure("No residual diagnostics available for the selected model(s).")
+            return (
+                table,
+                empty,
+                empty,
+                empty,
+                empty,
+                _empty_figure("Select XGBoost to view SHAP feature importance."),
             )
-        )
+
+        fig_resid_time = go.Figure()
+        for model_key, residuals in model_residuals.items():
+            fig_resid_time.add_trace(
+                go.Scatter(
+                    x=timestamps,
+                    y=residuals,
+                    mode="lines",
+                    name=model_labels.get(model_key, model_key.title()),
+                    line=dict(color=model_colors.get(model_key, COLORS["actual"]), width=1),
+                )
+            )
         fig_resid_time.add_hline(y=0, line=dict(color="#ffffff", dash="dash", width=0.5))
         fig_resid_time.update_layout(**PLOT_LAYOUT, yaxis_title="Residual (MW)")
 
-        fig_resid_hist = go.Figure(
-            go.Histogram(x=residuals, nbinsx=50, marker_color=COLORS["ensemble"])
-        )
+        fig_resid_hist = go.Figure()
+        for model_key, residuals in model_residuals.items():
+            fig_resid_hist.add_trace(
+                go.Histogram(
+                    x=residuals,
+                    nbinsx=50,
+                    name=model_labels.get(model_key, model_key.title()),
+                    marker_color=model_colors.get(model_key, COLORS["actual"]),
+                    opacity=0.6,
+                )
+            )
         fig_resid_hist.update_layout(
-            **PLOT_LAYOUT, xaxis_title="Residual (MW)", yaxis_title="Count"
+            **PLOT_LAYOUT,
+            barmode="overlay",
+            xaxis_title="Residual (MW)",
+            yaxis_title="Count",
         )
 
-        fig_resid_pred = go.Figure(
-            go.Scatter(
-                x=ensemble,
-                y=residuals,
-                mode="markers",
-                marker=dict(size=2, color=COLORS["xgboost"], opacity=0.3),
+        fig_resid_pred = go.Figure()
+        for model_key, residuals in model_residuals.items():
+            preds = model_predictions[model_key]
+            fig_resid_pred.add_trace(
+                go.Scatter(
+                    x=preds,
+                    y=residuals,
+                    mode="markers",
+                    name=model_labels.get(model_key, model_key.title()),
+                    marker=dict(
+                        size=3,
+                        color=model_colors.get(model_key, COLORS["actual"]),
+                        opacity=0.35,
+                    ),
+                )
             )
-        )
         fig_resid_pred.add_hline(y=0, line=dict(color="#ffffff", dash="dash", width=0.5))
         fig_resid_pred.update_layout(
             **PLOT_LAYOUT, xaxis_title="Predicted (MW)", yaxis_title="Residual (MW)"
         )
 
         hours_of_day = timestamps.dt.hour
-        error_by_hour = pd.DataFrame({"hour": hours_of_day, "abs_error": np.abs(residuals)})
-        hourly_error = error_by_hour.groupby("hour")["abs_error"].mean()
-        fig_heatmap = go.Figure(
-            go.Bar(
-                x=hourly_error.index,
-                y=hourly_error.values,
-                marker_color=[
-                    COLORS["ensemble"] if e > hourly_error.median() else COLORS["actual"]
-                    for e in hourly_error.values
-                ],
+        fig_heatmap = go.Figure()
+        for model_key, residuals in model_residuals.items():
+            error_by_hour = pd.DataFrame({"hour": hours_of_day, "abs_error": np.abs(residuals)})
+            hourly_error = error_by_hour.groupby("hour")["abs_error"].mean()
+            fig_heatmap.add_trace(
+                go.Bar(
+                    x=hourly_error.index,
+                    y=hourly_error.values,
+                    name=model_labels.get(model_key, model_key.title()),
+                    marker_color=model_colors.get(model_key, COLORS["actual"]),
+                    opacity=0.85,
+                )
             )
-        )
+        fig_heatmap.update_layout(**PLOT_LAYOUT, barmode="group")
         fig_heatmap.update_layout(
             **PLOT_LAYOUT, xaxis_title="Hour of Day", yaxis_title="Mean |Error| (MW)"
         )
 
-        feature_names, importance_vals = _get_feature_importance(region)
-        fig_shap = go.Figure(
-            go.Bar(
-                x=importance_vals[::-1],
-                y=feature_names[::-1],
-                orientation="h",
-                marker_color=COLORS["xgboost"],
+        if "xgboost" in selected:
+            feature_names, importance_vals = _get_feature_importance(region)
+            fig_shap = go.Figure(
+                go.Bar(
+                    x=importance_vals[::-1],
+                    y=feature_names[::-1],
+                    orientation="h",
+                    marker_color=COLORS["xgboost"],
+                )
             )
-        )
-        fig_shap.update_layout(**PLOT_LAYOUT, xaxis_title="Feature Importance")
+            fig_shap.update_layout(**PLOT_LAYOUT, xaxis_title="Feature Importance")
+        else:
+            fig_shap = _empty_figure("SHAP is available only for XGBoost. Select XGBoost above.")
 
         return table, fig_resid_time, fig_resid_hist, fig_resid_pred, fig_heatmap, fig_shap
 

--- a/tests/unit/test_callbacks_v1_paths.py
+++ b/tests/unit/test_callbacks_v1_paths.py
@@ -836,13 +836,21 @@ class TestModelsTabV1:
 
     def test_tab_guard(self, callbacks):
         """When active_tab is not tab-models, return no_update list."""
-        result = callbacks["update_models_tab"](_demand_json(), "tab-forecast", "FPL")
+        result = callbacks["update_models_tab"](_demand_json(), "tab-forecast", ["ensemble"], "FPL")
         assert result == [no_update] * 6
 
     def test_no_demand_returns_loading(self, callbacks):
         """When demand_json is None, return loading placeholders."""
-        result = callbacks["update_models_tab"](None, "tab-models", "FPL")
+        result = callbacks["update_models_tab"](None, "tab-models", ["ensemble"], "FPL")
         assert len(result) == 6
+
+    def test_no_model_selected_returns_empty_state(self, callbacks):
+        """When no models are selected, callback returns empty-state visuals."""
+        result = callbacks["update_models_tab"](_demand_json(), "tab-models", [], "FPL")
+        assert len(result) == 6
+        assert isinstance(result[0], html.P)
+        for fig in result[1:]:
+            assert isinstance(fig, go.Figure)
 
     def test_v1_fallback_with_valid_data(self, callbacks):
         """V1 compute fallback produces table + 5 figures."""
@@ -853,6 +861,9 @@ class TestModelsTabV1:
                 "xgboost": {"mape": 4.0, "rmse": 400, "mae": 350, "r2": 0.96},
                 "ensemble": {"mape": 3.5, "rmse": 350, "mae": 300, "r2": 0.97},
             },
+            "prophet": np.random.uniform(35000, 45000, 168),
+            "arima": np.random.uniform(35000, 45000, 168),
+            "xgboost": np.random.uniform(35000, 45000, 168),
             "ensemble": np.random.uniform(35000, 45000, 168),
         }
 
@@ -860,7 +871,9 @@ class TestModelsTabV1:
             patch("components.callbacks.redis_get", return_value=None),
             patch("models.model_service.get_forecasts", return_value=fake_forecasts),
         ):
-            result = callbacks["update_models_tab"](_demand_json(), "tab-models", "FPL")
+            result = callbacks["update_models_tab"](
+                _demand_json(), "tab-models", ["prophet", "arima", "xgboost", "ensemble"], "FPL"
+            )
 
         assert len(result) == 6
         # First element is a table
@@ -868,6 +881,20 @@ class TestModelsTabV1:
         # Remaining are figures
         for fig in result[1:]:
             assert isinstance(fig, go.Figure)
+
+    def test_shap_empty_state_when_xgboost_not_selected(self, callbacks):
+        """SHAP panel is intentionally blank when XGBoost is not in model selector."""
+        fake_forecasts = {
+            "metrics": {"prophet": {"mape": 5.0, "rmse": 500, "mae": 400, "r2": 0.95}},
+            "prophet": np.random.uniform(35000, 45000, 168),
+        }
+        with patch("models.model_service.get_forecasts", return_value=fake_forecasts):
+            result = callbacks["update_models_tab"](
+                _demand_json(), "tab-models", ["prophet"], "FPL"
+            )
+        shap_fig = result[5]
+        assert isinstance(shap_fig, go.Figure)
+        assert shap_fig.layout.annotations
 
 
 # ===================================================================

--- a/tests/unit/test_redis_fast_paths.py
+++ b/tests/unit/test_redis_fast_paths.py
@@ -376,6 +376,15 @@ class TestModelsTabFromRedis:
         assert _models_tab_from_redis("FPL") is None
 
     @patch("components.callbacks.redis_get")
+    def test_non_ensemble_selection_returns_none(self, mock_rg):
+        """Redis fast path is disabled for non-ensemble selections."""
+        mock_rg.return_value = _diagnostics_payload()
+
+        from components.callbacks import _models_tab_from_redis
+
+        assert _models_tab_from_redis("FPL", selected_models=["prophet"]) is None
+
+    @patch("components.callbacks.redis_get")
     def test_table_has_4_rows(self, mock_rg):
         """Metrics table has 4 rows: Prophet, SARIMAX, XGBoost, Ensemble."""
         mock_rg.return_value = _diagnostics_payload()


### PR DESCRIPTION
### Motivation

- Enable the Models diagnostics tab to display diagnostics for one or more user-selected models instead of assuming ensemble-only payloads.
- Keep the Redis fast-path lightweight while avoiding stale or incomplete diagnostics when non-ensemble selections are requested.

### Description

- Add a `selected_models` parameter to `_models_tab_from_redis` and short-circuit to `None` unless the selection is the default or exclusively `"ensemble"`, preserving the existing ensemble-only Redis payload behavior. 
- Extend the `update_models_tab` callback signature to accept `tab3-model-selector` values, validate empty selections, and pass `selected_models` through to `get_forecasts`. 
- Switch the v1 compute fallback to build per-model `predictions` and `residuals` for the selected models, drawing multi-trace figures for time series, histograms, predicted vs residual scatter, and hourly error bars, and fall back to context-aware empty figures where diagnostics are unavailable. 
- Make SHAP (feature importance) visible only when `xgboost` is selected and return an explanatory empty figure otherwise.

### Testing

- Updated and added unit tests in `tests/unit/test_callbacks_v1_paths.py` to cover new callback signature, empty selection state, v1 fallback with multiple models, and SHAP empty-state behavior, and they passed. 
- Updated and added unit tests in `tests/unit/test_redis_fast_paths.py` to verify the Redis fast-path behavior and the new guard that returns `None` for non-ensemble selections, and they passed. 
- Ran the modified unit test files to exercise both Redis and v1 code paths and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6ea8cd95083298bffcf727b02de77)