### PR TITLE
feat(forecast): inline panel toggles + Drivers panel (R4a-2)

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -565,6 +565,123 @@ body::before {
     gap: var(--space-2);
 }
 
+/* ── Inline panel toggles + collapsing panels (R4a-2) ─────────────── */
+
+.gp-panel-toggles {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+.gp-panel-toggle {
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-1);
+    padding: 6px 12px;
+    background: var(--bg-raised);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-full);
+    color: var(--text-secondary);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.2;
+    cursor: pointer;
+    transition: background-color var(--duration-fast) var(--ease),
+                border-color var(--duration-fast) var(--ease),
+                color var(--duration-fast) var(--ease);
+}
+
+.gp-panel-toggle:hover {
+    background: var(--bg-hover);
+    border-color: var(--border-default);
+    color: var(--text-primary);
+}
+
+.gp-panel-toggle:focus-visible {
+    outline: none;
+    box-shadow: var(--shadow-focus);
+}
+
+.gp-panel-toggle__sigil {
+    color: var(--accent-base);
+    font-weight: 600;
+}
+
+.gp-panel-toggle__label {
+    color: inherit;
+}
+
+.gp-panel-toggle__hint {
+    color: var(--text-disabled);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-left: var(--space-1);
+}
+
+/* Inline panel container (the body inside dbc.Collapse) */
+.gp-panel {
+    background: var(--bg-raised);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-lg);
+    padding: var(--card-padding);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    box-shadow: var(--edge-highlight);
+}
+
+.gp-panel__header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+}
+
+.gp-panel__eyebrow {
+    color: var(--text-disabled);
+    font-size: 10px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.gp-panel__hint {
+    color: var(--text-tertiary);
+    font-size: 12px;
+}
+
+.gp-panel__placeholder {
+    color: var(--text-tertiary);
+    font-size: 13px;
+    line-height: var(--leading-relaxed);
+    margin: 0;
+}
+
+/* 3-up grid for the Drivers panel (Temperature / Wind / Solar) */
+.gp-drivers-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-4);
+}
+
+.gp-driver-cell {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    background: var(--bg-base);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    min-width: 0;
+}
+
+@media (max-width: 768px) {
+    .gp-drivers-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* Mobile: stack the 5 metric cells into 2 rows of 2-3 */
 @media (max-width: 768px) {
     .gp-metrics-bar {

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -24,7 +24,7 @@ import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import structlog
-from dash import ALL, Input, Output, State, ctx, html, no_update
+from dash import ALL, Input, Output, State, ctx, dcc, html, no_update
 from plotly.subplots import make_subplots
 
 from components.cards import (
@@ -4147,11 +4147,41 @@ def register_callbacks(app):
 
         return new_mode, header_class, confidence_style, banner_style
 
-    # ── FORECAST TAB (R4a-1 — v2 linear stack) ───────────────────
-    # The hero chart + 4-up MetricsBar + InsightCard are still driven by
+    # ── FORECAST TAB (R4a — v2 linear stack + inline panels) ────
+    # Hero chart + 4-up MetricsBar + InsightCard are still driven by
     # ``update_demand_outlook`` below (existing 9-output callback,
-    # preserved). Two small new callbacks fill the v2 title block and
-    # the new ModelMetricsCard slot.
+    # preserved). Small new callbacks fill the v2 title block, the
+    # ModelMetricsCard slot, and (R4a-2) the inline Drivers panel
+    # rendered when its collapse opens.
+
+    # 3 clientside toggles — flip is_open on each panel collapse.
+    # Generic JS could pattern-match, but explicit is clearer.
+    for _panel_key in ("drivers", "generation", "scenarios"):
+        app.clientside_callback(
+            "function(n, is_open) { return n ? !is_open : is_open; }",
+            Output(f"forecast-panel-{_panel_key}-collapse", "is_open"),
+            Input(f"forecast-panel-toggle-{_panel_key}", "n_clicks"),
+            State(f"forecast-panel-{_panel_key}-collapse", "is_open"),
+            prevent_initial_call=True,
+        )
+
+    @app.callback(
+        Output("forecast-drivers-content", "children"),
+        [
+            Input("forecast-panel-drivers-collapse", "is_open"),
+            Input("weather-store", "data"),
+        ],
+        State("dashboard-tabs", "active_tab"),
+    )
+    def update_forecast_drivers_panel(is_open, weather_json, active_tab):
+        """Render the 3-up Drivers KPI grid (Temperature / Wind / Solar).
+
+        Lazy: only computes when the collapse is open and the user is
+        on the Forecast tab (avoid spending render cost while collapsed).
+        """
+        if active_tab != "tab-outlook" or not is_open:
+            return no_update
+        return _build_drivers_panel(weather_json)
 
     @app.callback(
         Output("outlook-title", "children"),
@@ -5175,6 +5205,152 @@ def _build_overview_insight(
     }
     eyebrow = eyebrow_map.get(persona_id, "Summary")
     return build_insight_card(eyebrow, body)
+
+
+# ── Forecast tab helpers (R4a) ───────────────────────────────────────
+
+
+def _build_drivers_panel(weather_json: str | None) -> list:
+    """3-up KPI cells (Temperature / Wind / Solar) with current value + 24h sparkline.
+
+    The Forecast tab's Drivers inline panel calls this when its collapse
+    opens. Each cell is a .gp-driver-cell with eyebrow / value / unit /
+    sparkline. Sparkline reuses the same v2 minimal-axis style as
+    _build_overview_sparkline.
+    """
+    if not weather_json:
+        return _drivers_empty()
+
+    try:
+        wdf = pd.read_json(io.StringIO(weather_json))
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("forecast_drivers_parse_failed", error=str(exc))
+        return _drivers_empty()
+
+    if wdf.empty or "timestamp" not in wdf.columns:
+        return _drivers_empty()
+
+    wdf = wdf.copy()
+    wdf["timestamp"] = pd.to_datetime(wdf["timestamp"])
+    wdf = wdf.sort_values("timestamp")
+    # Window: latest 24 rows (assume hourly cadence)
+    horizon = wdf.tail(24)
+
+    drivers = [
+        {
+            "label": "Temperature",
+            "column": "temperature_2m",
+            "unit": "°F",
+            "color": "#3b82f6",
+            "fillcolor": "rgba(59, 130, 246, 0.10)",
+            "fmt": lambda v: f"{v:.0f}",
+        },
+        {
+            "label": "Wind",
+            "column": "wind_speed_80m",
+            "unit": "mph",
+            "color": "#34d399",
+            "fillcolor": "rgba(52, 211, 153, 0.10)",
+            "fmt": lambda v: f"{v:.1f}",
+        },
+        {
+            "label": "Solar",
+            "column": "shortwave_radiation",
+            "unit": "W/m²",
+            "color": "#f97316",
+            "fillcolor": "rgba(249, 115, 22, 0.10)",
+            "fmt": lambda v: f"{v:.0f}",
+        },
+    ]
+
+    cells: list = []
+    for d in drivers:
+        col = d["column"]
+        if col not in horizon.columns or horizon[col].isna().all():
+            cells.append(_driver_cell_empty(d["label"]))
+            continue
+        latest = float(horizon[col].iloc[-1])
+        avg = float(horizon[col].mean())
+        delta = latest - avg
+        delta_class = (
+            "gp-metric-value--negative"
+            if delta > 0.5
+            else ("gp-metric-value--positive" if delta < -0.5 else "")
+        )
+        cells.append(
+            html.Div(
+                [
+                    html.Div(d["label"], className="gp-metric-label"),
+                    html.Div(
+                        [
+                            html.Span(
+                                d["fmt"](latest),
+                                className="gp-metric-value gp-metric-value--hero tabular",
+                            ),
+                            html.Span(d["unit"], className="gp-metric-unit"),
+                        ],
+                        className="gp-metric-value-row",
+                    ),
+                    html.Div(
+                        [
+                            html.Span(
+                                f"{delta:+.1f} vs 24h avg",
+                                className=f"gp-metric-sub {delta_class}",
+                            ),
+                        ],
+                    ),
+                    dcc.Graph(
+                        figure=_driver_sparkline(horizon, col, d["color"], d["fillcolor"]),
+                        config={"displayModeBar": False, "responsive": True},
+                        style={"height": "60px"},
+                    ),
+                ],
+                className="gp-driver-cell",
+            )
+        )
+    return cells
+
+
+def _drivers_empty() -> list:
+    cells = []
+    for label in ("Temperature", "Wind", "Solar"):
+        cells.append(_driver_cell_empty(label))
+    return cells
+
+
+def _driver_cell_empty(label: str) -> html.Div:
+    return html.Div(
+        [
+            html.Div(label, className="gp-metric-label"),
+            html.Span("—", className="gp-metric-value tabular"),
+            html.Div("No weather data", className="gp-metric-sub"),
+        ],
+        className="gp-driver-cell",
+    )
+
+
+def _driver_sparkline(df: pd.DataFrame, column: str, color: str, fillcolor: str) -> go.Figure:
+    """60px sparkline matching the v2 minimal-axes treatment."""
+    fig = go.Figure()
+    fig.add_trace(
+        go.Scatter(
+            x=df["timestamp"],
+            y=df[column],
+            mode="lines",
+            line=dict(color=color, width=1.5),
+            fill="tozeroy",
+            fillcolor=fillcolor,
+            hovertemplate="%{x|%H:%M}<br>%{y:,.1f}<extra></extra>",
+            showlegend=False,
+        )
+    )
+    fig.update_layout(
+        **_layout(uirevision=column),
+        xaxis=dict(visible=False),
+        yaxis=dict(visible=False),
+        margin=dict(l=0, r=0, t=4, b=4),
+    )
+    return fig
 
 
 def _build_overview_sparkline(demand_df: pd.DataFrame | None, region: str) -> go.Figure:

--- a/components/tab_demand_outlook.py
+++ b/components/tab_demand_outlook.py
@@ -203,6 +203,139 @@ def _metrics_bar() -> html.Div:
     return html.Div(cells, className="gp-metrics-bar gp-metrics-bar--4up")
 
 
+def _panel_toggle_strip() -> html.Div:
+    """Three chip-buttons that expand inline panels under the Forecast tab.
+
+    Each toggle drives a ``dbc.Collapse`` whose ``is_open`` is toggled by
+    a tiny clientside callback. Lazy server-side rendering populates the
+    panel content only when it opens (saves render cost when closed).
+    """
+    return html.Div(
+        [
+            html.Div("Expand", className="gp-control-eyebrow"),
+            html.Div(
+                [
+                    _panel_toggle("drivers", "Drivers", "Weather"),
+                    _panel_toggle("generation", "Generation", "Fuel mix"),
+                    _panel_toggle("scenarios", "Scenarios", "What-if"),
+                ],
+                className="gp-panel-toggles",
+            ),
+        ],
+        className="gp-control",
+    )
+
+
+def _panel_toggle(key: str, label: str, hint: str) -> html.Button:
+    """Single toggle chip. Click flips the collapse panel's ``is_open``."""
+    return html.Button(
+        [
+            html.Span("+ ", className="gp-panel-toggle__sigil"),
+            html.Span(label, className="gp-panel-toggle__label"),
+            html.Span(hint, className="gp-panel-toggle__hint"),
+        ],
+        id=f"forecast-panel-toggle-{key}",
+        n_clicks=0,
+        type="button",
+        className="gp-panel-toggle",
+        **{"aria-expanded": "false", "aria-controls": f"forecast-panel-{key}"},
+    )
+
+
+def _panel_header(eyebrow: str, hint: str | None = None) -> html.Div:
+    children: list = [html.Div(eyebrow, className="gp-panel__eyebrow")]
+    if hint:
+        children.append(html.Span(hint, className="gp-panel__hint"))
+    return html.Div(children, className="gp-panel__header")
+
+
+def _panel_drivers() -> dbc.Collapse:
+    """Drivers panel: 3-up KPI mini-bar (Temperature / Wind / Solar)."""
+    return dbc.Collapse(
+        html.Div(
+            [
+                _panel_header(
+                    "Drivers",
+                    "Weather signals shaping the next-24h forecast",
+                ),
+                # Filled by the update_forecast_drivers_panel callback when
+                # the collapse opens. Initial children are skeleton cells.
+                html.Div(
+                    id="forecast-drivers-content",
+                    children=_drivers_skeleton(),
+                    className="gp-drivers-grid",
+                ),
+            ],
+            className="gp-panel",
+            id="forecast-panel-drivers",
+        ),
+        id="forecast-panel-drivers-collapse",
+        is_open=False,
+    )
+
+
+def _drivers_skeleton() -> list:
+    """3 placeholder cells while the Drivers callback computes."""
+    cells = []
+    for label in ("Temperature", "Wind", "Solar"):
+        cells.append(
+            html.Div(
+                [
+                    html.Div(label, className="gp-metric-label"),
+                    html.Span("—", className="gp-metric-value tabular"),
+                    html.Div("Loading…", className="gp-metric-sub"),
+                ],
+                className="gp-driver-cell",
+            )
+        )
+    return cells
+
+
+def _panel_generation_stub() -> dbc.Collapse:
+    """Generation inline panel — content lands in R4a-3."""
+    return dbc.Collapse(
+        html.Div(
+            [
+                _panel_header("Generation", "Fuel mix and renewable share"),
+                html.P(
+                    "Generation panel content lands in R4a-3 — stacked-area "
+                    "fuel mix sorted by emissions intensity, plus a renewable-share "
+                    "trend line and a 3-up sub-MetricsBar (Net Load / Renewable Share / "
+                    "Largest Source).",
+                    className="gp-panel__placeholder",
+                ),
+            ],
+            className="gp-panel",
+            id="forecast-panel-generation",
+        ),
+        id="forecast-panel-generation-collapse",
+        is_open=False,
+    )
+
+
+def _panel_scenarios_stub() -> dbc.Collapse:
+    """Scenarios inline panel — content lands in R4a-4."""
+    return dbc.Collapse(
+        html.Div(
+            [
+                _panel_header("Scenarios", "What-if assumptions"),
+                html.P(
+                    "Scenarios panel content lands in R4a-4 — five preset chips "
+                    "(keyboard arrow-cycle + Enter-apply), debounced sliders for "
+                    "temperature/wind/solar deltas, side-by-side baseline-vs-scenario "
+                    "chart, and 4-up delta KPIs (ΔPeak / ΔReserve / ΔConfidence / "
+                    "ΔRenewable).",
+                    className="gp-panel__placeholder",
+                ),
+            ],
+            className="gp-panel",
+            id="forecast-panel-scenarios",
+        ),
+        id="forecast-panel-scenarios-collapse",
+        is_open=False,
+    )
+
+
 def layout() -> html.Div:
     """Build the v2 linear-stack Forecast tab layout."""
     return html.Div(
@@ -249,7 +382,15 @@ def layout() -> html.Div:
                     html.Div(id="outlook-model-card"),
                     # 6. InsightCard (existing id; styled by the wrapper)
                     html.Div(id="tab2-insight-card", className="gp-insight-card-slot"),
-                    # 7. Footer
+                    # 7. Inline panel toggle strip (R4a-2)
+                    _panel_toggle_strip(),
+                    # 7a. Drivers panel (R4a-2 — working)
+                    _panel_drivers(),
+                    # 7b. Generation panel (R4a-3 placeholder)
+                    _panel_generation_stub(),
+                    # 7c. Scenarios panel (R4a-4 placeholder)
+                    _panel_scenarios_stub(),
+                    # 8. Footer
                     build_page_footer(),
                 ],
                 className="gp-section-stack",


### PR DESCRIPTION
## What
**R4a-2 of [Shell Redesign — v2 alignment](../../.claude/plans/shell-redesign-v2.md).** Adds the inline-panel infrastructure beneath the Forecast tab's InsightCard — three toggle chips that expand collapsible panels. **Drivers panel** ships fully wired (3-up Temperature / Wind / Solar KPI grid with current value + delta-vs-24h-avg + 60px sparkline). **Generation** and **Scenarios** ship as visible placeholders — R4a-3 and R4a-4 fill them.

## Why
**Jira:** NEXD-

R3 hid 5 tabs (History / Backtest / Generation / Weather / Scenarios) so the strip could shrink to 4. The plan was always to fold their content back into the visible tabs as inline progressive-disclosure panels — not lose the workflows. R4a-2 establishes the pattern; R4a-3 and R4a-4 finish it.

## How

### Toggle infrastructure
- **Three chips** (`.gp-panel-toggle`) below the Forecast InsightCard: `+ Drivers / Weather`, `+ Generation / Fuel mix`, `+ Scenarios / What-if`
- **Three `dbc.Collapse` panels** with ids `forecast-panel-{drivers|generation|scenarios}-collapse`
- **Three clientside toggle callbacks** — trivial `function(n, is_open) { return n ? !is_open : is_open; }` pattern; `prevent_initial_call=True`
- **`aria-expanded` / `aria-controls`** on each toggle wired to the corresponding panel id
- **Lazy server rendering** — Drivers content callback only fires when its collapse is open AND the user is on the Forecast tab

### Drivers panel (working)
3-up grid (`.gp-drivers-grid`) with a card per weather signal. Each `.gp-driver-cell` shows:
- 10px UPPERCASE eyebrow label
- Hero numeric value (text-2xl tabular)
- Unit pill (°F / mph / W/m²)
- Delta-vs-24h-avg sub-line (semantic-color: red if up, green if down, neutral if |Δ| < 0.5)
- 60px sparkline (24h trace, no axes, semi-transparent fill matching the v2 palette: blue / green / orange)

Reads from the existing `weather-store` (`temperature_2m` / `wind_speed_80m` / `shortwave_radiation`).

### Generation + Scenarios panels (placeholders)
Visible inline panels with eyebrow + a short "lands in R4a-3 / R4a-4" placeholder paragraph documenting exactly what content will land. Keeps the toggle UX consistent across all three chips today; R4a-3 / R4a-4 swap the placeholders for working content.

### CSS additions ([assets/custom.css](assets/custom.css), ~120 lines)
- `.gp-panel-toggles` flex-wrap row + `.gp-panel-toggle` chip with `+`-sigil + label + hint
- `.gp-panel` — bordered + p-5 + `--edge-highlight` top sheen (matches `.gp-chart-card`)
- `.gp-panel__header` / `__eyebrow` / `__hint` / `__placeholder`
- `.gp-drivers-grid` 3-col → 1-col below 768px
- `.gp-driver-cell` — bg-base + bordered + p-3, accommodates eyebrow + value + sub + sparkline

## Testing
- [x] `ruff format --check .` and `ruff check .` clean
- [x] `python -c "import app; from components.tab_demand_outlook import layout; layout()"` boots cleanly
- [x] Targeted `pytest` → **211 passed**
- [x] Full unit suite **1295 passed** (matches R4a-1 baseline)

## Checklist
- [x] No secrets or API keys in code
- [x] structlog logging added for new error paths — `_build_drivers_panel` logs parse failures via `log.warning(...)` and falls back to skeleton cells
- [x] Type hints on all new functions
- [x] Docstrings on all new public functions
- [x] `ruff check` and `ruff format` pass
- [x] Coverage thresholds maintained
- [x] Reduced-motion respected — `dbc.Collapse` honors `prefers-reduced-motion` via the existing rule in `custom.css:845`

🤖 Generated with [Claude Code](https://claude.com/claude-code)