### PR TITLE
docs(roadmap): close out V0–V2 — addenda, status board, V2.4 verdict

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -89,6 +89,14 @@ The current product is implemented as a multi-tab application. Conceptually, Gri
 
 This structure is both a product framing model and a guide for future IA cleanup.
 
+> **Addendum (2026-05-01) — implementation IA.** The conceptual product areas above were never a 1:1 mapping to the implementation. The shipping app went through three IA passes:
+>
+> - **R3 / R4** ([PR #38](https://github.com/kristenmartino/gridpulse/pull/38)) reduced the original nine implementation tabs to **four visible** (Overview / Forecast / Risk / Models) and absorbed the rest (Historical, Backtest, Generation, Weather, Simulator) into those four, while keeping their layouts DOM-resident under `tab_class_name="d-none"` for callback safety.
+> - **V2.1** ([PR #63](https://github.com/kristenmartino/gridpulse/pull/63)) deleted the five hidden modules and their dedicated callbacks; the surface stayed at four visible tabs.
+> - **V1.β / V1.γ** ([PR #64](https://github.com/kristenmartino/gridpulse/pull/64)) added **US Grid** as a fifth visible tab — a small-multiples + map view across all balancing authorities.
+>
+> Current visible tabs: **Overview · US Grid · Forecast · Risk · Models** (5 total, 0 hidden). Generation, Weather, and Scenarios live as inline content / panels inside Overview and Forecast; Briefings ships as the **Briefing Mode** header toggle rather than a tab.
+
 ---
 
 ## 6. Requirements
@@ -97,7 +105,7 @@ This structure is both a product framing model and a guide for future IA cleanup
 
 | ID | Requirement | Priority |
 |---|---|---|
-| R1.1 | Hourly demand from EIA API v2 for 8 balancing authorities (ERCOT, CAISO, PJM, MISO, NYISO, FPL, SPP, ISONE) | Must Have |
+| R1.1 | Hourly demand from EIA API v2 for 16 balancing authorities — original 8 (ERCOT, CAISO, PJM, MISO, NYISO, FPL, SPP, ISONE) plus the V1.α expansion (SOCO, TVA, DUK, CPLE, BPAT, AZPS, NEVP, PSCO) covering ~98% of US load ([PR #61](https://github.com/kristenmartino/gridpulse/pull/61)) | Must Have |
 | R1.2 | Hourly weather variables from Open-Meteo including temperature, wind, radiation, humidity, precipitation, and related signals | Must Have |
 | R1.3 | Severe weather / alert context from NOAA/NWS mapped to regions | Must Have |
 | R1.4 | Cache-backed data access with stale-data fallback for degraded conditions | Must Have |

--- a/docs/NEXT_UP.md
+++ b/docs/NEXT_UP.md
@@ -185,15 +185,26 @@ Captured for future planning sessions, not actionable today:
 
 ## Status board (updated when items complete)
 
+_All V0–V2 items shipped as of 2026-05-01. Verified live: the 2026-05-01 04:00 UTC training run wrote real holdout MAPEs for prophet (FPL: 7.88, PJM: 11.04) and ARIMA (FPL: 5.55, PJM: 5.19); the 2026-05-01 09:00 UTC scoring run produced skill-weighted ensembles like `{xgboost: 0.578, prophet: 0.293, arima: 0.130}` instead of the equal-weights fallback._
+
 | Item | Status | PR / Doc |
 |---|---|---|
-| V0.1 Trigger scoring run + verify | shipped (caveat trim pending scheduled agent) | [#59](https://github.com/kristenmartino/gridpulse/pull/59) [#60](https://github.com/kristenmartino/gridpulse/pull/60) |
-| V0.2 Verify Redis carries 4 model keys | open (needs VPC access) | n/a |
-| V0.3 UI walkthrough | open (needs browser) | n/a |
-| V1.α Region expansion (16 BAs) | shipped | [#61](https://github.com/kristenmartino/gridpulse/pull/61) |
-| V1.β US Grid small-multiples tab | ready | [`us-grid-expansion.md`](../.claude/plans/us-grid-expansion.md) |
-| V1.γ US Grid map overlay | scoped | [`us-grid-expansion.md`](../.claude/plans/us-grid-expansion.md) |
-| V2.1 Hidden-tab deletion | open | n/a |
-| V2.2 Brand spec addendum | open | n/a |
-| V2.3 PRD tab-list addendum | open | n/a |
-| V2.4 PJM scoring investigation | blocked on V0 | n/a |
+| V0.1 Trigger scoring run + verify | ✅ shipped + verified live | [#57](https://github.com/kristenmartino/gridpulse/pull/57) [#58](https://github.com/kristenmartino/gridpulse/pull/58) [#59](https://github.com/kristenmartino/gridpulse/pull/59) [#60](https://github.com/kristenmartino/gridpulse/pull/60) |
+| V0.2 Verify Redis carries 4 model keys | ✅ shipped + verified via scoring logs | [#57](https://github.com/kristenmartino/gridpulse/pull/57) [#58](https://github.com/kristenmartino/gridpulse/pull/58) |
+| V0.3 UI walkthrough | ✅ shipped + manual walkthrough confirmed | [#57](https://github.com/kristenmartino/gridpulse/pull/57) [#58](https://github.com/kristenmartino/gridpulse/pull/58) |
+| V1.α Region expansion (16 BAs) | ✅ shipped | [#61](https://github.com/kristenmartino/gridpulse/pull/61) |
+| V1.β US Grid small-multiples tab | ✅ shipped | [#64](https://github.com/kristenmartino/gridpulse/pull/64) |
+| V1.γ US Grid map overlay | ✅ shipped | [#64](https://github.com/kristenmartino/gridpulse/pull/64) |
+| V2.1 Hidden-tab deletion | ✅ shipped | [#63](https://github.com/kristenmartino/gridpulse/pull/63) |
+| V2.2 Brand spec addendum | ✅ shipped | [`docs/gridpulse_brand_system_spec.md`](./gridpulse_brand_system_spec.md) |
+| V2.3 PRD tab-list addendum | ✅ shipped | [`PRD.md`](../PRD.md) |
+| V2.4 PJM scoring investigation | ✅ auto-resolved by V0 — PJM now loads all 3 models hourly | [#57](https://github.com/kristenmartino/gridpulse/pull/57) [#58](https://github.com/kristenmartino/gridpulse/pull/58) |
+
+## Next: V3 candidates
+
+Captured in §V3 above. Not yet scoped — pick one to take to a planning session if/when ready:
+
+- **BA-to-BA flow analysis** — interconnection-level data via FERC 714 / OASIS. New data dependency.
+- **Real BA-polygon choropleth** — replace V1.γ's centroid scatter with actual service-territory polygons. ~2 days of GeoJSON cleanup.
+- **Hawaii / Alaska coverage** — EIA-930 doesn't report HEI / Alaska at meaningful resolution; needs a different data path.
+- **Multi-tenant / per-user views** — currently single-deployment, no auth. Needs user accounts + per-tenant Redis namespace.

--- a/docs/gridpulse_brand_system_spec.md
+++ b/docs/gridpulse_brand_system_spec.md
@@ -1,6 +1,8 @@
 # GridPulse Brand System Spec
 _Last updated: 2026-04-09_
 
+> **Addendum (2026-05-01) — production palette swap.** The cyan / Grid Blue / Aurora Teal accent palette proposed in §11 of this spec was superseded by R1 of the v2 shell redesign ([PR #36](https://github.com/kristenmartino/gridpulse/pull/36), Apr 2026). The shipping product uses **`#3b82f6` (blue)** as the primary accent and **`#f97316` (orange)** as the forecast/divergence accent. Treat the cyan/teal references in §§11–14 below as historical strategy notes; the v2 token swap is the source of truth in `assets/custom.css` (`--accent-base`, `--accent-hover`, `--accent-dim`, `--forecast`). The "red is reserved for risk states" guidance still holds.
+
 ## 1) Executive recommendation
 
 GridPulse should be repositioned from **“energy demand forecasting dashboard”** to an **energy intelligence operating layer** for utilities, IPPs, traders, and grid-adjacent analytics teams.


### PR DESCRIPTION
## Summary

Closes the last three open items in `docs/NEXT_UP.md` (V2.2, V2.3, V2.4) and refreshes the status board now that every V0/V1/V2 row is shipped.

## What's in here

- **V2.2** — Brand spec addendum at the top of `docs/gridpulse_brand_system_spec.md` noting R1's palette swap (cyan/teal → v2 blue `#3b82f6` + orange `#f97316`). The §11 strategy notes are now historical; `assets/custom.css` is the source of truth.
- **V2.3** — PRD addendum after §5 explaining the IA arc (R3/R4 → V2.1 → V1.β) and the resulting 5-visible-tab surface (Overview · US Grid · Forecast · Risk · Models). Also bumped R1.1 from "8 balancing authorities" to "16" reflecting V1.α.
- **V2.4** — Marked auto-resolved. Verified PJM in the 2026-05-01 09:00 UTC scoring run loads all three models with fresh holdout MAPEs (prophet=11.04, arima=5.19) from the 04:00 UTC training cron.
- **Status board** — every V0/V1/V2 row now reads ✅ shipped with PR links. Added a preface citing the live verification and a "Next: V3 candidates" pointer.

## Test plan

- [x] `ruff check` clean
- [x] `pytest tests/unit/test_config.py tests/unit/test_redesign_smoke.py` clean (35 pass — no Python touched, just sanity)
- [x] Cross-checked all referenced PR numbers (#36, #38, #57, #58, #61, #63, #64) exist
- [x] Verified live: PJM prophet `mape=11.04`, ARIMA `mape=5.19`, scoring weights skill-weighted not equal

## What's actually next

After this merges, V3 candidates (BA-to-BA flow analysis, real BA-polygon choropleth, HEI/Alaska coverage, multi-tenant) are noted in NEXT_UP §V3 as "not yet scoped" — actual scoping work, not actionable today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)