### PR TITLE
fix(regions): NEVP capacity 8,000 → 15,445 MW (V3.ε)

### DIFF
--- a/config.py
+++ b/config.py
@@ -226,12 +226,15 @@ REGION_NAMES: dict[str, str] = {k: v["name"] for k, v in REGION_COORDINATES.item
 #           https://www.bpa.gov/-/media/Aep/power/white-book/2024-white-book.pdf
 #   AZPS  — 9,400 MW (Arizona Public Service 2023 IRP, ACC-approved 2024).
 #           https://www.aps.com/en/About/Our-Company/Doing-Business-with-Us/Resource-Planning
-#   NEVP  — ~8,000 MW (Nevada Power 2024 IRP filed with PUCN; approximate —
-#           NV Energy's NEVP-only fleet is not separately disclosed, this
-#           is derived from EIA-930 BA-level annual generation of ~37 TWh
-#           at typical IOU capacity factor and the 2024 IRP capacity
-#           additions). Verify against EIA-860 form on next data refresh.
-#           https://www.nvenergy.com/integrated-resource-plan
+#   NEVP  — 15,445 MW operating (EIA-860M February 2026, retrieved via
+#           EIA API v2 on 2026-05-01: 261 generators in the NEVP BA
+#           summed at the nameplate-capacity-mw field, filtered to
+#           statusDescription="Operating"). This is the BA-level fleet
+#           total — every generator in the territory including IPPs and
+#           wholesale sellers, not just NV Energy's own fleet. Supersedes
+#           the 8,000 MW first-pass estimate from V1.α (which conflated
+#           NV Energy's utility-owned fleet with the BA total).
+#           https://api.eia.gov/v2/electricity/operating-generator-capacity/
 #   PSCO  — 9,080 MW (Public Service Co. of Colorado / Xcel Colorado;
 #           EIA-860 BA-level installed capacity per Form 860 Schedule 6,
 #           reflected in EIA grid monitor PSCO BA page).
@@ -254,7 +257,7 @@ REGION_CAPACITY_MW: dict[str, int] = {
     "CPLE": 13_700,
     "BPAT": 17_462,
     "AZPS": 9_400,
-    "NEVP": 8_000,
+    "NEVP": 15_445,
     "PSCO": 9_080,
 }
 

--- a/docs/NEXT_UP.md
+++ b/docs/NEXT_UP.md
@@ -177,25 +177,21 @@ _Scoped 2026-05-01. Each item now has explicit acceptance criteria, files, and e
 
 **Recommended order** (highest leverage first, lowest blast radius first):
 
-1. **V3.ε** NEVP capacity verification — 15 min, doc-only
+1. ~~**V3.ε** NEVP capacity verification~~ — ✅ shipped 2026-05-01 ([config.py](../config.py); 8,000 → 15,445 MW per EIA-860M Feb 2026)
 2. **V3.α** Interchange flow visualization — ~1.5 days, mostly UI (data already plumbed)
 3. **V3.β** Real BA-polygon choropleth — ~3 days, GeoJSON cleanup + map upgrade
 4. **V3.γ** Hawaii / Alaska coverage — 3–5 days, data-path investigation
 5. **V3.δ** Multi-tenant / per-user views — deferred (weeks; awaits product-market signal)
 
-### V3.ε — NEVP capacity verification (15 min)
+### V3.ε — NEVP capacity verification — ✅ shipped 2026-05-01
 
-**Why**: V1.α set `REGION_CAPACITY_MW["NEVP"] = 8_000` ([config.py](../config.py)) as a first-pass estimate because NV Energy bundles Nevada Power south + Sierra Pacific Power north in its IRP, and PUCN filings don't break out NEVP-only fleet. The flag is documented inline in the comment block.
+**What landed**: `REGION_CAPACITY_MW["NEVP"]` updated from 8,000 → **15,445 MW** in [config.py](../config.py).
 
-**Files**:
-- [`config.py`](../config.py) — `REGION_CAPACITY_MW["NEVP"]` value + comment
+**Source**: EIA-860M February 2026, retrieved via the EIA API v2 (`/electricity/operating-generator-capacity/data/`) on 2026-05-01: 261 generators in the NEVP balancing authority, summed at the `nameplate-capacity-mw` field, filtered to `statusDescription == "Operating"`.
 
-**Acceptance**:
-- Replace 8,000 with the EIA-860 Form Schedule 6 BA-level installed capacity for NEVP (or NV Energy's most recent NEVP-specific IRP figure if they publish one).
-- Update the inline comment with the new source URL and date.
-- `pytest tests/unit/test_config.py` clean.
+**Why the V1.α estimate was so wrong**: I conflated NV Energy's utility-owned fleet (~6–8 GW) with the BA-level total. EIA's BA capacity counts every generator in the territory — utility-owned + IPPs + wholesale sellers. The 15,445 MW figure aligns with NEVP's Las Vegas summer peak (~7 GW) at typical IOU reserve margins.
 
-**Risk**: None — config-only, tested.
+**Follow-up worth noting**: the other 7 V1.α BAs were sourced from utility 10-Ks / IRPs, not EIA-860M. A future cleanup could re-source all 16 against EIA-860M for uniformity; that's not in this scope but worth a one-line note in [config.py](../config.py) if it ever happens.
 
 ---
 
@@ -335,7 +331,7 @@ _All V0–V2 items shipped as of 2026-05-01. Verified live: the 2026-05-01 04:00
 
 V3 was scoped on 2026-05-01. See §V3 above for the full plan per item. Recommended order:
 
-1. **V3.ε** NEVP capacity verification (15 min)
+1. ~~**V3.ε** NEVP capacity verification~~ — ✅ shipped 2026-05-01
 2. **V3.α** Interchange flow visualization (~1.5 days)
 3. **V3.β** Real BA-polygon choropleth (~3 days)
 4. **V3.γ** Hawaii coverage (3–5 days)


### PR DESCRIPTION
## Summary

Closes V3.ε from `docs/NEXT_UP.md`. Fixes a known approximation in `REGION_CAPACITY_MW` that V1.α flagged inline.

## What was wrong

V1.α set `REGION_CAPACITY_MW["NEVP"] = 8_000` as a first-pass estimate because NV Energy bundles Nevada Power south + Sierra Pacific Power north in its IRP. The estimate conflated **NV Energy's utility-owned fleet** (~6–8 GW) with the **BA-level total**. EIA's BA capacity counts every generator in the territory — utility-owned + IPPs + wholesale sellers — not just utility fleet.

## Authoritative source

**EIA-860M February 2026** (most recent published month), retrieved via the EIA API v2 endpoint `/electricity/operating-generator-capacity/data/` on 2026-05-01:

```
261 generators in NEVP balancing authority
Summed at nameplate-capacity-mw field
Filtered to statusDescription == "Operating"
Total: 15,445 MW
```

15,445 MW also matches NEVP's Las Vegas summer peak (~7 GW) at typical IOU reserve margins (~2× peak / capacity ratio).

## Changes

- `config.py` — `REGION_CAPACITY_MW["NEVP"]: 8_000 → 15_445` and the inline comment block now cites the EIA-860M methodology + retrieval date
- `docs/NEXT_UP.md` — V3.ε marked ✅ shipped with the source methodology preserved for future agents

## Test plan

- [x] `pytest tests/unit/test_config.py` — 15 pass
- [x] `from config import REGION_CAPACITY_MW; REGION_CAPACITY_MW["NEVP"] == 15_445` confirms
- [x] `ruff check` and `ruff format --check` clean

## Follow-up worth noting

The other 7 V1.α BAs (SOCO, TVA, DUK, CPLE, BPAT, AZPS, PSCO) were sourced from utility 10-Ks / IRPs, not EIA-860M. A future cleanup could re-source all 16 against EIA-860M for uniformity. Not in this PR's scope but documented in the V3.ε post-mortem note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)