### PR TITLE
fix(forecast): restrict model selector to XGBoost in production (option A)

### DIFF
--- a/components/tab_demand_outlook.py
+++ b/components/tab_demand_outlook.py
@@ -43,18 +43,39 @@ def _horizon_segmented() -> html.Div:
 
 
 def _model_segmented() -> html.Div:
-    """v2-style segmented control for active model."""
+    """v2-style segmented control for active model.
+
+    Production data path only carries XGBoost predictions: the scheduled
+    scoring job at ``jobs/phases.py:364`` writes only XGBoost output to
+    ``wattcast:forecast:{region}:1h``, and the v1 inline-compute fallback
+    in ``_run_forecast_outlook`` is gated by ``REQUIRE_REDIS`` (returns a
+    warming state instead of training Prophet / ARIMA on the request
+    thread). Surface only the option the data path can actually fulfill —
+    in dev (``REQUIRE_REDIS=False``) all four are still trainable inline,
+    so we keep the full segmented set there.
+
+    Plan: lift the single-option restriction once the scoring job is
+    extended to write Prophet + ARIMA + Ensemble predictions to Redis
+    alongside XGBoost (option B in the post-redesign discussion).
+    """
+    from config import REQUIRE_REDIS
+
+    if REQUIRE_REDIS:
+        options = [{"label": "XGBoost", "value": "xgboost"}]
+    else:
+        options = [
+            {"label": "XGBoost", "value": "xgboost"},
+            {"label": "Prophet", "value": "prophet"},
+            {"label": "ARIMA", "value": "arima"},
+            {"label": "Ensemble", "value": "ensemble"},
+        ]
+
     return html.Div(
         [
             html.Div("Model", className="gp-control-eyebrow"),
             dbc.RadioItems(
                 id="outlook-model",
-                options=[
-                    {"label": "XGBoost", "value": "xgboost"},
-                    {"label": "Prophet", "value": "prophet"},
-                    {"label": "ARIMA", "value": "arima"},
-                    {"label": "Ensemble", "value": "ensemble"},
-                ],
+                options=options,
                 value="xgboost",
                 inline=True,
                 className="gp-segmented",


### PR DESCRIPTION
## What
Quick fix for the "Forecast failed: warming" state on Prophet / ARIMA / Ensemble that the user caught in the post-redesign walkthrough. Surfaces only the model the production data path can actually fulfill.

## Why
**Jira:** NEXD-

Tracing why warming was showing on every non-XGBoost selection across every region:

1. **Scoring job writes only XGBoost** — `jobs/phases.py:364` (`predict_and_write_forecast`) sets `"xgboost": float(preds[i])` on each forecast row and writes to `wattcast:forecast:{region}:1h`. No Prophet, no ARIMA, no Ensemble.
2. **Redis read path bails on non-XGBoost** — `_outlook_tab_from_redis:1742`:
   ```python
   if model_name != "xgboost" and model_name not in forecasts[0]:
       return None  # falls through to v1 compute
   ```
3. **v1 inline compute is REQUIRE_REDIS-gated** — `_run_forecast_outlook:553` returns `{"error": "warming"}` instead of training inline, because Prophet/ARIMA training would block the web request for 10–30s.

Net: Prophet / ARIMA / Ensemble can never produce a forecast in any production-style deployment. The selector was a lie.

## How

Single edit to `components/tab_demand_outlook.py::_model_segmented()`:

```python
from config import REQUIRE_REDIS

if REQUIRE_REDIS:
    options = [{"label": "XGBoost", "value": "xgboost"}]
else:
    options = [
        {"label": "XGBoost", "value": "xgboost"},
        {"label": "Prophet", "value": "prophet"},
        {"label": "ARIMA", "value": "arima"},
        {"label": "Ensemble", "value": "ensemble"},
    ]
```

In dev (`REQUIRE_REDIS=False`) all four still render — the v1 inline path can train them. In staging/production (`REQUIRE_REDIS=True`) the selector becomes a single XGBoost pill — accurate, no false promise.

## Followup (option B — separate engineering work)

Extend `jobs/phases.py` to compute Prophet + ARIMA + Ensemble alongside XGBoost and write all four to Redis. Once that ships, lift the single-option restriction. **Tracked outside this PR.**

## Testing
- [x] `ruff format --check .` and `ruff check .` clean
- [x] Verified both branches: `REQUIRE_REDIS=True` → `['xgboost']`; `REQUIRE_REDIS=False` → `['xgboost', 'prophet', 'arima', 'ensemble']`
- [x] Targeted: `pytest tests/unit/test_redesign_smoke.py tests/unit/test_callbacks_v1_paths.py tests/unit/test_callbacks_closures.py -q` → **132 passed**

## Checklist
- [x] No secrets or API keys in code
- [x] structlog logging — _N/A_
- [x] Type hints on all new functions — _local import only_
- [x] Docstrings on all new public functions — _expanded the existing _model_segmented docstring with the diagnosis_
- [x] `ruff check` and `ruff format` pass
- [x] Coverage thresholds maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)