### PR TITLE
feat(ui): group BAs geographically in dropdown + US Grid cards

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2169,6 +2169,27 @@ body.briefing #meeting-mode-btn.gp-header__link:hover {
     gap: var(--space-4);
 }
 
+/* Geographic section headers inside the card grid. Span the full row
+   via ``grid-column: 1 / -1``; the bottom border under the label
+   creates the visual section break without needing a separate divider
+   element. The first header drops its top spacing so the grid hugs
+   the metrics bar above. */
+.gp-region-grid__section-header {
+    grid-column: 1 / -1;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    padding: var(--space-3) 0 var(--space-1);
+    border-bottom: 1px solid var(--border-subtle);
+    margin-bottom: calc(var(--space-1) * -1);
+}
+
+.gp-region-grid__section-header:first-child {
+    padding-top: 0;
+}
+
 .gp-region-card {
     display: flex;
     flex-direction: column;

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -2379,11 +2379,24 @@ def register_callbacks(app):
             if view == "map":
                 body = _build_us_grid_map(region_data)
             else:
-                cards = [
-                    _build_us_grid_region_card(region, region_data.get(region, {}))
-                    for region in REGION_NAMES
-                ]
-                body = html.Div(cards, className="gp-region-grid")
+                # Cards are grouped geographically. Section headers
+                # span the full grid row via ``grid-column: 1 / -1`` —
+                # see ``.gp-region-grid__section-header`` in custom.css.
+                from config import REGION_GROUPS
+
+                grid_children: list = []
+                for group_name, codes in REGION_GROUPS.items():
+                    grid_children.append(
+                        html.Div(
+                            group_name,
+                            className="gp-region-grid__section-header",
+                        )
+                    )
+                    grid_children.extend(
+                        _build_us_grid_region_card(code, region_data.get(code, {}))
+                        for code in codes
+                    )
+                body = html.Div(grid_children, className="gp-region-grid")
 
             return (title, metrics_bar, body)
         except Exception as exc:

--- a/components/layout.py
+++ b/components/layout.py
@@ -17,7 +17,7 @@ from components import (
     tab_overview,
     tab_us_grid,
 )
-from config import REGION_NAMES, TAB_LABELS
+from config import REGION_GROUPS, REGION_NAMES, TAB_LABELS
 from personas.config import list_personas
 
 # All five tabs in the strip are visible. ``_VISIBLE_TABS`` is kept as a
@@ -57,7 +57,17 @@ def _build_header() -> html.Header:
     persona_options = [
         {"label": f"{p['avatar']} {p['title']}", "value": p["id"]} for p in list_personas()
     ]
-    region_options = [{"label": name, "value": code} for code, name in REGION_NAMES.items()]
+    # Region options are grouped geographically (Central / Northeast /
+    # Southeast / West). dbc.Select doesn't support native <optgroup>,
+    # so we surface each group with a disabled separator option that's
+    # visually distinct but unselectable. The empty value="" never
+    # reaches a callback because Bootstrap honors the disabled attribute
+    # on click + keyboard nav.
+    region_options: list[dict] = []
+    for group_name, codes in REGION_GROUPS.items():
+        region_options.append({"label": f"── {group_name} ──", "value": "", "disabled": True})
+        for code in codes:
+            region_options.append({"label": REGION_NAMES.get(code, code), "value": code})
 
     brand = html.Div(
         [

--- a/config.py
+++ b/config.py
@@ -175,6 +175,30 @@ REGION_COORDINATES: dict[str, dict] = {
 REGION_NAMES: dict[str, str] = {k: v["name"] for k, v in REGION_COORDINATES.items()}
 
 # ---------------------------------------------------------------------------
+# Regional groupings — used by the header dropdown and the US Grid card
+# grid to surface geographic context. Groups are sorted A-Z by group
+# name; BA codes within each group are sorted A-Z by code (the
+# dictionary literal order below IS the render order — Python ≥3.7
+# preserves insertion order, and ``test_config.py`` guards both
+# orderings + total coverage of ``REGION_COORDINATES``).
+# ---------------------------------------------------------------------------
+REGION_GROUPS: dict[str, list[str]] = {
+    "Central": ["ERCOT", "MISO", "SPP"],
+    "Northeast": ["ISONE", "NYISO", "PJM"],
+    "Southeast": ["CPLE", "DUK", "FPL", "SOCO", "TVA"],
+    "West": ["AZPS", "BPAT", "CAISO", "NEVP", "PSCO"],
+}
+
+
+def grouped_regions() -> list[tuple[str, list[str]]]:
+    """Return ``REGION_GROUPS`` items as a list — convenience for callers
+    that iterate (group_name, codes) tuples without importing the dict
+    directly. Order matches ``REGION_GROUPS`` (groups A-Z, codes A-Z).
+    """
+    return list(REGION_GROUPS.items())
+
+
+# ---------------------------------------------------------------------------
 # Generation Capacity (MW)
 # Used by the scenario simulator's merit-order pricing model.
 # Values reflect total installed nameplate capacity from each BA's most

--- a/tests/unit/test_region_groups.py
+++ b/tests/unit/test_region_groups.py
@@ -1,0 +1,217 @@
+"""Tests for the geographic grouping of balancing authorities (V3 polish).
+
+``REGION_GROUPS`` is the single source of truth for both the header
+dropdown's optgroup-style separators and the US Grid card grid's section
+headers. These tests lock in:
+
+- Total coverage: every BA in ``REGION_COORDINATES`` appears exactly
+  once across the groups.
+- Group order: A-Z by group name (Central, Northeast, Southeast, West).
+- BA order within each group: A-Z by code.
+- Dropdown rendering: section options have ``disabled=True`` and value
+  ``""``; selectable options interleave correctly between separators.
+- Card grid rendering: section headers carry ``gp-region-grid__section-header``
+  and appear before each group's cards in the right order.
+"""
+
+from __future__ import annotations
+
+
+class TestRegionGroupsCoverage:
+    def test_every_ba_in_exactly_one_group(self):
+        from config import REGION_COORDINATES, REGION_GROUPS
+
+        all_grouped = [code for codes in REGION_GROUPS.values() for code in codes]
+        assert sorted(all_grouped) == sorted(REGION_COORDINATES.keys())
+        # No duplicates
+        assert len(all_grouped) == len(set(all_grouped))
+
+    def test_no_unknown_codes_in_groups(self):
+        """A code in REGION_GROUPS that doesn't exist in
+        REGION_COORDINATES would render an unselectable card."""
+        from config import REGION_COORDINATES, REGION_GROUPS
+
+        for codes in REGION_GROUPS.values():
+            for code in codes:
+                assert code in REGION_COORDINATES, (
+                    f"{code} listed in REGION_GROUPS but missing from REGION_COORDINATES"
+                )
+
+
+class TestRegionGroupsOrdering:
+    def test_groups_sorted_alphabetically(self):
+        from config import REGION_GROUPS
+
+        names = list(REGION_GROUPS.keys())
+        assert names == sorted(names)
+
+    def test_codes_within_each_group_sorted(self):
+        from config import REGION_GROUPS
+
+        for group_name, codes in REGION_GROUPS.items():
+            assert codes == sorted(codes), f"Group '{group_name}' codes not sorted A-Z: {codes}"
+
+    def test_groups_match_recommendation(self):
+        """Lock in the exact regional grouping shipped — change with
+        intent. If a future refactor wants to reshape the groups, the
+        test fail forces an explicit update + design review."""
+        from config import REGION_GROUPS
+
+        assert REGION_GROUPS == {
+            "Central": ["ERCOT", "MISO", "SPP"],
+            "Northeast": ["ISONE", "NYISO", "PJM"],
+            "Southeast": ["CPLE", "DUK", "FPL", "SOCO", "TVA"],
+            "West": ["AZPS", "BPAT", "CAISO", "NEVP", "PSCO"],
+        }
+
+
+class TestGroupedRegionsHelper:
+    def test_returns_list_of_tuples(self):
+        from config import grouped_regions
+
+        result = grouped_regions()
+        assert isinstance(result, list)
+        for item in result:
+            assert isinstance(item, tuple)
+            assert len(item) == 2
+
+    def test_order_matches_region_groups(self):
+        from config import REGION_GROUPS, grouped_regions
+
+        assert grouped_regions() == list(REGION_GROUPS.items())
+
+
+class TestHeaderDropdownGrouping:
+    """The header dropdown uses ``REGION_GROUPS`` to render disabled
+    separator options between selectable BA options. These tests lock
+    in the dropdown's options structure."""
+
+    def _region_options(self):
+        """Build region options the same way ``_build_header`` does."""
+        from config import REGION_GROUPS, REGION_NAMES
+
+        options: list[dict] = []
+        for group_name, codes in REGION_GROUPS.items():
+            options.append({"label": f"── {group_name} ──", "value": "", "disabled": True})
+            for code in codes:
+                options.append({"label": REGION_NAMES.get(code, code), "value": code})
+        return options
+
+    def test_total_option_count(self):
+        """Total = sum(group_size) + N_groups disabled separators."""
+        from config import REGION_GROUPS
+
+        opts = self._region_options()
+        n_codes = sum(len(codes) for codes in REGION_GROUPS.values())
+        n_separators = len(REGION_GROUPS)
+        assert len(opts) == n_codes + n_separators
+
+    def test_separators_are_disabled(self):
+        opts = self._region_options()
+        separators = [o for o in opts if o.get("disabled")]
+        assert len(separators) == 4  # 4 groups
+        for sep in separators:
+            assert sep["value"] == ""
+            assert sep["label"].startswith("── ")
+            assert sep["label"].endswith(" ──")
+
+    def test_selectable_options_carry_real_codes(self):
+        from config import REGION_COORDINATES
+
+        opts = self._region_options()
+        selectable = [o for o in opts if not o.get("disabled")]
+        codes = [o["value"] for o in selectable]
+        assert sorted(codes) == sorted(REGION_COORDINATES.keys())
+
+    def test_separator_precedes_its_group(self):
+        """Each disabled separator must immediately precede the BAs of
+        its group — checks that the rendering order isn't scrambled."""
+        from config import REGION_GROUPS
+
+        opts = self._region_options()
+        i = 0
+        for group_name, codes in REGION_GROUPS.items():
+            assert opts[i]["disabled"] is True
+            assert group_name in opts[i]["label"]
+            i += 1
+            for code in codes:
+                assert opts[i]["value"] == code
+                assert opts[i].get("disabled") is None or opts[i]["disabled"] is False
+                i += 1
+
+
+class TestUsGridCardGrouping:
+    """The US Grid card grid renders a section header before each
+    group's cards. The header is a Div with the
+    ``gp-region-grid__section-header`` class, and the grid is a
+    pattern-matching container (``gp-region-grid``) so existing CSS
+    handles full-row spans via ``grid-column: 1 / -1``."""
+
+    def _patch_redis(self, monkeypatch, redis_state):
+        from components import callbacks as cb
+
+        def _get(key):
+            return redis_state.get(key)
+
+        monkeypatch.setattr(cb, "redis_get", _get)
+
+    def _render_us_grid_body(self, monkeypatch):
+        """Build the cards body the way ``update_us_grid_snapshot`` does."""
+        from dash import html
+
+        from components.callbacks import _build_us_grid_region_card, _collect_us_grid_region_data
+        from config import REGION_GROUPS
+
+        region_data = _collect_us_grid_region_data()
+        grid_children: list = []
+        for group_name, codes in REGION_GROUPS.items():
+            grid_children.append(html.Div(group_name, className="gp-region-grid__section-header"))
+            grid_children.extend(
+                _build_us_grid_region_card(code, region_data.get(code, {})) for code in codes
+            )
+        return html.Div(grid_children, className="gp-region-grid")
+
+    def test_one_section_header_per_group(self, monkeypatch):
+        self._patch_redis(monkeypatch, {})  # cold pipeline; cards render placeholders
+        body = self._render_us_grid_body(monkeypatch)
+        headers = [
+            c
+            for c in body.children
+            if getattr(c, "className", "") == "gp-region-grid__section-header"
+        ]
+        from config import REGION_GROUPS
+
+        assert len(headers) == len(REGION_GROUPS)
+
+    def test_section_header_text_matches_group_name(self, monkeypatch):
+        self._patch_redis(monkeypatch, {})
+        body = self._render_us_grid_body(monkeypatch)
+        from config import REGION_GROUPS
+
+        header_texts = [
+            c.children
+            for c in body.children
+            if getattr(c, "className", "") == "gp-region-grid__section-header"
+        ]
+        assert header_texts == list(REGION_GROUPS.keys())
+
+    def test_cards_immediately_follow_their_section_header(self, monkeypatch):
+        """Order check: header → its codes → next header → its codes."""
+        self._patch_redis(monkeypatch, {})
+        body = self._render_us_grid_body(monkeypatch)
+        from config import REGION_GROUPS
+
+        children = body.children
+        idx = 0
+        for group_name, codes in REGION_GROUPS.items():
+            assert getattr(children[idx], "className", "") == "gp-region-grid__section-header"
+            assert children[idx].children == group_name
+            idx += 1
+            for code in codes:
+                # Cards have pattern-matching dict IDs of shape
+                # {"type": "us-grid-region-card", "region": code}
+                card = children[idx]
+                assert isinstance(card.id, dict)
+                assert card.id.get("type") == "us-grid-region-card"
+                assert card.id.get("region") == code
+                idx += 1


### PR DESCRIPTION
## Summary

With 16 BAs after V1.α, the alphabetical/insertion-ordered list became harder to scan. Adds geographic grouping as a single source of truth (`config.REGION_GROUPS`) and applies it to both the header dropdown and the US Grid card grid.

## Grouping (sorted A-Z by group name; codes A-Z within each)

| Group | BAs |
|---|---|
| **Central** | ERCOT, MISO, SPP |
| **Northeast** | ISONE, NYISO, PJM |
| **Southeast** | CPLE, DUK, FPL, SOCO, TVA |
| **West** | AZPS, BPAT, CAISO, NEVP, PSCO |

## What changed

- **`config.py`** adds `REGION_GROUPS` (4-key dict) + `grouped_regions()` helper.
- **`components/layout.py`** builds the dropdown options with disabled separator entries between groups. `dbc.Select` doesn't support native `<optgroup>`, so this is the standard workaround — Bootstrap honors the disabled flag for click + keyboard nav, and `value=""` never reaches a callback because the option is unselectable.
- **`components/callbacks.py`** `update_us_grid_snapshot` interleaves `html.Div` section headers between each group's cards. Headers span the full grid row via `grid-column: 1 / -1`.
- **`assets/custom.css`** adds `.gp-region-grid__section-header` — small uppercase label with a hairline border-bottom matching the existing card chip aesthetic. First header drops top padding so the grid hugs the metrics bar above. Existing responsive `grid-template-columns` adjustments (1024 / 768 / 480 breakpoints) pick up automatically.

## Test plan

- [x] **14 new tests** in `tests/unit/test_region_groups.py` lock in:
  - Total coverage: every BA in `REGION_COORDINATES` appears exactly once across the groups; no duplicates; no unknown codes
  - Group order: A-Z by group name
  - BA order within each group: A-Z by code
  - Dropdown structure: one disabled separator per group, immediately preceding its codes; selectable options carry real BA values
  - Card grid structure: section headers in the right order, cards immediately follow their header (verified by walking the pattern-matching `us-grid-region-card` IDs)
- [x] `pytest tests/unit -q` — **1349 pass** (1335 + 14 new).
- [x] `ruff check` and `ruff format --check` clean.
- [ ] Post-merge: open the deployed app; the header dropdown shows 4 disabled section labels (`── Central ──`, `── Northeast ──`, `── Southeast ──`, `── West ──`) with their BAs underneath. The US Grid tab shows the same four sections as headers in the card grid with cards aligned under the right section.

## Tradeoff (deliberate)

Users who pick by name lose alphabetic ordering across the whole list. With 16 BAs that didn't feel unwieldy enough to need a "Region | A-Z" sort toggle (~30 min of extra work) — keeping it simple. Easy to add later if the grouped view turns out to slow down power users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)