### PR TITLE
docs(roadmap): replace V0.1 acceptance line with real log events

### DIFF
--- a/docs/NEXT_UP.md
+++ b/docs/NEXT_UP.md
@@ -24,7 +24,12 @@ gcloud logging read 'resource.labels.job_name="gridpulse-scoring-job"' \
   --limit=30 --format='value(textPayload, jsonPayload)'
 ```
 
-**Acceptance**: log line `forecast {ok=True, models=['arima', 'ensemble', 'prophet', 'xgboost']}` for each region. **Effort**: 5 min.
+**Acceptance** (all from the `gcloud logging read` output above):
+- `scoring_job_complete ok_count=8 fail_count=0 failed_regions=[]` — every region's pipeline finished cleanly.
+- Three `model_loaded` lines per region (one each for `xgboost`, `prophet`, `arima`) — 24 total. Ensemble is computed in-process and never loaded from disk.
+- One `scoring_ensemble_*` line per region confirms the ensemble path executed. Until the first training tick after [afd6a49](https://github.com/kristenmartino/gridpulse/commit/afd6a49) writes prophet/arima holdout MAPEs into the trained-model `.meta.json`, expect `scoring_ensemble_equal_weights_fallback`; afterward, expect MAPE-derived weights with no fallback log.
+
+**Effort**: 5 min.
 
 ### V0.2 — Verify Redis carries all four model keys
 


### PR DESCRIPTION
## Summary

- The V0.1 acceptance criterion landed in [#59](https://github.com/kristenmartino/gridpulse/pull/59) quoted a log line — \`forecast {ok=True, models=['arima', 'ensemble', 'prophet', 'xgboost']}\` — that the scoring job never emits. \`_score_region\` ([jobs/scoring_job.py:101-104](jobs/scoring_job.py:101)) builds that shape as an in-memory \`summary[\"phases\"][\"forecast\"]\` dict but returns it, not logs it. The string is grep-zero across the whole repo.
- I caught this when actually running V0.1 end-to-end. Replaces the fictitious string with three checks the code actually emits, all visible in the same \`gcloud logging read\` output the procedure already prints.

## Verification

Ran the full V0.1 procedure against execution \`gridpulse-scoring-job-drc4g\` after PR #59 merged (2026-04-30). Every check in the new acceptance block passed:

\`\`\`
scoring_job_complete elapsed_s=87.94 fail_count=0 failed_regions=[] ok_count=8
\`\`\`

Plus 24 \`model_loaded\` lines (xgboost + prophet + arima × 8 regions) and 8 \`scoring_ensemble_equal_weights_fallback\` lines — the latter is expected until the first training tick after [afd6a49](https://github.com/kristenmartino/gridpulse/commit/afd6a49) lands prophet/arima holdout MAPEs into the trained-model \`.meta.json\`. The new acceptance block calls this out so the next operator running V0.1 doesn't mistake the fallback line for a regression.

## Test plan

- [ ] Render \`docs/NEXT_UP.md\` on GitHub and confirm V0.1 reads cleanly.
- [ ] Spot-check that the \`scoring_ensemble_equal_weights_fallback\` callout still applies on the next operator's run; flip the wording once the post-afd6a49 training tick has rolled prophet/arima MAPEs into Redis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)