### PR TITLE
docs(roadmap): trim V0.1 equal-weights fallback caveat — afd6a49 has propagated

### DIFF
--- a/docs/NEXT_UP.md
+++ b/docs/NEXT_UP.md
@@ -27,7 +27,7 @@ gcloud logging read 'resource.labels.job_name="gridpulse-scoring-job"' \
 **Acceptance** (all from the `gcloud logging read` output above, post-V1.α):
 - `scoring_job_complete ok_count=16 fail_count=0 failed_regions=[]` — every region's pipeline finished cleanly.
 - Three `model_loaded` lines per region (one each for `xgboost`, `prophet`, `arima`) — 48 total. Ensemble is computed in-process and never loaded from disk.
-- One `scoring_ensemble_*` line per region confirms the ensemble path executed. Until the first training tick after [afd6a49](https://github.com/kristenmartino/gridpulse/commit/afd6a49) writes prophet/arima holdout MAPEs into the trained-model `.meta.json`, expect `scoring_ensemble_equal_weights_fallback`; afterward, expect MAPE-derived weights with no fallback log.
+- One `scoring_ensemble_*` line per region confirms the ensemble path executed.
 
 **Effort**: 5 min.
 


### PR DESCRIPTION
**This is a draft PR.** I couldn't verify in production from the remote sandbox (no `gcloud` auth for `nextera-portfolio`). Run the three checks below — pick the scoring execution that started after the most recent training `completionTimestamp` — and confirm `fail_count=0` plus zero fallback lines before merging.

## What changed

Removed the trailing caveat sentence from the V0.1 Acceptance block in `docs/NEXT_UP.md`. The bullet now reads:

> - One `scoring_ensemble_*` line per region confirms the ensemble path executed.

The sentence removed was: _"Until the first training tick after afd6a49 writes prophet/arima holdout MAPEs into the trained-model `.meta.json`, expect `scoring_ensemble_equal_weights_fallback`; afterward, expect MAPE-derived weights with no fallback log."_

No other lines were touched.

## Verification steps

Run these three read-only commands and confirm all three pass before merging:

```bash
# 1. Confirm the 04:00 UTC training execution completed successfully today (2026-05-01)
gcloud run jobs executions list --job=gridpulse-training-job --region=us-east1 --limit=2 \
  --format='value(name,creationTimestamp,completionTimestamp,startTime,status.conditions[0].type,status.conditions[0].status)'
```
**Expected**: most recent execution started ~04:00 UTC 2026-05-01 and shows `Completed / True`. Note its `completionTimestamp`.

```bash
# 2. Find the scoring execution that ran AFTER the training completionTimestamp above
gcloud run jobs executions list --job=gridpulse-scoring-job --region=us-east1 --limit=5 \
  --format='value(name,startTime,completionTimestamp)'
```
**Expected**: one execution with `startTime` after training's `completionTimestamp` (around 06:00 UTC). Save its name as `$LATEST`.

```bash
# 3. Confirm zero equal-weights fallback lines in that execution's logs
gcloud logging read \
  "resource.labels.job_name=\"gridpulse-scoring-job\" AND labels.\"run.googleapis.com/execution_name\"=\"$LATEST\"" \
  --limit=1000 --format='value(textPayload)' \
  | grep -E "scoring_job_complete|scoring_ensemble_equal_weights_fallback"
```
**Pass criteria**: one `scoring_job_complete` line with `fail_count=0`, and **zero** `scoring_ensemble_equal_weights_fallback` lines.

If verification fails, close this PR — the next training tick needs diagnosis before the caveat can be trimmed. Likely candidates after V1.α: prophet/arima training failed for one of the 8 newly-added BAs (SOCO, TVA, DUK, CPLE, BPAT, AZPS, NEVP, PSCO).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01TE1txa55QUmje7RhnjThi6)_