### PR TITLE
feat(ui): add net interchange chip to US Grid region cards (V3.α)

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2279,6 +2279,33 @@ body.briefing #meeting-mode-btn.gp-header__link:hover {
     background: var(--danger-dim);
 }
 
+/* V3.α — net BA-to-BA interchange chip. Sign-coded:
+   export (+ flow out) reads success-tone, import (- flow in) reads
+   forecast/orange-tone (the same accent forecasts use), and a near-
+   zero net renders neutral so it doesn't compete for attention. */
+.gp-region-card__interchange {
+    font-size: var(--text-xs);
+    font-weight: 500;
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-sm);
+    font-variant-numeric: tabular-nums;
+}
+
+.gp-region-card__interchange--export {
+    color: var(--success);
+    background: var(--success-dim);
+}
+
+.gp-region-card__interchange--import {
+    color: var(--forecast);
+    background: rgba(249, 115, 22, 0.12);
+}
+
+.gp-region-card__interchange--neutral {
+    color: var(--text-tertiary);
+    background: var(--surface-sunken);
+}
+
 .gp-region-card__sparkline {
     height: 28px;
     color: var(--accent-base);

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -6349,22 +6349,26 @@ def _run_backtest_for_horizon(
 def _collect_us_grid_region_data() -> dict[str, dict]:
     """Pull per-region snapshots from Redis for the US Grid card grid.
 
-    Returns ``{region_code: {"current_mw", "prev_mw", "today_mw"}}`` for every
-    region in ``REGION_NAMES``. Regions without a Redis entry (cold pipeline,
-    new BAs awaiting their first scoring run) get an empty dict so the caller
-    can render an "—" placeholder card.
+    Returns ``{region_code: {"current_mw", "prev_mw", "today_mw",
+    "interchange"}}`` for every region in ``REGION_NAMES``. Regions
+    without a Redis entry (cold pipeline, new BAs awaiting their first
+    scoring run) get an empty dict so the caller can render an "—"
+    placeholder card. ``interchange`` is the V3.α
+    ``wattcast:interchange:{region}:1h`` payload, or ``None`` if absent.
     """
     out: dict[str, dict] = {}
     for region in REGION_NAMES:
         actuals = redis_get(f"wattcast:actuals:{region}")
         demand = (actuals or {}).get("demand_mw") or []
+        interchange = redis_get(f"wattcast:interchange:{region}:1h")
         if not demand:
-            out[region] = {}
+            out[region] = {"interchange": interchange} if interchange else {}
             continue
         out[region] = {
             "current_mw": demand[-1],
             "prev_mw": demand[-2] if len(demand) >= 2 else None,
             "today_mw": demand[-24:],
+            "interchange": interchange,
         }
     return out
 
@@ -6459,6 +6463,48 @@ def _build_us_grid_sparkline(values: list[float]) -> html.Div:
     )
 
 
+def _build_interchange_chip(interchange: dict | None) -> html.Span | None:
+    """V3.α: net BA-to-BA interchange chip.
+
+    Renders ``+1.2 GW`` when exporting (positive net), ``-0.8 GW`` when
+    importing (negative net), or ``≈0`` when net is below the visual
+    threshold. Hover tooltip lists the top counterparty BAs and their
+    signed flows.
+    """
+    if not interchange or interchange.get("net_mw") is None:
+        return None
+
+    net_mw = float(interchange["net_mw"])
+    counterparties = interchange.get("counterparties") or []
+
+    # Below ±50 MW the sign isn't meaningful at GW resolution; render as ≈0
+    # to avoid noise. Real flows in the system are typically 100s–1000s MW.
+    if abs(net_mw) < 50:
+        label = "≈0"
+        tone = "neutral"
+    else:
+        gw = net_mw / 1000.0
+        sign = "+" if gw >= 0 else "−"
+        label = f"{sign}{abs(gw):.1f} GW"
+        tone = "export" if gw >= 0 else "import"
+
+    if counterparties:
+        parts = []
+        for cp in counterparties:
+            mw = float(cp["mw"])
+            cp_sign = "+" if mw >= 0 else "−"
+            parts.append(f"{cp_sign}{abs(mw):,.0f} MW → {cp['to_ba']}")
+        tooltip = "Top counterparties (last hour): " + " · ".join(parts)
+    else:
+        tooltip = f"Net interchange (last hour): {net_mw:+,.0f} MW"
+
+    return html.Span(
+        label,
+        className=f"gp-region-card__interchange gp-region-card__interchange--{tone}",
+        title=tooltip,
+    )
+
+
 def _build_us_grid_region_card(region: str, data: dict) -> html.Div:
     """One region card for the US Grid small-multiples grid.
 
@@ -6524,12 +6570,17 @@ def _build_us_grid_region_card(region: str, data: dict) -> html.Div:
     if delta_chip is not None:
         demand_row_children.append(delta_chip)
 
+    interchange_chip = _build_interchange_chip(data.get("interchange"))
+
+    header_children: list = [html.Span(name, className="gp-region-card__name")]
+    if stress_chip is not None:
+        header_children.append(stress_chip)
+    if interchange_chip is not None:
+        header_children.append(interchange_chip)
+
     return html.Div(
         [
-            html.Div(
-                [html.Span(name, className="gp-region-card__name"), stress_chip],
-                className="gp-region-card__header",
-            ),
+            html.Div(header_children, className="gp-region-card__header"),
             html.Div(demand_row_children, className="gp-region-card__demand"),
             _build_us_grid_sparkline(today_mw),
         ],

--- a/jobs/phases.py
+++ b/jobs/phases.py
@@ -287,6 +287,93 @@ def write_generation(region: str) -> PhaseResult:
         return PhaseResult(region=region, ok=False, error=str(e))
 
 
+# ── Phase: interchange (V3.α) ────────────────────────────────
+
+
+def write_interchange(region: str) -> PhaseResult:
+    """Fetch BA-to-BA hourly interchange and write a per-region snapshot to Redis.
+
+    Output Redis key: ``wattcast:interchange:{region}:1h``. Schema::
+
+        {
+            "region": "PJM",
+            "scored_at": "<iso>",
+            "latest_hour": "<iso>",
+            "net_mw": -1234.5,            # signed: + export / - import
+            "counterparties": [
+                {"to_ba": "MISO", "mw": -1200.5},
+                {"to_ba": "NYISO", "mw": -800.0},
+                {"to_ba": "DUK",  "mw":  350.0},
+            ],
+        }
+
+    Counterparties are the top 3 by absolute interchange in the latest
+    available hour. Empty fetches (BA not in EIA-930 or sparse data)
+    write a placeholder with ``net_mw=None`` so the UI renders ``"—"``
+    instead of guessing.
+    """
+    from data.eia_client import fetch_interchange
+    from data.redis_client import redis_set
+
+    if not _has_eia_key():
+        return PhaseResult(region=region, ok=False, error="no_eia_api_key")
+
+    try:
+        flow_df = fetch_interchange(region)
+    except Exception as e:
+        log.warning("job_interchange_fetch_failed", region=region, error=str(e))
+        return PhaseResult(region=region, ok=False, error=str(e))
+
+    payload: dict[str, Any] = {
+        "region": region,
+        "scored_at": datetime.now(UTC).isoformat(),
+        "latest_hour": None,
+        "net_mw": None,
+        "counterparties": [],
+    }
+
+    if flow_df is None or flow_df.empty:
+        log.info("job_interchange_empty", region=region)
+        redis_set(f"wattcast:interchange:{region}:1h", payload, ttl=REDIS_TTL)
+        return PhaseResult(region=region, ok=True, details={"net_mw": None, "rows": 0})
+
+    flow_df = flow_df.dropna(subset=["interchange_mw"])
+    if flow_df.empty:
+        redis_set(f"wattcast:interchange:{region}:1h", payload, ttl=REDIS_TTL)
+        return PhaseResult(region=region, ok=True, details={"net_mw": None, "rows": 0})
+
+    latest_ts = flow_df["timestamp"].max()
+    latest = flow_df[flow_df["timestamp"] == latest_ts]
+    by_counterparty = (
+        latest.groupby("to_ba")["interchange_mw"].sum().sort_values(key=abs, ascending=False)
+    )
+    top3 = by_counterparty.head(3)
+    counterparties = [
+        {"to_ba": str(to_ba), "mw": round(float(mw), 2)} for to_ba, mw in top3.items()
+    ]
+    net_mw = round(float(by_counterparty.sum()), 2)
+
+    payload.update(
+        {
+            "latest_hour": latest_ts.isoformat() if hasattr(latest_ts, "isoformat") else None,
+            "net_mw": net_mw,
+            "counterparties": counterparties,
+        }
+    )
+    redis_set(f"wattcast:interchange:{region}:1h", payload, ttl=REDIS_TTL)
+    log.info(
+        "job_interchange_written",
+        region=region,
+        net_mw=net_mw,
+        n_counterparties=len(counterparties),
+    )
+    return PhaseResult(
+        region=region,
+        ok=True,
+        details={"net_mw": net_mw, "n_counterparties": len(counterparties)},
+    )
+
+
 # ── Phase: forecast (scoring) ────────────────────────────────
 
 

--- a/jobs/scoring_job.py
+++ b/jobs/scoring_job.py
@@ -61,6 +61,15 @@ def _score_region(region: str) -> dict:
         **(gen_res.details if gen_res.ok else {"error": gen_res.error}),
     }
 
+    # V3.α: BA-to-BA interchange snapshot. Independent of generation —
+    # a sparse interchange fetch shouldn't fail the broader scoring run,
+    # so we ignore the PhaseResult's ok flag for the summary aggregate.
+    ix_res = phases.write_interchange(region)
+    summary["phases"]["interchange"] = {
+        "ok": ix_res.ok,
+        **(ix_res.details if ix_res.ok else {"error": ix_res.error}),
+    }
+
     # Feature engineering + model load are only needed for the forecast
     # and diagnostics phases. If the model is missing (first deploy before
     # training job has run) we still emit actuals + weather + generation.

--- a/tests/unit/test_phases_interchange.py
+++ b/tests/unit/test_phases_interchange.py
@@ -1,0 +1,251 @@
+"""Unit tests for the V3.α interchange phase in jobs/phases.py.
+
+Covers ``write_interchange``'s Redis payload shape:
+
+- Empty fetch → placeholder payload with ``net_mw=None`` so the UI
+  renders "—" rather than guessing.
+- Populated fetch → top-3 counterparties by absolute interchange,
+  signed net (+ export / - import), latest-hour timestamp.
+- API error → PhaseResult.ok=False, no Redis write.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def fake_redis(monkeypatch):
+    """Capture redis_set writes in an in-memory dict."""
+    store: dict[str, dict] = {}
+
+    def _set(key: str, value, ttl: int = 86400) -> bool:
+        store[key] = value
+        return True
+
+    import data.redis_client as rc
+
+    monkeypatch.setattr(rc, "redis_set", _set)
+    return store
+
+
+@pytest.fixture
+def stub_eia_key(monkeypatch):
+    """Pretend EIA_API_KEY is configured so the phase doesn't bail early."""
+    import jobs.phases as phases
+
+    monkeypatch.setattr(phases, "_has_eia_key", lambda: True)
+
+
+def _interchange_df(rows):
+    """Build a DataFrame matching ``fetch_interchange``'s return shape."""
+    return pd.DataFrame(
+        rows,
+        columns=["timestamp", "from_ba", "to_ba", "interchange_mw"],
+    )
+
+
+class TestWriteInterchange:
+    def test_empty_dataframe_writes_placeholder(self, fake_redis, stub_eia_key, monkeypatch):
+        """Empty fetch → Redis row with net_mw=None and empty counterparties."""
+        import data.eia_client as eia
+        from jobs import phases
+
+        monkeypatch.setattr(eia, "fetch_interchange", lambda region: _interchange_df([]))
+
+        result = phases.write_interchange("PJM")
+
+        assert result.ok is True
+        payload = fake_redis["wattcast:interchange:PJM:1h"]
+        assert payload["region"] == "PJM"
+        assert payload["net_mw"] is None
+        assert payload["counterparties"] == []
+        assert payload["latest_hour"] is None
+        assert "scored_at" in payload
+
+    def test_populated_picks_top3_by_absolute_mw(self, fake_redis, stub_eia_key, monkeypatch):
+        """Top-3 selection respects sign — biggest |MW| first, sign preserved."""
+        import data.eia_client as eia
+        from jobs import phases
+
+        latest = pd.Timestamp("2026-05-01T09:00:00Z")
+        rows = [
+            (latest, "PJM", "MISO", -1200.5),  # importing 1.2 GW
+            (latest, "PJM", "NYISO", -800.0),  # importing 0.8 GW
+            (latest, "PJM", "DUK", 350.0),  # exporting 0.35 GW
+            (latest, "PJM", "TVA", 25.0),  # tiny export — should drop
+        ]
+        monkeypatch.setattr(
+            eia,
+            "fetch_interchange",
+            lambda region: _interchange_df(rows),
+        )
+
+        result = phases.write_interchange("PJM")
+
+        assert result.ok is True
+        payload = fake_redis["wattcast:interchange:PJM:1h"]
+        assert payload["latest_hour"] == latest.isoformat()
+        # Net = sum of all four = -1625.5
+        assert payload["net_mw"] == pytest.approx(-1625.5, abs=0.01)
+        cps = payload["counterparties"]
+        assert len(cps) == 3
+        # Top by |MW|: MISO -1200.5, NYISO -800, DUK 350
+        assert [cp["to_ba"] for cp in cps] == ["MISO", "NYISO", "DUK"]
+        assert cps[0]["mw"] == pytest.approx(-1200.5)
+        assert cps[2]["mw"] == pytest.approx(350.0)
+
+    def test_only_latest_hour_aggregated(self, fake_redis, stub_eia_key, monkeypatch):
+        """Older rows in the DataFrame must not contaminate the snapshot."""
+        import data.eia_client as eia
+        from jobs import phases
+
+        old = pd.Timestamp("2026-05-01T07:00:00Z")
+        latest = pd.Timestamp("2026-05-01T09:00:00Z")
+        rows = [
+            # Old hour — should be ignored
+            (old, "PJM", "MISO", 9999.0),
+            # Latest hour — only this should drive the snapshot
+            (latest, "PJM", "MISO", -500.0),
+            (latest, "PJM", "NYISO", -250.0),
+        ]
+        monkeypatch.setattr(
+            eia,
+            "fetch_interchange",
+            lambda region: _interchange_df(rows),
+        )
+
+        phases.write_interchange("PJM")
+        payload = fake_redis["wattcast:interchange:PJM:1h"]
+        assert payload["latest_hour"] == latest.isoformat()
+        assert payload["net_mw"] == pytest.approx(-750.0, abs=0.01)
+        assert payload["counterparties"][0]["mw"] == pytest.approx(-500.0)
+
+    def test_dataframe_with_nan_drops_nan_rows(self, fake_redis, stub_eia_key, monkeypatch):
+        """NaN interchange values are dropped before aggregation."""
+        import data.eia_client as eia
+        from jobs import phases
+
+        latest = pd.Timestamp("2026-05-01T09:00:00Z")
+        rows = [
+            (latest, "PJM", "MISO", -1000.0),
+            (latest, "PJM", "NYISO", np.nan),  # dropped
+        ]
+        monkeypatch.setattr(
+            eia,
+            "fetch_interchange",
+            lambda region: _interchange_df(rows),
+        )
+
+        phases.write_interchange("PJM")
+        payload = fake_redis["wattcast:interchange:PJM:1h"]
+        assert payload["net_mw"] == pytest.approx(-1000.0)
+        assert len(payload["counterparties"]) == 1
+        assert payload["counterparties"][0]["to_ba"] == "MISO"
+
+    def test_fetch_failure_returns_phase_failure_no_write(
+        self, fake_redis, stub_eia_key, monkeypatch
+    ):
+        """Fetch raises → PhaseResult.ok=False, nothing written to Redis."""
+        import data.eia_client as eia
+        from jobs import phases
+
+        def _broken_fetch(region):
+            raise RuntimeError("synthetic EIA outage")
+
+        monkeypatch.setattr(eia, "fetch_interchange", _broken_fetch)
+
+        result = phases.write_interchange("PJM")
+
+        assert result.ok is False
+        assert "synthetic EIA outage" in (result.error or "")
+        assert "wattcast:interchange:PJM:1h" not in fake_redis
+
+    def test_no_eia_api_key_returns_failure(self, fake_redis, monkeypatch):
+        """No API key → bail before fetch attempt."""
+        from jobs import phases
+
+        monkeypatch.setattr(phases, "_has_eia_key", lambda: False)
+
+        result = phases.write_interchange("PJM")
+
+        assert result.ok is False
+        assert result.error == "no_eia_api_key"
+        assert "wattcast:interchange:PJM:1h" not in fake_redis
+
+
+class TestInterchangeChipRender:
+    """Cover the UI-side ``_build_interchange_chip`` rendering logic.
+
+    The chip lives in components/callbacks.py because Dash callbacks
+    reference it directly; tests here are pure-function shape asserts.
+    """
+
+    def test_none_payload_returns_none(self):
+        from components.callbacks import _build_interchange_chip
+
+        assert _build_interchange_chip(None) is None
+
+    def test_payload_with_null_net_returns_none(self):
+        from components.callbacks import _build_interchange_chip
+
+        assert _build_interchange_chip({"net_mw": None, "counterparties": []}) is None
+
+    def test_export_renders_with_plus_sign(self):
+        from components.callbacks import _build_interchange_chip
+
+        chip = _build_interchange_chip(
+            {
+                "net_mw": 1234.5,
+                "counterparties": [{"to_ba": "MISO", "mw": 1234.5}],
+            }
+        )
+        assert chip is not None
+        assert "export" in chip.className
+        # Visible label uses ASCII-friendly + sign for export
+        assert chip.children == "+1.2 GW"
+
+    def test_import_renders_with_minus_sign(self):
+        from components.callbacks import _build_interchange_chip
+
+        chip = _build_interchange_chip(
+            {
+                "net_mw": -1234.5,
+                "counterparties": [{"to_ba": "MISO", "mw": -1234.5}],
+            }
+        )
+        assert chip is not None
+        assert "import" in chip.className
+        # Minus uses unicode "−" (U+2212), the typographically correct minus
+        assert chip.children == "−1.2 GW"
+
+    def test_near_zero_renders_neutral(self):
+        from components.callbacks import _build_interchange_chip
+
+        chip = _build_interchange_chip(
+            {"net_mw": 12.0, "counterparties": [{"to_ba": "MISO", "mw": 12.0}]}
+        )
+        assert chip is not None
+        assert "neutral" in chip.className
+        assert chip.children == "≈0"
+
+    def test_tooltip_lists_counterparties(self):
+        from components.callbacks import _build_interchange_chip
+
+        chip = _build_interchange_chip(
+            {
+                "net_mw": -2000.0,
+                "counterparties": [
+                    {"to_ba": "MISO", "mw": -1500.0},
+                    {"to_ba": "NYISO", "mw": -500.0},
+                ],
+            }
+        )
+        # Plotly's `title` kwarg is the hover tooltip
+        tooltip = chip.title
+        assert "MISO" in tooltip
+        assert "NYISO" in tooltip
+        # Top counterparty appears first
+        assert tooltip.find("MISO") < tooltip.find("NYISO")


### PR DESCRIPTION
## Summary

Closes V3.α from `docs/NEXT_UP.md`. Surfaces BA-to-BA interchange flows on the US Grid tab.

Each region card now shows net import/export rate as a small sign-coded chip in the header, with a hover tooltip listing the top 3 counterparty BAs and their signed flows in the latest hour.

## Why this was small

The data side was already there — `data/eia_client.fetch_interchange` has been plumbed since the original v2 build, returning `[timestamp, from_ba, to_ba, interchange_mw]`. The V3.α scoping ([NEXT_UP.md §V3.α](docs/NEXT_UP.md)) noted this and estimated ~1.5 days. Actual work was a new scoring phase + a chip helper + CSS + tests, all narrow.

## What's in the change

| File | What |
|---|---|
| `jobs/phases.py` | New `write_interchange` phase. Aggregates the latest hour by counterparty, picks top 3 by `\|MW\|`, writes `wattcast:interchange:{region}:1h`. Empty/sparse fetches still write a placeholder so the UI renders `—` rather than guessing. |
| `jobs/scoring_job.py` | Wires the phase next to `write_generation`. Independent of model state. |
| `components/callbacks.py` | `_build_interchange_chip` (3 tones: export `+1.2 GW`, import `−0.8 GW`, neutral `≈0` below ±50 MW); `_collect_us_grid_region_data` pulls the new key; `_build_us_grid_region_card` threads the chip into the card header. |
| `assets/custom.css` | `.gp-region-card__interchange{--export,--import,--neutral}` styled to match existing chip conventions (success-tone for export, forecast/orange for import). |
| `tests/unit/test_phases_interchange.py` | 12 new tests. |

## Test plan

- [x] `pytest tests/unit/test_phases_interchange.py` — 12 pass, covering: empty fetch / populated top-3 / latest-hour-only aggregation / NaN drop / fetch error / no-API-key fast-fail, plus chip render cases (export/import/neutral/null payload/tooltip).
- [x] `pytest tests/` — **1389 pass** (1377 + 12 new).
- [x] `ruff check` and `ruff format --check` clean.
- [ ] Post-merge: next hourly scoring run after deploy populates `wattcast:interchange:{region}:1h` for all 16 BAs. Verify via `gcloud logging read 'jsonPayload.event="job_interchange_written"'` — should show 16 entries with non-null `net_mw` for active interconnected BAs.
- [ ] Post-merge: open the deployed US Grid tab; each region card with active interchange shows a chip in the header; hover surfaces the counterparty breakdown.

## Notes

- Below ±50 MW the sign isn't meaningful at GW resolution, so the chip renders `≈0` in neutral tone. Real flows in the system are typically 100s–1000s MW; this just keeps the chip from flickering on noise near zero.
- BAs that aren't interconnected (FPL is a peninsular grid, ERCOT is electrically isolated) will write empty `counterparties: []` — the chip is omitted entirely, which is the right behavior.
- The Sankey-across-all-16-BAs option I noted in the V3.α scoping was deferred — per-region detail is more readable. Sankey could be a future overlay on the Map view if there's demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)