### PR TITLE
fix(ui): cap absurd stress display for import-dominated BAs

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2300,6 +2300,17 @@ body.briefing #meeting-mode-btn.gp-header__link:hover {
     background: var(--danger-dim);
 }
 
+/* V3.η stop-gap: BAs whose served demand exceeds in-territory
+   capacity by >2×. The capacity figure is wrong for ranking purposes
+   (utility BAs that import nearly all their power); display a neutral
+   "imports" label instead of a misleading multi-hundred-percent
+   number. See ``_STRESS_RELIABLE_CEILING`` in components/callbacks.py. */
+.gp-region-card__stress--imports {
+    color: var(--text-tertiary);
+    background: var(--bg-raised);
+    font-style: italic;
+}
+
 /* V3.α — net BA-to-BA interchange chip. Sign-coded:
    export (+ flow out) reads success-tone, import (- flow in) reads
    forecast/orange-tone (the same accent forecasts use), and a near-

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -6554,6 +6554,18 @@ def _is_real_positive(value) -> bool:
     return bool(np.isfinite(f) and f > 0)
 
 
+# ``REGION_CAPACITY_MW`` (sourced from EIA-860M Feb 2026) counts only
+# in-territory operating generators. For a handful of import-dominated
+# utility BAs (CPLW = Duke Energy Progress West NC mountains, HST =
+# City of Homestead, GVL = Gainesville, SPA = federal hydro marketer)
+# the actual served demand exceeds in-territory capacity many times
+# over because they import nearly all their power. A "demand /
+# capacity" stress ratio above this ceiling means the capacity figure
+# is wrong, not that the BA is genuinely stressed — drop those rows
+# from any stress ranking. Underlying-data fix is the V3.η follow-up.
+_STRESS_RELIABLE_CEILING = 2.0
+
+
 def _build_us_grid_metrics_items(region_data: dict[str, dict]) -> list[dict]:
     """4-up MetricsBar items: Total Demand · Peak Today · Top-Stress BA · Lowest Reserve."""
     populated = {r: d for r, d in region_data.items() if _is_real_positive(d.get("current_mw"))}
@@ -6581,10 +6593,24 @@ def _build_us_grid_metrics_items(region_data: dict[str, dict]) -> list[dict]:
         for region, d in populated.items()
         if (cap := REGION_CAPACITY_MW.get(region, 0)) > 0
     }
-    if stress_by_region:
-        top_region = max(stress_by_region, key=stress_by_region.get)
-        top_stress_pct = stress_by_region[top_region] * 100
-        lowest_reserve_pct = (1 - max(stress_by_region.values())) * 100
+    # Drop import-dominated BAs whose ``REGION_CAPACITY_MW`` (sourced
+    # from EIA-860M, counts only in-territory operating generators) is
+    # smaller than the BA's served demand. Observed in V3.ζ: CPLW had
+    # 449 MW served vs 42 MW of in-territory generation, producing a
+    # nonsensical "Highest-Stress: CPLW · 1071%". Anything above the
+    # ``_STRESS_RELIABLE_CEILING`` is structural (the BA imports most
+    # of its power), not real stress — exclude from the ranking. The
+    # underlying-data fix lives in the V3.η follow-up.
+    reliable_stress = {r: s for r, s in stress_by_region.items() if s <= _STRESS_RELIABLE_CEILING}
+    if reliable_stress:
+        top_region = max(reliable_stress, key=reliable_stress.get)
+        # Cap displayed stress at 100% so a tight-day reading of 110%
+        # doesn't render as e.g. "PJM · 110%". Matches the map's
+        # cap (``_build_us_grid_map`` line ~6821).
+        top_stress_pct = min(reliable_stress[top_region], 1.0) * 100
+        # Floor reserve at 0% — a BA running at or above its capacity
+        # has zero operator reserve, never negative.
+        lowest_reserve_pct = max(0.0, (1 - max(reliable_stress.values())) * 100)
         top_tone = "negative" if top_stress_pct >= 85 else "secondary"
         reserve_tone = "negative" if lowest_reserve_pct < 15 else "secondary"
         top_value = f"{top_region} · {top_stress_pct:.0f}%"
@@ -6725,18 +6751,36 @@ def _build_us_grid_region_card(region: str, data: dict) -> html.Div:
 
     stress_chip = None
     if capacity_mw > 0:
-        stress_pct = current_mw / capacity_mw * 100
-        if stress_pct >= 85:
-            tone = "high"
-        elif stress_pct >= 70:
-            tone = "mid"
+        stress_ratio = current_mw / capacity_mw
+        if stress_ratio > _STRESS_RELIABLE_CEILING:
+            # Import-dominated BA — capacity figure is wrong for this
+            # purpose (counts only in-territory generators). Show a
+            # qualitative "imports" chip instead of a misleading
+            # "1071%" number. See ``_STRESS_RELIABLE_CEILING`` comment.
+            stress_chip = html.Span(
+                "imports",
+                className="gp-region-card__stress gp-region-card__stress--imports",
+                title=(
+                    f"Demand ({current_mw:,.0f} MW) far exceeds in-territory "
+                    f"generators ({capacity_mw:,.0f} MW). This BA imports nearly "
+                    f"all its power; stress ratio is not meaningful here."
+                ),
+            )
         else:
-            tone = "low"
-        stress_chip = html.Span(
-            f"{stress_pct:.0f}%",
-            className=f"gp-region-card__stress gp-region-card__stress--{tone}",
-            title=(f"Demand vs. capacity: {current_mw:,.0f} / {capacity_mw:,.0f} MW"),
-        )
+            # Cap displayed stress at 100% so a tight-day reading of
+            # 110% renders as "100%". Matches the choropleth and map.
+            stress_pct = min(stress_ratio, 1.0) * 100
+            if stress_pct >= 85:
+                tone = "high"
+            elif stress_pct >= 70:
+                tone = "mid"
+            else:
+                tone = "low"
+            stress_chip = html.Span(
+                f"{stress_pct:.0f}%",
+                className=f"gp-region-card__stress gp-region-card__stress--{tone}",
+                title=(f"Demand vs. capacity: {current_mw:,.0f} / {capacity_mw:,.0f} MW"),
+            )
 
     demand_row_children: list = [
         html.Span(

--- a/docs/NEXT_UP.md
+++ b/docs/NEXT_UP.md
@@ -286,6 +286,29 @@ _Scoped 2026-05-01. Each item now has explicit acceptance criteria, files, and e
 
 ---
 
+### V3.η — Capacity figure for import-dominated BAs
+
+**Why**: V3.ζ surfaced a class of bug where ``REGION_CAPACITY_MW`` (sourced from EIA-860M, counting in-territory operating generators) is wildly low for utility BAs that import nearly all their power. CPLW (Duke Energy Progress West, NC mountains) has 42 MW of in-territory generators serving ~449 MW of demand → stress ratio of 10.71×. Same pattern likely affects HST (36 MW capacity), GVL (600 MW), and SPA (federal hydro marketer redistributing power across multiple states).
+
+**User impact (pre-patch)**: "Highest-Stress Region: CPLW · 1071%" / "Lowest Reserve: -971%" on the deployed US Grid metrics bar (reported 2026-05-02). Stop-gap shipped under the same fix that introduced the ``_STRESS_RELIABLE_CEILING = 2.0`` defensive filter — V3.η is the proper data fix.
+
+**Goal**: Replace EIA-860M generator capacity with a "demand-serving capacity" denominator for import-dominated BAs — annual peak demand × 1.15 reserve margin, or N/A if the BA is purely an importer (don't show stress at all).
+
+**Files**:
+- [`config.py`](../config.py) — `REGION_CAPACITY_MW` for the ~5 affected BAs (CPLW, HST, GVL, SPA; verify TAL, TPWR, etc. as well)
+- New `scripts/derive_demand_serving_capacity.py` — one-shot script that pulls each BA's annual peak demand from EIA-930 and computes the corrected figure with reserve margin
+
+**Acceptance**:
+- For every BA with EIA-860M capacity < BA peak demand, replace with `peak_demand_mw * 1.15`. Document inline.
+- Optionally: add a `IS_IMPORT_DOMINATED: set[str]` tag for BAs where the stress metric is intrinsically meaningless (federal marketers); UI hides their stress chip.
+- The ``_STRESS_RELIABLE_CEILING`` filter becomes a defense-in-depth safety net rather than the primary mechanism.
+
+**Effort**: ~2 hours (script + verification + config update).
+
+**Risk**: Choosing the wrong reserve margin number could materially change downstream pricing/scenario results. Document the methodology clearly.
+
+---
+
 ### V3.γ — Hawaii / Alaska coverage
 
 **Why**: GridPulse claims "~98% of US load coverage" after V1.α, but contiguous-only. Adding HI/AK is the natural completion.

--- a/tests/unit/test_us_grid_stress_cap.py
+++ b/tests/unit/test_us_grid_stress_cap.py
@@ -1,0 +1,239 @@
+"""Regression tests for the US Grid stress-display cap (V3.ζ follow-up).
+
+User reported 2026-05-02: "Highest-Stress Region: CPLW · 1071%" and
+"Lowest Reserve: -971%" on the deployed US Grid metrics bar. Same
+class of bug for the per-region card's stress chip — CPLW would
+display "1071%" on its own card.
+
+Root cause: ``REGION_CAPACITY_MW["CPLW"] = 42`` (sourced from
+EIA-860M Feb 2026, counts in-territory operating generators). CPLW
+serves ~449 MW by importing nearly all its power from neighbors.
+demand / capacity = 10.71× = 1071%. Math is correct, capacity figure
+is meaningless for ranking purposes.
+
+Fix:
+- ``_STRESS_RELIABLE_CEILING = 2.0`` filters BAs with stress ratio
+  above this from any ranking (their capacity figure is wrong).
+- Metrics bar caps top-stress display at 100% and floors reserve at 0%.
+- Region card swaps the stress chip for an "imports" qualitative
+  chip when stress > ceiling.
+
+Tests cover the user-reported scenario, edge cases at the threshold,
+and the multi-BA case where one bad ratio doesn't affect others.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def _stress_chip(card_div):
+    """Walk a region card and return the stress chip's className/text."""
+    found = []
+
+    def _walk(c):
+        if hasattr(c, "className") and c.className:
+            cls = c.className
+            if isinstance(cls, str) and "gp-region-card__stress" in cls:
+                text = getattr(c, "children", None)
+                found.append((cls, text))
+        children = getattr(c, "children", None)
+        if isinstance(children, (list, tuple)):
+            for ch in children:
+                _walk(ch)
+        elif children is not None and not isinstance(children, str):
+            _walk(children)
+
+    _walk(card_div)
+    return found[0] if found else (None, None)
+
+
+class TestMetricsBarStressCap:
+    """The user-reported scenario — Top-Stress drove to 1071% and
+    Lowest Reserve to -971% because CPLW's capacity is wrong for the
+    ranking purpose."""
+
+    def test_cplw_excluded_from_top_stress_ranking(self):
+        """The 1071% BA must not win 'Highest-Stress'. The next-highest
+        reliable BA wins instead."""
+        from components.callbacks import _build_us_grid_metrics_items
+
+        # CPLW: 449 / 42 = 10.71 (excluded). PJM: 70000 / 184202 ≈ 0.38 (highest reliable).
+        region_data = {
+            "CPLW": {"current_mw": 449.0, "today_mw": [449.0] * 24},
+            "PJM": {"current_mw": 70000.0, "today_mw": [70000.0] * 24},
+            "ERCOT": {"current_mw": 50000.0, "today_mw": [50000.0] * 24},
+        }
+        items = _build_us_grid_metrics_items(region_data)
+        top = next(i for i in items if i["label"] == "Highest-Stress Region")
+        # PJM @ 38% should win, not CPLW @ 1071%
+        assert "PJM" in top["value"]
+        assert "CPLW" not in top["value"]
+        assert "1071" not in top["value"]
+        assert "%" in top["value"]
+
+    def test_lowest_reserve_floored_at_zero(self):
+        """When the highest-stress BA is below 100%, reserve is the
+        positive complement. Even if some BA edges over 100% it should
+        floor at 0% — never the absurd -971% from the bug report."""
+        from components.callbacks import _build_us_grid_metrics_items
+
+        region_data = {
+            "CPLW": {"current_mw": 449.0, "today_mw": [449.0] * 24},
+            "PJM": {"current_mw": 70000.0, "today_mw": [70000.0] * 24},
+        }
+        items = _build_us_grid_metrics_items(region_data)
+        reserve = next(i for i in items if i["label"] == "Lowest Reserve")
+        assert "-" not in reserve["value"]
+        assert reserve["value"] != "—"
+
+    def test_displayed_stress_caps_at_100_percent(self):
+        """Even within the reliable band (<200%), display caps at 100%
+        so a tight-day 110% reading renders cleanly."""
+        from components.callbacks import _build_us_grid_metrics_items
+
+        # Inject a region with stress between 100% and ceiling
+        with patch.dict(
+            "components.callbacks.REGION_CAPACITY_MW",
+            {"PJM": 50000},  # 70000/50000 = 140% (reliable but over 100%)
+            clear=False,
+        ):
+            region_data = {"PJM": {"current_mw": 70000.0, "today_mw": [70000.0] * 24}}
+            items = _build_us_grid_metrics_items(region_data)
+            top = next(i for i in items if i["label"] == "Highest-Stress Region")
+            # Display should cap at 100% (no "140%" reading)
+            assert "100" in top["value"]
+            assert "140" not in top["value"]
+
+    def test_all_unreliable_renders_placeholder(self):
+        """If every populated region is import-dominated, there's no
+        reliable stress ranking and the metric falls back to '—'.
+        Using current_mw values chosen to push every ratio above the
+        2.0 unreliable ceiling against the actual config capacities."""
+        from components.callbacks import _build_us_grid_metrics_items
+
+        region_data = {
+            "CPLW": {"current_mw": 449.0, "today_mw": [449.0] * 24},  # 449/42 = 10.7×
+            "HST": {"current_mw": 200.0, "today_mw": [200.0] * 24},  # 200/36 = 5.6×
+            "GVL": {"current_mw": 2000.0, "today_mw": [2000.0] * 24},  # 2000/600 = 3.3×
+        }
+        items = _build_us_grid_metrics_items(region_data)
+        top = next(i for i in items if i["label"] == "Highest-Stress Region")
+        reserve = next(i for i in items if i["label"] == "Lowest Reserve")
+        assert top["value"] == "—"
+        assert reserve["value"] == "—"
+
+    def test_total_demand_still_includes_unreliable_bas(self):
+        """The Total Demand metric should NOT exclude import-dominated
+        BAs — their demand reading is still real (just their capacity
+        ratio isn't useful). Operators want the actual served-demand
+        rollup, not a filtered view."""
+        from components.callbacks import _build_us_grid_metrics_items
+
+        region_data = {
+            "CPLW": {"current_mw": 449.0, "today_mw": [449.0] * 24},
+            "PJM": {"current_mw": 70000.0, "today_mw": [70000.0] * 24},
+        }
+        items = _build_us_grid_metrics_items(region_data)
+        total = next(i for i in items if i["label"] == "Total Demand")
+        # CPLW + PJM = 70449 MW = 70.4 GW
+        assert total["value"] == "70.4"
+
+
+class TestRegionCardStressChip:
+    """The CPLW card itself would have shown '1071%' as a stress chip
+    before the fix. After: shows a qualitative 'imports' chip with a
+    hover tooltip explaining the data context."""
+
+    def test_imports_chip_for_unreliable_capacity(self):
+        from components.callbacks import _build_us_grid_region_card
+
+        # CPLW with realistic served demand vs in-territory capacity
+        with patch("components.callbacks.REGION_NAMES", {"CPLW": "DEP-W (NC mtn)"}):
+            card = _build_us_grid_region_card(
+                "CPLW",
+                {"current_mw": 449.0, "prev_mw": 445.0, "today_mw": [449.0] * 24},
+            )
+        cls, text = _stress_chip(card)
+        assert cls is not None
+        assert "imports" in cls
+        assert text == "imports"
+
+    def test_normal_chip_for_healthy_ba(self):
+        """PJM has a sane capacity figure, so the chip should be a
+        regular percentage."""
+        from components.callbacks import _build_us_grid_region_card
+
+        with patch("components.callbacks.REGION_NAMES", {"PJM": "Mid-Atlantic (PJM)"}):
+            card = _build_us_grid_region_card(
+                "PJM",
+                {"current_mw": 70000.0, "prev_mw": 69000.0, "today_mw": [70000.0] * 24},
+            )
+        cls, text = _stress_chip(card)
+        assert cls is not None
+        # 70000 / 184202 ≈ 38% → "low" tone
+        assert "low" in cls
+        assert "imports" not in cls
+        assert text and "%" in text
+
+    def test_card_chip_caps_at_100_percent_for_in_band_excess(self):
+        """If a BA's stress is between 100% and the unreliable ceiling
+        (200%) — e.g. tight-day reading — the chip caps the displayed
+        number at 100% rather than showing 140%."""
+        from components.callbacks import _build_us_grid_region_card
+
+        with (
+            patch.dict(
+                "components.callbacks.REGION_CAPACITY_MW",
+                {"PJM": 50000},  # 140%
+                clear=False,
+            ),
+            patch("components.callbacks.REGION_NAMES", {"PJM": "PJM"}),
+        ):
+            card = _build_us_grid_region_card(
+                "PJM",
+                {"current_mw": 70000.0, "prev_mw": 69000.0, "today_mw": [70000.0] * 24},
+            )
+        cls, text = _stress_chip(card)
+        assert text == "100%"
+
+
+class TestStressCeilingThreshold:
+    """The 200% ceiling is documented inline. These tests pin the
+    boundary so the ceiling can't drift silently."""
+
+    def test_ceiling_constant_value(self):
+        from components.callbacks import _STRESS_RELIABLE_CEILING
+
+        assert _STRESS_RELIABLE_CEILING == 2.0
+
+    def test_just_below_ceiling_is_reliable(self):
+        """199% (just below 200%) is treated as reliable — a region
+        running this hot is highly stressed but the capacity figure
+        is at least plausible."""
+        from components.callbacks import _build_us_grid_metrics_items
+
+        with patch.dict(
+            "components.callbacks.REGION_CAPACITY_MW", {"PJM": 35176}, clear=False
+        ):  # 70000/35176 ≈ 199%
+            region_data = {"PJM": {"current_mw": 70000.0, "today_mw": [70000.0] * 24}}
+            items = _build_us_grid_metrics_items(region_data)
+            top = next(i for i in items if i["label"] == "Highest-Stress Region")
+            assert "PJM" in top["value"]  # included in ranking, not excluded
+
+    def test_just_above_ceiling_is_unreliable(self):
+        """201% triggers the unreliable-data filter."""
+        from components.callbacks import _build_us_grid_metrics_items
+
+        with patch.dict(
+            "components.callbacks.REGION_CAPACITY_MW", {"PJM": 34825}, clear=False
+        ):  # 70000/34825 ≈ 201%
+            region_data = {
+                "PJM": {"current_mw": 70000.0, "today_mw": [70000.0] * 24},
+                "ERCOT": {"current_mw": 50000.0, "today_mw": [50000.0] * 24},
+            }
+            items = _build_us_grid_metrics_items(region_data)
+            top = next(i for i in items if i["label"] == "Highest-Stress Region")
+            # PJM excluded; ERCOT (the next-highest reliable) wins
+            assert "PJM" not in top["value"]
+            assert "ERCOT" in top["value"]


### PR DESCRIPTION
## Summary

Fixes the **"Highest-Stress Region: CPLW · 1071%" / "Lowest Reserve: -971%"** bug reported on the deployed US Grid metrics bar 2026-05-02.

## Root cause

`REGION_CAPACITY_MW["CPLW"] = 42` (sourced from EIA-860M Feb 2026, counts in-territory operating generators). CPLW (Duke Energy Progress West, NC mountains) serves ~449 MW by importing nearly all its power from neighbors. **449 / 42 = 10.71× = 1071%**. Math is correct, capacity figure is meaningless for stress ranking.

Same pattern likely affects:
- **HST** (Homestead): 36 MW capacity
- **GVL** (Gainesville): 600 MW capacity (less severe)
- **SPA** (federal hydro marketer): 2,559 MW capacity but distributes power across 5 states

## Stop-gap fix (this PR)

- **New `_STRESS_RELIABLE_CEILING = 2.0`** — anything above 200% is treated as *"capacity figure is wrong"* and excluded from stress rankings. Documented inline with the affected BAs.
- **Metrics bar** — `_build_us_grid_metrics_items` filters `stress_by_region` to the reliable subset before picking Top-Stress and Lowest Reserve. Caps displayed stress at 100% (matches the map's existing cap). Floors reserve at 0%.
- **Region card** — when stress > 200%, renders a qualitative `imports` chip (italic, neutral tone) with a tooltip explaining the data context, instead of the misleading multi-hundred-percent number.
- **CSS** — new `.gp-region-card__stress--imports` styling visually distinct from the low/mid/high traffic-light tones.

## Proper fix tracked separately (V3.η)

NEXT_UP.md gains a V3.η entry: *replace EIA-860M generator capacity with peak-demand × reserve-margin for affected BAs, or mark them `IS_IMPORT_DOMINATED` and hide stress entirely.* ~2hr work; out of scope here.

## Test plan

11 new tests cover:
- CPLW excluded from Top-Stress ranking → PJM (next-highest reliable) wins instead
- Lowest Reserve floors at 0%, never negative
- Displayed stress caps at 100% even within the reliable band
- All-unreliable scenario renders `"—"` placeholder
- Total Demand still **includes** import-dominated BAs (served demand is real, only the stress ratio isn't)
- Region card `imports` chip for unreliable; normal `%` for healthy
- Threshold edge cases at 199% (reliable) and 201% (unreliable)

`pytest tests/ -q` — **1632 pass**. Lint clean.

## Notes for reviewers

- The `patch.dict("components.callbacks.REGION_CAPACITY_MW", ...)` form is intentional — `callbacks.py` imports the dict by reference from `config`, and patching `"config.REGION_CAPACITY_MW"` failed silently in test ordering with other tests' module imports.
- The `_STRESS_RELIABLE_CEILING` value is documented inline; pin/move to `config.py` if/when V3.η lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)