### PR TITLE
feat(shell): consolidate tabs 9 → 4 + restructure header (R3)

### DIFF
--- a/assets/accessibility.js
+++ b/assets/accessibility.js
@@ -1,27 +1,27 @@
 /* Keyboard shortcuts and accessibility enhancements */
 
-// Alt+1-8: Switch tabs
+// Alt+1..4: Switch between the four visible tabs.
+// R3 reduced 9 → 4 (Overview / Forecast / Risk / Models). Hidden tabs
+// stay rendered for callback safety but aren't surfaced via shortcuts.
 document.addEventListener('keydown', function(e) {
     if (!e.altKey) return;
 
     const tabMap = {
-        '1': 'tab-forecast',
+        '1': 'tab-overview',
         '2': 'tab-outlook',
-        '3': 'tab-backtest',
-        '4': 'tab-generation',
-        '5': 'tab-weather',
-        '6': 'tab-models',
-        '7': 'tab-alerts',
-        '8': 'tab-simulator',
+        '3': 'tab-alerts',
+        '4': 'tab-models',
     };
 
     if (tabMap[e.key]) {
         e.preventDefault();
-        // Find the tab link and click it
-        const tabLinks = document.querySelectorAll('.nav-tabs .nav-link');
+        // Click only visible tab pills — skip any hidden via .d-none.
+        const visibleLinks = Array.from(
+            document.querySelectorAll('.nav-tabs .nav-item:not(.d-none) .nav-link')
+        );
         const tabIndex = parseInt(e.key) - 1;
-        if (tabLinks[tabIndex]) {
-            tabLinks[tabIndex].click();
+        if (visibleLinks[tabIndex]) {
+            visibleLinks[tabIndex].click();
         }
     }
 

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -457,7 +457,164 @@ body::before {
     }
 }
 
-/* ── Header ────────────────────────────────────────────── */
+/* ── Header (R3 — v2 alignment) ────────────────────────────────
+ *
+ * Mirrors gridpulse-v2/dashboard/page.tsx:84-125 — fixed h-14, full-width
+ * border-bottom, max-w-5xl inner content. Hosts the brand monogram +
+ * wordmark on the left and region/persona/mode controls on the right.
+ */
+
+.gp-header {
+    background: var(--bg-base);
+    border-bottom: 1px solid var(--border-subtle);
+    height: 56px;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    z-index: 2;  /* over the body::before noise overlay */
+}
+
+.gp-header__inner {
+    max-width: var(--content-max-width);
+    margin: 0 auto;
+    padding: 0 var(--content-gutter);
+    height: 100%;
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+}
+
+.gp-header__brand {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+}
+
+.gp-header__monogram {
+    width: 24px;
+    height: 24px;
+    display: block;
+    flex-shrink: 0;
+}
+
+.gp-header__wordmark {
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    font-size: var(--text-lg);
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: 1;
+    margin: 0;
+}
+
+.gp-header__wordmark-grid {
+    color: var(--text-primary);
+}
+
+.gp-header__wordmark-pulse {
+    color: var(--accent-base);
+}
+
+/* Right-aligned cluster of controls */
+.gp-header__controls {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-shrink: 0;
+}
+
+/* Compact select used inside the header (replaces the prior
+   "Balancing Authority" / "View" labeled column layout). */
+.gp-header__select {
+    background-color: var(--bg-raised);
+    color: var(--text-primary);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    height: 32px;
+    padding: 0 var(--space-3);
+    transition: border-color var(--duration-fast) var(--ease),
+                background-color var(--duration-fast) var(--ease);
+}
+
+.gp-header__select:hover {
+    background-color: var(--bg-hover);
+    border-color: var(--border-default);
+}
+
+.gp-header__select:focus,
+.gp-header__select:focus-visible {
+    outline: none;
+    border-color: var(--accent-base);
+    box-shadow: var(--shadow-focus);
+}
+
+/* Persona chip — discreet pill, smaller and quieter than the region picker */
+.gp-header__chip {
+    max-width: 200px;
+    background-color: transparent;
+    color: var(--text-secondary);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-full);
+    font-size: 12px;
+    font-weight: 500;
+    height: 28px;
+    padding: 0 var(--space-3);
+}
+
+.gp-header__chip:hover {
+    background-color: var(--bg-raised);
+    border-color: var(--border-default);
+    color: var(--text-primary);
+}
+
+/* Text-only header link (Briefing Mode, Save View) — quieter than a button */
+.gp-header__link {
+    color: var(--text-tertiary);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    background: transparent;
+    border: 0;
+    padding: var(--space-1) var(--space-2);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    transition: color var(--duration-fast) var(--ease),
+                background-color var(--duration-fast) var(--ease);
+}
+
+.gp-header__link:hover {
+    color: var(--text-primary);
+    background: var(--bg-raised);
+}
+
+.gp-header__link:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+}
+
+/* Tab strip below the header — also bounded to max-w-5xl for visual balance */
+.dashboard-tabs,
+.gp-tabs-shell {
+    max-width: var(--content-max-width);
+    margin: 0 auto;
+    padding: 0 var(--content-gutter);
+}
+
+@media (max-width: 768px) {
+    .gp-header__inner {
+        gap: var(--space-2);
+    }
+
+    .gp-header__chip,
+    .gp-header__link {
+        display: none;  /* keep only brand + region selector on phones */
+    }
+}
+
+/* ── Legacy header (kept for callbacks toggling .meeting-mode) ─── */
 .dashboard-header {
     background: var(--bg-overlay);
     backdrop-filter: blur(8px);

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -35,7 +35,6 @@ from components.cards import (
     build_model_metrics_card,
     build_news_feed,
     build_page_title,
-    build_welcome_card,
 )
 from config import (
     CACHE_TTL_SECONDS,
@@ -46,7 +45,7 @@ from config import (
 )
 from data.redis_client import redis_get
 from hash_utils import stable_int_seed
-from personas.config import get_persona, get_welcome_card
+from personas.config import get_persona
 
 log = structlog.get_logger()
 
@@ -2249,67 +2248,27 @@ def register_callbacks(app):
                 json.dumps(pipeline_summary, default=str),
             )
 
-    # ── 2. PERSONA SWITCHING ──────────────────────────────────
+    # ── 2. PERSONA SWITCHING (R3) ─────────────────────────────
+    # R3 deleted the standalone ``welcome-card`` and ``kpi-cards`` divs that
+    # used to render between the header and the tab strip. Every visible
+    # tab now ships its own page-title block + KPI bar; persona switching
+    # only redirects the user to the persona's preferred default tab.
 
     @app.callback(
-        [
-            Output("welcome-card", "children"),
-            Output("kpi-cards", "children"),
-            Output("dashboard-tabs", "active_tab"),
-        ],
-        [
-            Input("persona-selector", "value"),
-            Input("region-selector", "value"),
-        ],
-        [
-            State("demand-store", "data"),
-            State("weather-store", "data"),
-            State("dashboard-tabs", "active_tab"),
-        ],
+        Output("dashboard-tabs", "active_tab"),
+        Input("persona-selector", "value"),
+        prevent_initial_call=True,
     )
-    def switch_persona(persona_id, region, demand_json, weather_json, current_tab):
-        """Reconfigure dashboard for selected persona with live data.
+    def switch_persona_default_tab(persona_id):
+        """Land the user on the persona's default tab when the persona changes.
 
-        Fires on persona change AND region change (immediate, no API wait).
-        Only switches active tab when the persona selector triggered the callback.
-        Hides standalone welcome/KPI cards when on overview tab (overview has its own).
+        Region changes no longer trigger a tab redirect — it's a noisy UX
+        when the user is mid-task in a non-default tab.
         """
+        if not persona_id:
+            return no_update
         persona = get_persona(persona_id)
-
-        # Only switch active tab when persona changed (not on region/data change)
-        triggered = ctx.triggered_id
-        active_tab = persona.default_tab if triggered == "persona-selector" else no_update
-
-        # Determine which tab we'll land on
-        landing_tab = active_tab if active_tab is not no_update else current_tab
-
-        # On overview tab, hide standalone welcome/KPI (overview has its own inline versions)
-        if landing_tab == "tab-overview":
-            return html.Div(), html.Div(), active_tab
-
-        card_data = get_welcome_card(persona_id)
-
-        from personas.welcome import generate_welcome_message
-
-        # Parse from the demand-store; Redis fast path has already populated it.
-        demand_df = None
-        weather_df = None
-        if demand_json:
-            demand_df = pd.read_json(io.StringIO(demand_json))
-            if weather_json:
-                weather_df = pd.read_json(io.StringIO(weather_json))
-
-        message = generate_welcome_message(persona_id, region, demand_df, weather_df)
-
-        welcome = build_welcome_card(
-            title=card_data["title"],
-            message=message,
-            avatar=card_data["avatar"],
-            color=card_data["color"],
-        )
-        kpis = _build_persona_kpis(persona_id, region, demand_df, weather_df)
-
-        return welcome, kpis, active_tab
+        return persona.default_tab
 
     # ── 2b. PERSONA TAB VISIBILITY (AC-7.5) ──────────────────
     # NOTE: dbc.Tab uses tab_id (not id) and does not support dynamic
@@ -4160,7 +4119,6 @@ def register_callbacks(app):
         [
             Output("meeting-mode-store", "data"),
             Output("dashboard-header", "className"),
-            Output("welcome-card", "style"),
             Output("widget-confidence-bar", "style"),
             Output("fallback-banner", "style"),
         ],
@@ -4169,29 +4127,25 @@ def register_callbacks(app):
         prevent_initial_call=True,
     )
     def toggle_meeting_mode(n_clicks, current_mode):
-        """C9: Toggle meeting-ready mode.
+        """C9: Toggle meeting-ready (Briefing Mode) projection chrome.
 
-        Meeting mode strips navigation chrome, filters, and sidebars.
-        Reformats for projection/PDF: charts expand, narrative becomes
-        slide title, annotations remain.
+        Strips navigation, freshness banner, and confidence-bar carriers.
+        Charts and narrative remain. R5c will add the body.briefing class
+        + watermark for the full v2-style projection treatment.
         """
         is_meeting = current_mode != "true"
         new_mode = "true" if is_meeting else "false"
 
         if is_meeting:
-            # Hide non-essential UI elements
-            header_class = "dashboard-header meeting-mode"
-            welcome_style = {"display": "none"}
+            header_class = "dashboard-header gp-header meeting-mode"
             confidence_style = {"display": "none"}
             banner_style = {"display": "none"}
         else:
-            # Restore normal mode
-            header_class = "dashboard-header"
-            welcome_style = {}
+            header_class = "dashboard-header gp-header"
             confidence_style = {}
             banner_style = {}
 
-        return new_mode, header_class, welcome_style, confidence_style, banner_style
+        return new_mode, header_class, confidence_style, banner_style
 
     # ── DEMAND OUTLOOK TAB ──────────────────────────────────────
 

--- a/components/layout.py
+++ b/components/layout.py
@@ -1,15 +1,22 @@
-"""
-Main dashboard layout — header, persona switcher, region selector, KPI bar, tabs.
+"""Main dashboard layout — header, tab strip, data stores.
 
-CRITICAL: All 9 tab layouts are rendered statically inside dbc.Tab(children=...).
-This ensures every component ID always exists in the DOM. Dash Bootstrap handles
-showing/hiding tabs — we do NOT dynamically render tab content via callbacks.
+R3 of shell-redesign-v2.md. Header rebuilt to mirror gridpulse-v2's
+56px h-14 strip with monogram + Grid|Pulse wordmark on the left and
+region/persona/mode controls on the right. Tab strip reduced to 4
+visible tabs (Overview, Forecast, Risk, Models); five other tabs are
+still rendered into the DOM via ``tab_class_name="d-none"`` so their
+component IDs exist for callback safety. R4 will fold their content
+into the four visible tabs and remove the hidden tabs entirely.
+
+CRITICAL: All 9 tab layouts are still rendered statically inside
+``dbc.Tab(children=...)``. Hiding the tab strip button via Bootstrap's
+``d-none`` class keeps the panel content in the DOM (callbacks resolve)
+without exposing the navigation pill.
 """
 
 import dash_bootstrap_components as dbc
 from dash import dcc, html
 
-# Import all tab layouts
 from components import (
     tab_alerts,
     tab_backtest,
@@ -24,195 +31,166 @@ from components import (
 from config import REGION_NAMES, TAB_LABELS
 from personas.config import list_personas
 
+# R3 visible-tab whitelist. Other tabs render but their pill is hidden.
+_VISIBLE_TABS = {"tab-overview", "tab-outlook", "tab-alerts", "tab-models"}
+
+# R3 surface the four visible tabs under v2-aligned labels regardless of
+# whatever name a hidden tab happens to use today.
+_VISIBLE_LABEL_OVERRIDES = {
+    "tab-overview": "Overview",
+    "tab-outlook": "Forecast",
+    "tab-alerts": "Risk",
+    "tab-models": "Models",
+}
+
+
+def _monogram() -> html.Span:
+    """Inline 24×24 SVG monogram. Same path data as ``assets/favicon.svg``."""
+    svg = (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" '
+        'class="gp-header__monogram" aria-hidden="true">'
+        '<rect width="32" height="32" rx="6" fill="#0a0a0b"/>'
+        '<path d="M4 16 L11 16 L14 8 L16 24 L18 12 L21 16 L28 16" '
+        'stroke="#3b82f6" stroke-width="2.25" '
+        'stroke-linecap="round" stroke-linejoin="round" fill="none"/>'
+        "</svg>"
+    )
+    return html.Span(
+        dcc.Markdown(svg, dangerously_allow_html=True),
+        className="gp-header__monogram-wrap",
+    )
+
+
+def _build_header() -> html.Header:
+    """v2-aligned header: monogram + wordmark + region/persona/mode controls."""
+    persona_options = [
+        {"label": f"{p['avatar']} {p['title']}", "value": p["id"]} for p in list_personas()
+    ]
+    region_options = [{"label": name, "value": code} for code, name in REGION_NAMES.items()]
+
+    brand = html.Div(
+        [
+            _monogram(),
+            html.H1(
+                [
+                    html.Span("Grid", className="gp-header__wordmark-grid"),
+                    html.Span("Pulse", className="gp-header__wordmark-pulse"),
+                ],
+                className="gp-header__wordmark dashboard-title",
+            ),
+        ],
+        className="gp-header__brand",
+    )
+
+    controls = html.Div(
+        [
+            dbc.Select(
+                id="region-selector",
+                options=region_options,
+                value="FPL",
+                className="gp-header__select region-selector",
+            ),
+            dbc.Select(
+                id="persona-selector",
+                options=persona_options,
+                value="grid_ops",
+                className="gp-header__chip persona-switcher",
+            ),
+            html.Button(
+                "Briefing Mode",
+                id="meeting-mode-btn",
+                n_clicks=0,
+                className="gp-header__link",
+            ),
+            html.Button(
+                "Save View",
+                id="bookmark-btn",
+                n_clicks=0,
+                className="gp-header__link",
+            ),
+            # Hidden — kept for the freshness callback that writes here.
+            html.Div(id="header-freshness", style={"display": "none"}),
+        ],
+        className="gp-header__controls",
+    )
+
+    return html.Header(
+        html.Div([brand, controls], className="gp-header__inner"),
+        className="dashboard-header gp-header",
+        id="dashboard-header",
+    )
+
+
+def _tab(tab_id: str, layout_fn) -> dbc.Tab:
+    """Wrap a tab module's layout in ``dbc.Tab``. Hidden tabs use ``d-none``
+    on the pill so the panel renders without surfacing in the strip."""
+    label = _VISIBLE_LABEL_OVERRIDES.get(tab_id, TAB_LABELS.get(tab_id, tab_id))
+    is_visible = tab_id in _VISIBLE_TABS
+    return dbc.Tab(
+        layout_fn(),
+        label=label,
+        tab_id=tab_id,
+        tab_class_name="" if is_visible else "d-none",
+    )
+
 
 def build_layout() -> dbc.Container:
-    """Build the full dashboard layout with all 8 tabs pre-rendered."""
+    """Build the full dashboard layout (R3 — 4 visible tabs)."""
     return dbc.Container(
         [
-            # ── URL state for bookmarks (C2) ──────────────────────
+            # URL state for bookmarks (C2)
             dcc.Location(id="url", refresh=False),
-            # ── Interval for auto-refresh ──────────────────────────
+            # Auto-refresh interval
             dcc.Interval(id="refresh-interval", interval=300_000, n_intervals=0),
-            # ── Header ─────────────────────────────────────────────
-            html.Div(
-                [
-                    dbc.Row(
-                        [
-                            dbc.Col(
-                                [
-                                    html.H1("GridPulse", className="dashboard-title"),
-                                    html.P(
-                                        "Energy Intelligence Platform",
-                                        className="dashboard-subtitle",
-                                    ),
-                                ],
-                                md=4,
-                                className="d-flex flex-column justify-content-center",
-                            ),
-                            dbc.Col(
-                                [
-                                    html.Label(
-                                        "Balancing Authority",
-                                        style={"color": "#A8B3C7", "fontSize": "0.7rem"},
-                                    ),
-                                    dbc.Select(
-                                        id="region-selector",
-                                        options=[
-                                            {"label": name, "value": code}
-                                            for code, name in REGION_NAMES.items()
-                                        ],
-                                        value="FPL",
-                                        className="region-selector",
-                                    ),
-                                ],
-                                md=3,
-                                className="d-flex flex-column justify-content-center",
-                            ),
-                            dbc.Col(
-                                [
-                                    html.Label(
-                                        "View", style={"color": "#A8B3C7", "fontSize": "0.7rem"}
-                                    ),
-                                    dbc.Select(
-                                        id="persona-selector",
-                                        options=[
-                                            {
-                                                "label": f"{p['avatar']} {p['title']}",
-                                                "value": p["id"],
-                                            }
-                                            for p in list_personas()
-                                        ],
-                                        value="grid_ops",
-                                        className="persona-switcher",
-                                    ),
-                                ],
-                                md=2,
-                                className="d-flex flex-column justify-content-center",
-                            ),
-                            dbc.Col(
-                                [
-                                    html.Div(
-                                        [
-                                            dbc.Button(
-                                                "Briefing Mode",
-                                                id="meeting-mode-btn",
-                                                size="sm",
-                                                color="info",
-                                                outline=True,
-                                                className="me-2",
-                                                style={"fontSize": "0.75rem"},
-                                            ),
-                                            dbc.Button(
-                                                "Save View",
-                                                id="bookmark-btn",
-                                                size="sm",
-                                                color="secondary",
-                                                outline=True,
-                                                className="me-2",
-                                                style={"fontSize": "0.75rem"},
-                                            ),
-                                            html.Div(
-                                                id="header-freshness", style={"display": "none"}
-                                            ),
-                                        ],
-                                        className="d-flex flex-column align-items-end justify-content-center h-100",
-                                    ),
-                                ],
-                                md=3,
-                            ),
-                        ],
-                        align="center",
-                    ),
-                ],
-                className="dashboard-header",
-                id="dashboard-header",
-            ),
-            # ── Bookmark notification ──────────────────────────────
+            # Header
+            _build_header(),
+            # Bookmark / save-view toast
             html.Div(
                 id="bookmark-toast",
-                style={"position": "fixed", "top": "10px", "right": "10px", "zIndex": 9999},
+                style={
+                    "position": "fixed",
+                    "top": "10px",
+                    "right": "10px",
+                    "zIndex": 9999,
+                },
             ),
-            # ── Data Freshness Banner (G2) ─────────────────────────
+            # Data freshness banner (G2 — visible only when degraded)
             html.Div(id="fallback-banner"),
-            # ── Per-Widget Confidence Badges (A4 + E3) — hidden, moved to overview data health
+            # Per-Widget confidence badges (A4 + E3) — hidden carrier element
             html.Div(id="widget-confidence-bar", style={"display": "none"}),
-            # ── Welcome Card ───────────────────────────────────────
-            html.Div(id="welcome-card"),
-            # ── KPI Row ────────────────────────────────────────────
-            html.Div(id="kpi-cards"),
-            # ── Tabs (full width) ─────────────────────────────────
+            # Tab strip (4 visible: Overview / Forecast / Risk / Models)
             dbc.Tabs(
                 id="dashboard-tabs",
                 active_tab="tab-overview",
                 children=[
-                    dbc.Tab(
-                        tab_overview.layout(),
-                        label=TAB_LABELS["tab-overview"],
-                        tab_id="tab-overview",
-                    ),
-                    dbc.Tab(
-                        tab_forecast.layout(),
-                        label=TAB_LABELS["tab-forecast"],
-                        tab_id="tab-forecast",
-                    ),
-                    dbc.Tab(
-                        tab_demand_outlook.layout(),
-                        label=TAB_LABELS["tab-outlook"],
-                        tab_id="tab-outlook",
-                    ),
-                    dbc.Tab(
-                        tab_models.layout(),
-                        label=TAB_LABELS["tab-models"],
-                        tab_id="tab-models",
-                    ),
-                    dbc.Tab(
-                        tab_backtest.layout(),
-                        label=TAB_LABELS["tab-backtest"],
-                        tab_id="tab-backtest",
-                    ),
-                    dbc.Tab(
-                        tab_generation.layout(),
-                        label=TAB_LABELS["tab-generation"],
-                        tab_id="tab-generation",
-                    ),
-                    dbc.Tab(
-                        tab_weather.layout(),
-                        label=TAB_LABELS["tab-weather"],
-                        tab_id="tab-weather",
-                    ),
-                    dbc.Tab(
-                        tab_alerts.layout(),
-                        label=TAB_LABELS["tab-alerts"],
-                        tab_id="tab-alerts",
-                    ),
-                    dbc.Tab(
-                        tab_simulator.layout(),
-                        label=TAB_LABELS["tab-simulator"],
-                        tab_id="tab-simulator",
-                    ),
+                    _tab("tab-overview", tab_overview.layout),
+                    _tab("tab-outlook", tab_demand_outlook.layout),
+                    _tab("tab-alerts", tab_alerts.layout),
+                    _tab("tab-models", tab_models.layout),
+                    # ── Hidden tabs (DOM resident; folded into visible tabs in R4) ──
+                    _tab("tab-forecast", tab_forecast.layout),
+                    _tab("tab-backtest", tab_backtest.layout),
+                    _tab("tab-generation", tab_generation.layout),
+                    _tab("tab-weather", tab_weather.layout),
+                    _tab("tab-simulator", tab_simulator.layout),
                 ],
             ),
-            # ── Data Stores ────────────────────────────────────────
+            # Data Stores
             dcc.Store(id="news-store"),
             dcc.Store(id="demand-store"),
             dcc.Store(id="weather-store"),
             dcc.Store(id="features-store"),
             dcc.Store(id="models-store"),
             dcc.Store(id="alerts-store"),
-            # G2: Track whether each data source served fresh or stale data
             dcc.Store(id="data-freshness-store"),
-            # C9: Meeting-ready mode state (True/False)
             dcc.Store(id="meeting-mode-store", data="false"),
-            # D2: Latest audit record for display
             dcc.Store(id="audit-store"),
-            # I1: Latest pipeline log for diagnostics
             dcc.Store(id="pipeline-log-store"),
-            # AI briefing cache for Overview tab
             dcc.Store(id="briefing-store"),
-            # NEXD-8: Session snapshot for "What Changed" (persisted in localStorage)
+            # NEXD-8: Session snapshot for "What Changed" (R4a-reserved)
             dcc.Store(id="session-snapshot-store", storage_type="local"),
             dcc.Store(id="changes-store"),
-            # NEXD-9: User preferences (persisted in localStorage)
+            # NEXD-9: User preferences
             dcc.Store(id="user-prefs-store", storage_type="local"),
         ],
         fluid=True,

--- a/tests/unit/test_callbacks_closures.py
+++ b/tests/unit/test_callbacks_closures.py
@@ -422,30 +422,35 @@ class TestUpdateWidgetConfidence:
 
 
 class TestToggleMeetingMode:
-    """C9: Meeting-ready mode toggle callback (lines 3072-3088)."""
+    """C9: Briefing Mode (meeting-mode) toggle callback.
+
+    R3 trimmed the welcome-card style output (the underlying div was
+    deleted). Surviving outputs: meeting-mode-store, dashboard-header
+    className, widget-confidence-bar style, fallback-banner style.
+    """
 
     def test_toggle_on_from_false(self, callbacks):
         fn = callbacks["toggle_meeting_mode"]
-        mode, header_cls, welcome_style, conf_style, banner_style = fn(1, "false")
+        mode, header_cls, conf_style, banner_style = fn(1, "false")
         assert mode == "true"
         assert "meeting-mode" in header_cls
-        assert welcome_style == {"display": "none"}
         assert conf_style == {"display": "none"}
         assert banner_style == {"display": "none"}
 
     def test_toggle_off_from_true(self, callbacks):
         fn = callbacks["toggle_meeting_mode"]
-        mode, header_cls, welcome_style, conf_style, banner_style = fn(2, "true")
+        mode, header_cls, conf_style, banner_style = fn(2, "true")
         assert mode == "false"
-        assert header_cls == "dashboard-header"
-        assert welcome_style == {}
+        # R3: header className includes both dashboard-header + gp-header
+        assert "meeting-mode" not in header_cls
+        assert "dashboard-header" in header_cls
         assert conf_style == {}
         assert banner_style == {}
 
     def test_toggle_on_from_none(self, callbacks):
         fn = callbacks["toggle_meeting_mode"]
         # None != "true" => is_meeting = True
-        mode, header_cls, welcome_style, conf_style, banner_style = fn(1, None)
+        mode, header_cls, _conf_style, _banner_style = fn(1, None)
         assert mode == "true"
         assert "meeting-mode" in header_cls
 

--- a/tests/unit/test_callbacks_v1_paths.py
+++ b/tests/unit/test_callbacks_v1_paths.py
@@ -750,47 +750,34 @@ class TestLoadDataV1:
 
 
 class TestSwitchPersona:
-    """Tests for the switch_persona callback (lines 1698-1734)."""
+    """Tests for the persona-tab redirect callback.
 
-    def test_basic_persona_switch(self, callbacks):
-        """Basic persona switch returns welcome card, KPIs, and tab."""
-        mock_ctx = MagicMock()
-        mock_ctx.triggered_id = "persona-selector"
+    R3 of shell-redesign-v2.md trimmed the prior 3-output ``switch_persona``
+    (welcome / KPIs / active_tab) down to the single tab-redirect callback
+    ``switch_persona_default_tab``, since R3 deleted the standalone
+    ``welcome-card`` / ``kpi-cards`` divs that lived between the header and
+    the tab strip. Region changes no longer redirect the active tab — only
+    the persona selector does.
+    """
 
-        with patch("components.callbacks.ctx", mock_ctx):
-            # 5th arg = current_tab (State)
-            result = callbacks["switch_persona"]("grid_ops", "FPL", None, None, "tab-forecast")
+    def test_persona_change_redirects_to_default_tab(self, callbacks):
+        """Switching persona returns the persona's default_tab."""
+        result = callbacks["switch_persona_default_tab"]("grid_ops")
+        # grid_ops persona defaults to tab-overview
+        assert result == "tab-overview"
 
-        assert len(result) == 3
-        welcome, kpis, active_tab = result
-        assert welcome is not None
-        assert kpis is not None
-        # persona-selector triggered, so active_tab should be set
-        assert active_tab is not no_update
+    def test_renewables_persona_returns_its_default_tab(self, callbacks):
+        """Each persona has its own default_tab; the callback echoes it."""
+        result = callbacks["switch_persona_default_tab"]("renewables")
+        # default_tab for renewables persona — verify against config
+        from personas.config import get_persona
 
-    def test_region_change_does_not_switch_tab(self, callbacks):
-        """When region-selector triggers, active_tab should be no_update."""
-        mock_ctx = MagicMock()
-        mock_ctx.triggered_id = "region-selector"
+        assert result == get_persona("renewables").default_tab
 
-        with patch("components.callbacks.ctx", mock_ctx):
-            result = callbacks["switch_persona"]("grid_ops", "FPL", None, None, "tab-forecast")
-
-        welcome, kpis, active_tab = result
-        assert active_tab is no_update
-
-    def test_with_demand_data(self, callbacks):
-        """When demand_json is provided, switch_persona parses and builds KPIs."""
-        mock_ctx = MagicMock()
-        mock_ctx.triggered_id = "region-selector"
-
-        with patch("components.callbacks.ctx", mock_ctx):
-            result = callbacks["switch_persona"](
-                "renewables", "FPL", _demand_json(), _weather_json(), "tab-forecast"
-            )
-
-        assert len(result) == 3
-        assert result[0] is not None
+    def test_empty_persona_returns_no_update(self, callbacks):
+        """Falsy persona id should be a no-op (no_update)."""
+        result = callbacks["switch_persona_default_tab"](None)
+        assert result is no_update
 
 
 # ===================================================================


### PR DESCRIPTION
## What
**R3 of [Shell Redesign — v2 alignment](../../.claude/plans/shell-redesign-v2.md).** Reduces visible tabs from 9 to 4 (`Overview` / `Forecast` / `Risk` / `Models`) and rebuilds the header to match `gridpulse-v2`'s 56px h-14 strip — monogram + `Grid|Pulse` wordmark on the left, region/persona/mode controls on the right.

## Why
**Jira:** NEXD-

R2 ([#37](../37)) attacked the clutter inside Overview by collapsing 8 cards. R3 attacks the **shell**: the welcome-card + KPI-row that lived between the header and the tab strip are gone, and the 9-tab strip becomes a 4-tab strip — the rest of the workflows (history, generation, weather, scenarios, backtest) become inline panels inside Forecast (R4a) and Models (R4c).

## How

### Visible tab strip (4)
| Visible label | Underlying tab_id | What it carries |
|---|---|---|
| Overview | `tab-overview` | R2 linear stack |
| **Forecast** | `tab-outlook` | Demand outlook (R4a will absorb History, Drivers, Generation, Scenarios as inline panels) |
| **Risk** | `tab-alerts` | Severity timeline (R4b will add weather severity strip + reserve pressure) |
| **Models** | `tab-models` | Diagnostics + SHAP (R4c will fold Backtest as a section) |

### Hidden tabs (5 — DOM-resident, pill hidden via `tab_class_name="d-none"`)
`tab-forecast` (Historical Demand), `tab-backtest`, `tab-generation`, `tab-weather`, `tab-simulator`. Their layouts still render → existing callbacks resolve → R4 can fold their content piece by piece without breaking the app.

### Header rebuild (`components/layout.py`)

**Before:** `.dashboard-header` with a 4-column row (title + region + persona + buttons) plus `welcome-card` and `kpi-cards` divs stacked beneath. **After:**

```
<header class="dashboard-header gp-header">      // h-14, border-bottom
  <div class="gp-header__inner">                  // max-w 1024px, centered
    <div class="gp-header__brand">
      <svg> [pulse monogram, 24px, #3b82f6] </svg>
      <h1 class="gp-header__wordmark">
        <span class="…__wordmark-grid">Grid</span>
        <span class="…__wordmark-pulse">Pulse</span>
      </h1>
    </div>
    <div class="gp-header__controls">
      <Select id="region-selector"  class="gp-header__select"/>
      <Select id="persona-selector" class="gp-header__chip"/>
      <button id="meeting-mode-btn" class="gp-header__link">Briefing Mode</button>
      <button id="bookmark-btn"     class="gp-header__link">Save View</button>
    </div>
  </div>
</header>
```

Monogram SVG path identical to `assets/favicon.svg` — same ECG-pulse glyph, just inline. Folds in **G3** of the original Phase G plan (color-split wordmark).

### CSS (`assets/custom.css`, ~140 new lines)
- `.gp-header` — h-14, border-bottom, bg-base, no backdrop-blur
- `.gp-header__inner` — max-w 1024px, flex row, gap 16px
- `.gp-header__monogram`, `.gp-header__wordmark*` (Grid neutral / Pulse blue)
- `.gp-header__select` (compact 32px), `.gp-header__chip` (28px transparent pill), `.gp-header__link` (text-only)
- Mobile: hide chip + links below 768px so phones see only brand + region picker
- Legacy `.dashboard-header` rule kept for the `meeting-mode` className output (no breakage)

### Callbacks (`components/callbacks.py`)
- **`switch_persona` → `switch_persona_default_tab`** (renamed + simplified). 3 outputs → 1. Fires only on **persona** change; region change no longer redirects mid-task.
- **`toggle_meeting_mode`** — 5 outputs → 4 (welcome-card style output dropped — div is gone).
- Removed unused `build_welcome_card` / `get_welcome_card` imports.

### Keyboard (`assets/accessibility.js`)
Alt+1..8 → **Alt+1..4** (visible tabs only). Selector matches only `.nav-tabs .nav-item:not(.d-none) .nav-link`.

### Tests
- `test_callbacks_v1_paths.py::TestSwitchPersona` — full rewrite; 3 tests asserting new single-Output signature
- `test_callbacks_closures.py::TestToggleMeetingMode` — updated to assert 4 outputs (welcome-card style gone) and the new `"dashboard-header gp-header"` combined className

## Testing
- [x] Unit tests added/updated
- [x] `ruff format --check .` and `ruff check .` clean
- [x] `python -c "import app"` boots cleanly
- [x] Full unit suite **1295 passed** (matches R2 baseline)

## Checklist
- [x] No secrets or API keys in code
- [x] Type hints on all new functions
- [x] Docstrings on all new public functions
- [x] `ruff check` and `ruff format` pass
- [x] Coverage thresholds maintained
- [x] PRD.md and TECHNICAL_SPEC.md updated if implementation deviates — _**Follow-up:** PRD documents 9 tabs; addendum lands in R5/R6 doc pass_

🤖 Generated with [Claude Code](https://claude.com/claude-code)