### PR TITLE
fix(training): compute holdout MAPE for prophet and arima

### DIFF
--- a/jobs/training_job.py
+++ b/jobs/training_job.py
@@ -68,12 +68,81 @@ def _train_xgboost(region_data: phases.RegionData) -> str | None:
     )
 
 
+_HOLDOUT_HOURS = 168
+_MIN_TRAIN_HOURS = 720  # need at least 30 days of training before a 7-day holdout
+
+
+def _holdout_mape_prophet(featured_df, region: str) -> float | None:
+    """Compute Prophet's MAPE on the last ``_HOLDOUT_HOURS`` of ``featured_df``.
+
+    Returns ``None`` when the window is too short or the holdout train/predict
+    fails for any reason — the caller still trains a production model on the
+    full data; only the saved MAPE is missing in that case.
+    """
+    import numpy as np
+
+    from models.evaluation import compute_mape
+    from models.prophet_model import predict_prophet, train_prophet
+
+    if len(featured_df) <= _HOLDOUT_HOURS + _MIN_TRAIN_HOURS:
+        return None
+    train_df = featured_df.iloc[:-_HOLDOUT_HOURS]
+    val_df = featured_df.iloc[-_HOLDOUT_HOURS:]
+    try:
+        holdout_model = train_prophet(train_df)
+        pred = predict_prophet(holdout_model, val_df, periods=len(val_df))
+        forecast = np.asarray(pred["forecast"], dtype=float)[: len(val_df)]
+        y_val = np.asarray(val_df["demand_mw"].values, dtype=float)
+        mape = float(compute_mape(y_val, forecast))
+        if not np.isfinite(mape) or mape <= 0:
+            return None
+        log.info("training_prophet_holdout_mape", region=region, mape=round(mape, 3))
+        return mape
+    except Exception as e:
+        log.warning("training_prophet_holdout_failed", region=region, error=str(e))
+        return None
+
+
+def _holdout_mape_arima(featured_df, region: str) -> float | None:
+    """Compute SARIMAX's MAPE on the last ``_HOLDOUT_HOURS`` of ``featured_df``."""
+    import numpy as np
+
+    from models.arima_model import predict_arima, train_arima
+    from models.evaluation import compute_mape
+
+    if len(featured_df) <= _HOLDOUT_HOURS + _MIN_TRAIN_HOURS:
+        return None
+    train_df = featured_df.iloc[:-_HOLDOUT_HOURS]
+    val_df = featured_df.iloc[-_HOLDOUT_HOURS:]
+    try:
+        holdout_model = train_arima(train_df)
+        forecast = np.asarray(
+            predict_arima(holdout_model, val_df, periods=len(val_df)),
+            dtype=float,
+        )[: len(val_df)]
+        y_val = np.asarray(val_df["demand_mw"].values, dtype=float)
+        mape = float(compute_mape(y_val, forecast))
+        if not np.isfinite(mape) or mape <= 0:
+            return None
+        log.info("training_arima_holdout_mape", region=region, mape=round(mape, 3))
+        return mape
+    except Exception as e:
+        log.warning("training_arima_holdout_failed", region=region, error=str(e))
+        return None
+
+
 def _train_prophet(region_data: phases.RegionData) -> str | None:
-    """Best-effort Prophet training. Returns the saved version or ``None``."""
+    """Best-effort Prophet training. Returns the saved version or ``None``.
+
+    Trains twice: once on the train portion to score a holdout MAPE that
+    drives ensemble weighting at scoring time, and once on the full window
+    for the production model that gets persisted to GCS.
+    """
     from models.prophet_model import train_prophet
 
     region = region_data.region
     assert region_data.featured_df is not None
+    mape = _holdout_mape_prophet(region_data.featured_df, region)
     try:
         prophet_obj = train_prophet(region_data.featured_df)
     except Exception as e:
@@ -86,16 +155,20 @@ def _train_prophet(region_data: phases.RegionData) -> str | None:
         model_obj=prophet_obj,
         data_hash=_compute_data_hash(region_data),
         train_rows=len(region_data.featured_df),
