### PR TITLE
fix(ui): guard the Now metric against NaN tail (PSCO 2026-05-02)

### DIFF
--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -4057,29 +4057,43 @@ def _build_overview_metrics_items(demand_df: pd.DataFrame | None) -> list[dict]:
     df = df.sort_values("timestamp")
 
     # Strip spurious zero-demand rows (EIA's missing-observation marker)
+    # AND NaN rows (EIA-930's publishing lag for the most recent hour,
+    # especially for newer / smaller BAs like PSCO / NEVP / AZPS — those
+    # rows arrive at the next hourly tick instead). The ``> 0`` check
+    # filters both: NaN > 0 is False.
     nonzero = df[df["demand_mw"] > 0]
     last_7d = nonzero.tail(168)
 
-    now_value = float(df["demand_mw"].iloc[-1]) if not df.empty else 0.0
+    # ``now_value`` reads from ``nonzero`` rather than ``df`` so the
+    # most recent NaN / zero hour doesn't surface as "nan" / "0" in the
+    # hero metric. Falls back to "—" when no usable reading exists.
+    now_value = float(nonzero["demand_mw"].iloc[-1]) if not nonzero.empty else None
     peak_7d = float(last_7d["demand_mw"].max()) if not last_7d.empty else 0.0
     low_7d = float(last_7d["demand_mw"].min()) if not last_7d.empty else 0.0
     avg_7d = float(last_7d["demand_mw"].mean()) if not last_7d.empty else 0.0
 
-    # 24h trend (now vs 24 hours ago)
-    ago_24h = float(df["demand_mw"].iloc[-25]) if len(df) >= 25 else now_value
-    trend_pct = ((now_value - ago_24h) / ago_24h * 100.0) if ago_24h else 0.0
+    # 24h trend uses the same NaN-aware source as ``now_value`` so a
+    # missing ago_24h hour doesn't poison the percentage with NaN.
+    if now_value is not None and len(nonzero) >= 25:
+        ago_24h = float(nonzero["demand_mw"].iloc[-25])
+        trend_pct = ((now_value - ago_24h) / ago_24h * 100.0) if ago_24h else 0.0
+    else:
+        trend_pct = 0.0
     # Inverted semantic: rising demand reads as "warning" (negative tone),
     # falling demand reads as "positive" — matches v2 MetricsBar.tsx:64.
     trend_tone = (
         "negative" if trend_pct > 0.5 else ("positive" if trend_pct < -0.5 else "secondary")
     )
 
+    now_display = f"{now_value:,.0f}" if now_value is not None else "—"
+    trend_display = f"{trend_pct:+.1f}%" if now_value is not None else "—"
+
     return [
-        {"label": "Now", "value": f"{now_value:,.0f}", "unit": "MW", "hero": True},
+        {"label": "Now", "value": now_display, "unit": "MW", "hero": True},
         {"label": "7d Peak", "value": f"{peak_7d:,.0f}", "unit": "MW", "tone": "secondary"},
         {"label": "7d Low", "value": f"{low_7d:,.0f}", "unit": "MW", "tone": "secondary"},
         {"label": "Average", "value": f"{avg_7d:,.0f}", "unit": "MW", "tone": "secondary"},
-        {"label": "24h Trend", "value": f"{trend_pct:+.1f}%", "unit": None, "tone": trend_tone},
+        {"label": "24h Trend", "value": trend_display, "unit": None, "tone": trend_tone},
     ]
 
 

