### PR TITLE
feat(ui): Briefing Mode chrome + watermark (R5c)

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -334,6 +334,120 @@ select:disabled,
     opacity: 0.6;
 }
 
+/* ── Briefing Mode (R5c — projection / meeting-ready chrome) ───── */
+/*
+ * Toggled via body.briefing (clientside mirror of meeting-mode-store).
+ * Strips navigation, scales hero KPI + page title, hides the noise
+ * overlay (reads as banding on projector LCDs), and stamps a watermark
+ * in the lower-right of the header.
+ */
+
+body.briefing::before {
+    display: none;
+}
+
+body.briefing .nav-tabs {
+    display: none;
+}
+
+/* Hide secondary controls and toggle strips in projection */
+body.briefing .gp-panel-toggles,
+body.briefing .gp-controls-row,
+body.briefing .gp-as-of-chip,
+body.briefing .freshness-badge,
+body.briefing .modebar,
+body.briefing .modebar-container {
+    display: none !important;
+}
+
+/* Bigger breathing room between sections in projection */
+body.briefing .gp-section-stack {
+    gap: var(--space-12);
+}
+
+/* Page title scales up */
+body.briefing .gp-page-title__heading {
+    font-size: 36px;
+    letter-spacing: -0.025em;
+}
+
+body.briefing .gp-page-title__subtitle {
+    font-size: var(--text-md);
+}
+
+/* Hero KPI scales dramatically so it reads from across a room */
+body.briefing .gp-metric-value--hero {
+    font-size: 56px;
+    line-height: 1.05;
+}
+
+body.briefing .gp-metric-value {
+    font-size: 24px;
+}
+
+body.briefing .gp-metric-label {
+    font-size: 12px;
+}
+
+body.briefing .gp-chart-card {
+    padding: var(--space-8);
+}
+
+/* Insight card reads as the meeting-room subtitle */
+body.briefing .gp-insight-card__body {
+    font-size: 18px;
+    line-height: 1.6;
+}
+
+body.briefing .gp-insight-card__eyebrow {
+    font-size: 12px;
+}
+
+/* Header — keep the brand visible, hide the persona chip, slightly
+ * taller for breathing room. Region selector + Save View + Exit
+ * Briefing button stay accessible. */
+body.briefing .gp-header__chip {
+    display: none;
+}
+
+body.briefing .gp-header {
+    height: 64px;
+}
+
+body.briefing .gp-header__wordmark {
+    font-size: var(--text-xl);
+}
+
+/* Watermark — soft "GridPulse" stamp in the lower-right of the header,
+ * visually anchoring the projection screen even when nav is gone. */
+body.briefing .dashboard-header {
+    position: relative;
+}
+
+body.briefing .dashboard-header::after {
+    content: "GridPulse";
+    position: absolute;
+    right: var(--content-gutter);
+    bottom: -28px;
+    color: var(--text-tertiary);
+    font-family: var(--font-display);
+    font-size: var(--text-sm);
+    letter-spacing: 0.06em;
+    opacity: 0.55;
+    pointer-events: none;
+}
+
+/* Exit-briefing button — emphasize so users can find it again */
+body.briefing #meeting-mode-btn.gp-header__link {
+    color: var(--accent-base);
+    background: var(--accent-dim);
+}
+
+body.briefing #meeting-mode-btn.gp-header__link:hover {
+    color: var(--text-primary);
+    background: var(--accent-base);
+}
+
 /* ── v2 Linear Stack Components (R2 of shell-redesign-v2.md) ───────────
  *
  * Mirrors gridpulse-v2's dashboard rhythm:

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -4216,7 +4216,23 @@ def register_callbacks(app):
 
         return widget_confidence_bar(freshness, age_seconds).children
 
-    # ── SPRINT 5: C9 — MEETING-READY MODE ─────────────────────
+    # ── SPRINT 5: C9 — BRIEFING MODE (R5c) ─────────────────────
+    # Clientside mirror — observes meeting-mode-store and toggles
+    # `body.briefing` so the CSS rules in assets/custom.css can hide
+    # the tab strip, scale type, and stamp the watermark. Also
+    # rewrites the toggle button's label between "Briefing Mode" and
+    # "Exit Briefing" so the user has a clear way out.
+    app.clientside_callback(
+        """
+        function(mode) {
+            const isOn = mode === 'true';
+            document.body.classList.toggle('briefing', isOn);
+            return isOn ? 'Exit Briefing' : 'Briefing Mode';
+        }
+        """,
+        Output("meeting-mode-btn", "children"),
+        Input("meeting-mode-store", "data"),
+    )
 
     @app.callback(
         [
@@ -4233,8 +4249,8 @@ def register_callbacks(app):
         """C9: Toggle meeting-ready (Briefing Mode) projection chrome.
 
         Strips navigation, freshness banner, and confidence-bar carriers.
-        Charts and narrative remain. R5c will add the body.briefing class
-        + watermark for the full v2-style projection treatment.
+        Charts and narrative remain. The clientside callback above mirrors
+        meeting-mode-store onto body.briefing for the v2 projection CSS.
         """
         is_meeting = current_mode != "true"
         new_mode = "true" if is_meeting else "false"


### PR DESCRIPTION
## What
**R5c of [Shell Redesign — v2 alignment](../../.claude/plans/shell-redesign-v2.md).** Wires the Briefing Mode toggle to a clientside `body.briefing` class and adds the v2-style projection-mode CSS rules — chrome stripped, type scaled up dramatically, watermark stamped in the header's lower-right.

> **Stacked on [#47](../47) (R5b).** Reviewers see only the R5c delta. Will retarget to `main` once R5b merges.

## Why
**Jira:** NEXD-

The Briefing Mode button has existed since the Sprint-5 work but didn't actually do anything visible on the new linear-stack surfaces. R5c gives it teeth — clicking it now strips nav, scales the hero KPI to 56px, and stamps a watermark — exactly what a stakeholder review or projection screen needs.

## How

### Clientside callback (`components/callbacks.py`)
```js
function(mode) {
    const isOn = mode === 'true';
    document.body.classList.toggle('briefing', isOn);
    return isOn ? 'Exit Briefing' : 'Briefing Mode';
}
```
- Mirrors `meeting-mode-store.data` → `body.classList.toggle("briefing")`
- Rewrites the toggle button label between `Briefing Mode` and `Exit Briefing` so users have a clear way out

### CSS rules (`assets/custom.css`, ~110 lines)
- `body.briefing::before { display: none }` — disables the noise overlay on projection (reads as banding under projector LCDs)
- `body.briefing .nav-tabs { display: none }` — hides the tab strip
- Hides `.gp-panel-toggles`, `.gp-controls-row`, `.gp-as-of-chip`, `.freshness-badge`, `.modebar` — secondary chrome that competes with data on projection
- Doubles section gap (`--space-12` = 48px instead of 32px)
- Page-title heading 36px, subtitle 14px
- **Hero KPI value 56px** (from 28px); other metric values 24px; labels 12px
- Chart-card padding bumps to `--space-8` (32px)
- InsightCard body 18px, eyebrow 12px
- Header trims to 64px; persona chip hidden; wordmark stays `--text-xl`; region selector + Save View + Exit Briefing remain accessible
- **Watermark**: `body.briefing .dashboard-header::after` stamps a soft `GridPulse` mark lower-right of the header strip (`--text-tertiary`, 55% opacity, `--font-display`, +0.06em tracking)
- **Exit Briefing button** gets `accent-dim` bg + `accent-base` text so it's findable when chrome is gone

## Testing
- [x] `ruff format --check .` and `ruff check .` clean
- [x] `python -c "import app"` boots cleanly
- [x] Targeted `pytest tests/unit/test_tab_overview.py tests/unit/test_callbacks_v1_paths.py tests/unit/test_callbacks_closures.py tests/unit/test_callbacks_module_helpers.py tests/unit/test_cross_tab_links.py tests/integration/test_infrastructure.py -q` → **222 passed**

## Checklist
- [x] No secrets or API keys in code
- [x] Type hints — _N/A; CSS + clientside JS only_
- [x] Docstrings on all new public functions
- [x] `ruff check` and `ruff format` pass
- [x] Coverage thresholds maintained
- [x] Reduced-motion respected — Briefing Mode is a static class swap, no animations involved

## Verification (post-merge)
1. Click "Briefing Mode" in the header → tab strip hides, KPI hero scales to 56px, watermark appears below the header line, button label flips to "Exit Briefing"
2. Click "Exit Briefing" → all chrome restores, label flips back to "Briefing Mode"
3. On a projector / second display: text should remain readable across a meeting room
4. The Forecast tab's inline panels (Drivers / Generation / Scenarios) keep their current open/closed state when toggling Briefing Mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)