-        mape=None,
+        mape=mape,
     )
 
 
 def _train_arima(region_data: phases.RegionData) -> str | None:
-    """Best-effort SARIMAX training. Returns the saved version or ``None``."""
+    """Best-effort SARIMAX training. Returns the saved version or ``None``.
+
+    Holdout-MAPE computation mirrors :func:`_train_prophet`.
+    """
     from models.arima_model import train_arima
 
     region = region_data.region
     assert region_data.featured_df is not None
+    mape = _holdout_mape_arima(region_data.featured_df, region)
     try:
         arima_dict = train_arima(region_data.featured_df)
     except Exception as e:
@@ -108,7 +181,7 @@ def _train_arima(region_data: phases.RegionData) -> str | None:
         model_obj=arima_dict,
         data_hash=_compute_data_hash(region_data),
         train_rows=len(region_data.featured_df),
-        mape=None,
+        mape=mape,
     )
 
 

--- a/tests/unit/test_training_job_holdout_mape.py
+++ b/tests/unit/test_training_job_holdout_mape.py
@@ -1,0 +1,218 @@
+"""Unit tests for the holdout-MAPE flow in jobs/training_job.py.
+
+Before this change, ``_train_prophet`` and ``_train_arima`` always passed
+``mape=None`` to ``save_model``. Scoring then dropped Prophet/ARIMA from
+the inverse-MAPE blend (because their MAPE was ``None``) and the
+"ensemble" forecast in Redis collapsed to xgboost-only. These tests
+verify the holdout MAPE computation path now feeds real values into
+``save_model``, and gracefully falls back when the holdout window is
+too short or predict raises.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def featured_df_long():
+    """60 days @ hourly granularity — covers ``_HOLDOUT_HOURS + _MIN_TRAIN_HOURS``."""
+    ts = pd.date_range("2024-01-01", periods=60 * 24, freq="h", tz="UTC")
+    n = len(ts)
+    return pd.DataFrame(
+        {
+            "timestamp": ts,
+            "demand_mw": 40_000.0 + 5_000.0 * np.sin(2 * np.pi * np.arange(n) / 24),
+            "hour": ts.hour,
+        }
+    )
+
+
+@pytest.fixture
+def featured_df_short():
+    """20 days — too short to leave 30 days of training after a 7-day holdout."""
+    ts = pd.date_range("2024-01-01", periods=20 * 24, freq="h", tz="UTC")
+    return pd.DataFrame(
+        {
+            "timestamp": ts,
+            "demand_mw": np.full(len(ts), 40_000.0),
+            "hour": ts.hour,
+        }
+    )
+
+
+class TestHoldoutMapeProphet:
+    def test_returns_mape_when_predict_succeeds(self, featured_df_long, monkeypatch) -> None:
+        """Train + predict succeed → returns finite positive MAPE."""
+        import models.prophet_model as prophet_mod
+
+        # Forecast offset by a constant so MAPE is non-zero.
+        def _fake_predict(model, df, periods=168):
+            actuals = df["demand_mw"].values
+            return {"forecast": actuals * 1.05}  # 5% bias → MAPE ≈ 5
+
+        monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: object())
+        monkeypatch.setattr(prophet_mod, "predict_prophet", _fake_predict)
+
+        from jobs.training_job import _holdout_mape_prophet
+
+        mape = _holdout_mape_prophet(featured_df_long, region="TEST")
+        assert mape is not None
+        assert mape == pytest.approx(5.0, abs=0.5)
+
+    def test_short_window_returns_none(self, featured_df_short, monkeypatch) -> None:
+        """Insufficient data → skip holdout, return None (no spurious MAPE)."""
+        import models.prophet_model as prophet_mod
+
+        called: list[bool] = []
+        monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: called.append(True))
+
+        from jobs.training_job import _holdout_mape_prophet
+
+        assert _holdout_mape_prophet(featured_df_short, region="TEST") is None
+        assert called == []  # train should not even be invoked
+
+    def test_predict_failure_returns_none(self, featured_df_long, monkeypatch) -> None:
+        """Predict raising → swallow, return None (production training continues)."""
+        import models.prophet_model as prophet_mod
+
+        def _broken_predict(model, df, periods=168):
+            raise RuntimeError("synthetic prophet predict failure")
+
+        monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: object())
+        monkeypatch.setattr(prophet_mod, "predict_prophet", _broken_predict)
+
+        from jobs.training_job import _holdout_mape_prophet
+
+        assert _holdout_mape_prophet(featured_df_long, region="TEST") is None
+
+    def test_non_finite_mape_returns_none(self, featured_df_long, monkeypatch) -> None:
+        """Forecast with zero actuals → MAPE blows up → return None."""
+        import models.prophet_model as prophet_mod
+
+        def _fake_predict(model, df, periods=168):
+            # NaN forecast → compute_mape returns NaN
+            return {"forecast": np.full(len(df), np.nan)}
+
+        monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: object())
+        monkeypatch.setattr(prophet_mod, "predict_prophet", _fake_predict)
+
+        from jobs.training_job import _holdout_mape_prophet
+
+        assert _holdout_mape_prophet(featured_df_long, region="TEST") is None
+
+
+class TestHoldoutMapeArima:
+    def test_returns_mape_when_predict_succeeds(self, featured_df_long, monkeypatch) -> None:
+        import models.arima_model as arima_mod
+
+        def _fake_predict(model_dict, exog, periods=168):
+            actuals = exog["demand_mw"].values
+            return actuals * 0.97  # 3% under-forecast → MAPE ≈ 3
+
+        monkeypatch.setattr(arima_mod, "train_arima", lambda df: {"params": []})
+        monkeypatch.setattr(arima_mod, "predict_arima", _fake_predict)
+
+        from jobs.training_job import _holdout_mape_arima
+
+        mape = _holdout_mape_arima(featured_df_long, region="TEST")
+        assert mape is not None
+        assert mape == pytest.approx(3.0, abs=0.5)
+
+    def test_short_window_returns_none(self, featured_df_short) -> None:
+        from jobs.training_job import _holdout_mape_arima
+
+        assert _holdout_mape_arima(featured_df_short, region="TEST") is None
+
+    def test_predict_failure_returns_none(self, featured_df_long, monkeypatch) -> None:
+        import models.arima_model as arima_mod
+
+        def _broken_predict(model_dict, exog, periods=168):
+            raise ValueError("synthetic arima predict failure")
+
+        monkeypatch.setattr(arima_mod, "train_arima", lambda df: {"params": []})
+        monkeypatch.setattr(arima_mod, "predict_arima", _broken_predict)
+
+        from jobs.training_job import _holdout_mape_arima
+
+        assert _holdout_mape_arima(featured_df_long, region="TEST") is None
+
+
+class TestTrainPersistsMape:
+    """End-to-end: train_prophet/_train_arima pass real MAPE to save_model.
+
+    This is the key behavior the scoring-side fix relies on — without a
+    real MAPE in the saved metadata, scoring's inverse-MAPE blend has
+    nothing to weight by and falls back to equal weights.
+    """
+
+    def _make_region_data(self, df) -> object:
+        from jobs.phases import RegionData
+
+        return RegionData(
+            region="TEST",
+            demand_df=df[["timestamp", "demand_mw"]].copy(),
+            weather_df=df.copy(),
+            featured_df=df,
+        )
+
+    def test_prophet_passes_holdout_mape_to_save_model(self, featured_df_long, monkeypatch) -> None:
+        import models.prophet_model as prophet_mod
+
+        monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: object())
+        monkeypatch.setattr(
+            prophet_mod,
+            "predict_prophet",
+            lambda model, df, periods=168: {
+                "forecast": np.asarray(df["demand_mw"].values) * 1.04,  # MAPE ≈ 4
+            },
+        )
+
+        captured: dict = {}
+
+        def _save_model(**kwargs):
+            captured.update(kwargs)
+            return "v-test"
+
+        monkeypatch.setattr("jobs.training_job.save_model", _save_model)
+        # Stub the data hash helper to avoid pulling in the full feature pipeline.
+        monkeypatch.setattr("jobs.training_job._compute_data_hash", lambda region_data: "h")
+
+        from jobs.training_job import _train_prophet
+
+        version = _train_prophet(self._make_region_data(featured_df_long))
+        assert version == "v-test"
+        assert captured["model_name"] == "prophet"
+        assert captured["mape"] is not None
+        assert captured["mape"] == pytest.approx(4.0, abs=0.5)
+
+    def test_arima_passes_holdout_mape_to_save_model(self, featured_df_long, monkeypatch) -> None:
+        import models.arima_model as arima_mod
+
+        monkeypatch.setattr(arima_mod, "train_arima", lambda df: {"params": []})
+        monkeypatch.setattr(
+            arima_mod,
+            "predict_arima",
+            lambda model_dict, exog, periods=168: (
+                np.asarray(exog["demand_mw"].values) * 0.96
+            ),  # MAPE ≈ 4
+        )
+
+        captured: dict = {}
+
+        def _save_model(**kwargs):
+            captured.update(kwargs)
+            return "v-test"
+
+        monkeypatch.setattr("jobs.training_job.save_model", _save_model)
+        monkeypatch.setattr("jobs.training_job._compute_data_hash", lambda region_data: "h")
+
+        from jobs.training_job import _train_arima
+
+        version = _train_arima(self._make_region_data(featured_df_long))
+        assert version == "v-test"
+        assert captured["model_name"] == "arima"
+        assert captured["mape"] is not None
+        assert captured["mape"] == pytest.approx(4.0, abs=0.5)


### PR DESCRIPTION
## Summary

Pairs with [#57 (`craft/scoring-equal-weights-fallback`)](https://github.com/kristenmartino/gridpulse/pull/57) — together they fix the production state where the multi-model ensemble shipped in #55 was silently collapsing to xgboost-only.

`_train_prophet` and `_train_arima` previously hardcoded `mape=None` in their `save_model` calls. Only XGBoost computed a real MAPE (from CV scores). The saved Prophet/ARIMA metadata was the upstream cause of the partial-MAPE state at scoring time.

## Fix

Both models train twice per region: once on the train portion of `featured_df` (last 7 days held out) to score MAPE, and once on the full window for the production model. Holdout is best-effort — when the data window is too short or train/predict raises, the helper returns `None` and the production model is still trained and saved.

Per-region wall-clock impact: Prophet adds ~3 sec, ARIMA adds ~1.5 min. Across 8 regions that's ~12 min on top of the current ~30 min run, well within the 2-hour task timeout.

## Why two PRs

- **#57 (this PR's pair)** lands the always-on safety net immediately. The next hourly scoring run after merge produces a real equal-weights ensemble — even before the next nightly training run.
- **This PR** restores skill-weighted (inverse-MAPE) ensembling once nightly training has produced metadata with real MAPEs. Effective the morning after merge.

## Test plan

- [x] `pytest tests/unit/test_training_job_holdout_mape.py` — 9 new tests covering MAPE computation, short-window skip, predict failure, non-finite MAPE, and end-to-end flow into `save_model`.
- [x] `pytest tests/integration/test_training_job.py tests/unit/test_models_training.py tests/unit/test_model_persistence.py` — 82 tests, all green.
- [x] `ruff check` and `ruff format --check` clean.
- [ ] Post-merge: morning after the first nightly training run, verify `gs://nextera-portfolio-energy-cache/cache/models/{REGION}/prophet/{version}.meta.json` has a non-null `mape` field for every region. Then verify the next hourly scoring run produces `ensemble_weights` with non-equal values (e.g. `{xgboost: 0.45, prophet: 0.30, arima: 0.25}`) reflecting actual model skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)