--- a/tests/unit/test_overview_metrics_nan_guard.py
+++ b/tests/unit/test_overview_metrics_nan_guard.py
@@ -1,0 +1,108 @@
+"""Regression tests for _build_overview_metrics_items NaN handling.
+
+EIA-930 has a publishing lag for the most recent hour, especially for
+newer / smaller BAs (PSCO, NEVP, AZPS). Until the row catches up the
+hourly demand series ends with a NaN. The hero "Now" metric was reading
+``df["demand_mw"].iloc[-1]`` directly and rendering the resulting NaN
+as the literal string "nan" in the UI (PSCO, 2026-05-02). Now it pulls
+from the same NaN-aware ``nonzero`` filter the other metrics use.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def _hour_range(n: int) -> pd.DatetimeIndex:
+    return pd.date_range("2026-05-01", periods=n, freq="h", tz="UTC")
+
+
+class TestNowMetricNaNGuard:
+    def test_clean_data_renders_latest_value(self):
+        from components.callbacks import _build_overview_metrics_items
+
+        ts = _hour_range(48)
+        df = pd.DataFrame({"timestamp": ts, "demand_mw": [5000.0] * 47 + [5500.0]})
+        items = _build_overview_metrics_items(df)
+        now = next(i for i in items if i["label"] == "Now")
+        assert now["value"] == "5,500"
+
+    def test_trailing_nan_falls_back_to_latest_real_reading(self):
+        """The PSCO bug: latest hour is NaN → metric should show the most
+        recent real value, not "nan"."""
+        from components.callbacks import _build_overview_metrics_items
+
+        ts = _hour_range(48)
+        demand = [5000.0] * 47 + [float("nan")]
+        df = pd.DataFrame({"timestamp": ts, "demand_mw": demand})
+        items = _build_overview_metrics_items(df)
+        now = next(i for i in items if i["label"] == "Now")
+        assert now["value"] == "5,000"
+        assert "nan" not in now["value"].lower()
+
+    def test_trailing_zero_also_skipped(self):
+        """EIA's other missing-observation marker (zero) is filtered too."""
+        from components.callbacks import _build_overview_metrics_items
+
+        ts = _hour_range(48)
+        demand = [5000.0] * 47 + [0.0]
+        df = pd.DataFrame({"timestamp": ts, "demand_mw": demand})
+        items = _build_overview_metrics_items(df)
+        now = next(i for i in items if i["label"] == "Now")
+        assert now["value"] == "5,000"
+
+    def test_all_nan_renders_em_dash_not_nan(self):
+        """Defensive: a fully sparse series → "—" placeholder, never "nan"."""
+        from components.callbacks import _build_overview_metrics_items
+
+        ts = _hour_range(24)
+        df = pd.DataFrame({"timestamp": ts, "demand_mw": [float("nan")] * 24})
+        items = _build_overview_metrics_items(df)
+        now = next(i for i in items if i["label"] == "Now")
+        trend = next(i for i in items if i["label"] == "24h Trend")
+        assert now["value"] == "—"
+        assert trend["value"] == "—"
+        assert "nan" not in now["value"].lower()
+
+    def test_trend_skips_nan_in_ago_24h_position(self):
+        """Trend's 24-hours-ago point is also NaN-aware: a NaN at index
+        -25 of the raw frame must not produce a NaN trend percentage."""
+        from components.callbacks import _build_overview_metrics_items
+
+        ts = _hour_range(48)
+        demand = [5000.0] * 48
+        # Inject NaN exactly at the -25 position the old code used
+        demand[-25] = float("nan")
+        df = pd.DataFrame({"timestamp": ts, "demand_mw": demand})
+        items = _build_overview_metrics_items(df)
+        trend = next(i for i in items if i["label"] == "24h Trend")
+        # nonzero series still has 47 entries; the NaN-aware iloc[-25] of
+        # nonzero falls within the real data so trend is finite.
+        assert "nan" not in trend["value"].lower()
+        assert "%" in trend["value"]
+
+    def test_empty_dataframe_returns_placeholder(self):
+        """Already-handled fast path: empty df → placeholder stays the same."""
+        from components.callbacks import _build_overview_metrics_items
+
+        items = _build_overview_metrics_items(pd.DataFrame(columns=["timestamp", "demand_mw"]))
+        assert all(i["value"] == "—" for i in items)
+
+    def test_none_input_returns_placeholder(self):
+        from components.callbacks import _build_overview_metrics_items
+
+        items = _build_overview_metrics_items(None)
+        assert all(i["value"] == "—" for i in items)
+
+    def test_nan_with_numpy_dtype(self):
+        """np.nan in a float64 column → same behavior as a Python float NaN."""
+        from components.callbacks import _build_overview_metrics_items
+
+        ts = _hour_range(48)
+        demand = np.full(48, 5000.0)
+        demand[-1] = np.nan
+        df = pd.DataFrame({"timestamp": ts, "demand_mw": demand})
+        items = _build_overview_metrics_items(df)
+        now = next(i for i in items if i["label"] == "Now")
+        assert now["value"] == "5,000"


### PR DESCRIPTION
## Summary

Fixes "Now: nan" on the Forecast tab for Colorado (PSCO) reported 2026-05-02. Same class of bug likely affects NEVP and AZPS intermittently.

## Root cause

The hero `Now` metric in `_build_overview_metrics_items` was doing `df["demand_mw"].iloc[-1]` directly. EIA-930 has a publishing lag for the most recent hour, especially for newer / smaller BAs — until that row catches up the demand series ends with `NaN`, which Python's f-string formatter renders as the literal string `"nan"`.

The other metrics in the same bar (7d Peak / 7d Low / Average) already filter through `nonzero = df[df["demand_mw"] > 0]`, which incidentally drops NaN too (since `NaN > 0` is False). The `Now` metric and the 24h-trend's `ago_24h` pivot were the two remaining read-from-raw paths.

## Fix

- `now_value` now reads `nonzero["demand_mw"].iloc[-1]` — most recent **real** reading rather than the latest row.
- The 24h trend's `ago_24h` pivot also reads from `nonzero`.
- When the entire `nonzero` window is empty (truly cold region) `now_value` falls back to `None` and the cell renders `"—"`, matching the existing placeholder behavior.
- Trend renders `"—"` alongside `Now` in that case, rather than reporting `+0.0%` from a zero baseline.

## Test plan

- [x] `pytest tests/unit/test_overview_metrics_nan_guard.py` — 8 new tests pass: trailing NaN (the PSCO case), trailing zero, all-NaN, trend-pivot NaN, empty df, None input, numpy-dtype NaN, clean baseline.
- [x] `pytest tests/unit/test_tab_overview.py` — existing 29 tests still pass.
- [x] `pytest tests/unit -q` — 1287 pass.
- [x] `ruff check` and `ruff format --check` clean.
- [ ] Post-merge: open the deployed Forecast tab on PSCO; the "Now" metric shows the most recent real demand value or `"—"`, never the literal `"nan"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)