### PR TITLE
fix(ui): models tab — real holdout MAPE + leaderboard/table parity

### DIFF
--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -1226,7 +1226,12 @@ def _models_tab_from_redis(region, selected_models: list[str] | None = None):
     uirev = f"{region}:{','.join(sorted(selected_models))}"
 
     log.info("diagnostics_redis_hit", region=region)
-    metrics = cached.get("metrics", {})
+    # Read metrics through the shared resolver so the table and the
+    # leaderboard stay locked together (real holdout MAPE per model
+    # from each pickle's meta.json; RMSE/MAE/R² from this Redis payload).
+    from models.model_service import get_model_metrics
+
+    metrics = get_model_metrics(region)
     timestamps = pd.to_datetime(cached.get("timestamps", []))
     ensemble = np.array(cached.get("ensemble", []))
     residuals = np.array(cached.get("residuals", []))
@@ -2620,10 +2625,15 @@ def register_callbacks(app):
         demand_df["timestamp"] = pd.to_datetime(demand_df["timestamp"])
         actual = demand_df["demand_mw"].values
 
-        from models.model_service import get_forecasts
+        from models.model_service import get_forecasts, get_model_metrics
 
         forecasts = get_forecasts(region, demand_df, selected_models)
-        metrics = forecasts.get("metrics", {})
+        # Read metrics from the same Redis-first source the leaderboard
+        # uses (``get_model_metrics``) so the table and the leaderboard
+        # always show consistent numbers — even if ``get_forecasts``
+        # fell back to fresh simulated forecasts whose computed metrics
+        # would otherwise diverge from the Redis payload's metrics.
+        metrics = get_model_metrics(region) or forecasts.get("metrics", {})
         model_order = ["prophet", "arima", "xgboost", "ensemble"]
         selected = [m for m in model_order if m in set(selected_models)]
 

--- a/models/model_service.py
+++ b/models/model_service.py
@@ -64,15 +64,82 @@ def get_model_metrics(region: str) -> dict[str, dict[str, float]]:
     """
     Get validation metrics for a region's trained models.
 
+    **MAPE is the authoritative metric** — pulled per-model from each
+    pickle's `.meta.json` in GCS, written by the daily training job
+    (V0.2 / V3.ε). Other fields (RMSE / MAE / R²) come from the
+    Redis diagnostics payload when present; that payload is computed
+    from actual demand vs scoring-job forecasts and is currently
+    simulation-derived in production (the scoring job's diagnostics
+    path uses `_simulate_forecasts` because it doesn't share GCS
+    pickles with the in-process model cache). Treat RMSE / MAE / R²
+    as approximations until that path is unified.
+
+    Resolution order:
+    1. Per-model holdout MAPE from ``models.persistence.get_model_metadata``
+       (real training-time values, prophet / arima / xgboost only —
+       ensemble has no own meta.json so its MAPE comes from Redis).
+    2. ``wattcast:diagnostics:{region}`` for RMSE / MAE / R² and the
+       ensemble's MAPE; supplements layer 1 without overwriting it.
+    3. In-process trained pickle (dev mode running with the local
+       precompute thread).
+    4. Simulated baseline (consistent defaults). Last-resort dev
+       fallback when none of the above produce data.
+
     Returns:
-        Dict of model_name → {mape, rmse, mae, r2}.
-        Returns simulated metrics if no trained models exist.
+        Dict of model_name → {mape?, rmse?, mae?, r2?}. Empty fields
+        omitted; the UI tolerates partial dicts.
     """
+    out: dict[str, dict[str, float]] = {}
+
+    # 1. Real holdout MAPE per model — written by jobs/training_job.py.
+    try:
+        from models.persistence import get_model_metadata
+
+        for model_name in ("prophet", "arima", "xgboost"):
+            try:
+                meta = get_model_metadata(region, model_name)
+            except Exception:
+                meta = None
+            if meta is None:
+                continue
+            mape = getattr(meta, "mape", None)
+            if mape is not None and np.isfinite(mape) and mape > 0:
+                out[model_name] = {"mape": float(mape)}
+    except Exception as e:  # pragma: no cover — defensive (GCS outage)
+        log.debug("get_model_metrics_meta_miss", region=region, error=str(e))
+
+    # 2. Supplement with Redis diagnostics (RMSE / MAE / R² + ensemble MAPE).
+    try:
+        from data.redis_client import redis_get
+
+        cached = redis_get(f"wattcast:diagnostics:{region}")
+        if cached and isinstance(cached.get("metrics"), dict):
+            for model_name, redis_m in cached["metrics"].items():
+                if not isinstance(redis_m, dict):
+                    continue
+                base = out.get(model_name, {})
+                # MAPE from Redis only when meta.json didn't provide one
+                # (currently true only for the ensemble row).
+                if "mape" not in base and "mape" in redis_m:
+                    base["mape"] = redis_m["mape"]
+                # RMSE / MAE / R² supplement layer 1.
+                for field in ("rmse", "mae", "r2"):
+                    if field in redis_m and field not in base:
+                        base[field] = redis_m[field]
+                if base:
+                    out[model_name] = base
+    except Exception as e:  # pragma: no cover — defensive
+        log.debug("get_model_metrics_redis_miss", region=region, error=str(e))
+
+    if out:
+        return out
+
+    # 3. Local pickle — dev mode.
     model_data = _load_cached_models(region)
     if model_data and "metrics" in model_data:
         return model_data["metrics"]
 
-    # Simulated metrics (consistent, reasonable values)
+    # 4. Simulated baseline — last resort.
     return {
         "prophet": {"mape": 2.8, "rmse": 450, "mae": 320, "r2": 0.967},
         "arima": {"mape": 3.5, "rmse": 580, "mae": 410, "r2": 0.945},

--- a/tests/unit/test_models_tab_consistency.py
+++ b/tests/unit/test_models_tab_consistency.py
@@ -1,0 +1,238 @@
+"""Regression tests: Models tab leaderboard + diagnostics table read
+the same metrics source.
+
+User-reported bugs 2026-05-02:
+
+1. **Leaderboard / table mismatch**: top row of MAPEs didn't match
+   the table below. Root cause: leaderboard called
+   ``get_model_metrics`` which fell through to a hardcoded simulated
+   dict; table read the diagnostics Redis payload (different
+   simulated path). Both ended up "fake" but via different chains.
+
+2. **Both surfaces showed simulated MAPE values, not real**: even
+   after the Cloud Run training job writes real holdout MAPE per
+   model to GCS at ``cache/models/{region}/{model}/{version}.meta.json``
+   (V0.2 / V3.ε), neither surface read those values.
+
+Fix: ``get_model_metrics`` is now meta.json-first. It reads the real
+holdout MAPE from each model's pickle metadata, supplements
+RMSE/MAE/R² (and the ensemble MAPE) from the Redis diagnostics
+payload, and falls back to local pickles + simulated only when
+nothing else is available. ``_models_tab_from_redis`` and the v1
+fallback both call ``get_model_metrics`` so leaderboard + table can't
+diverge.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _meta(model_name, mape, region="PJM"):
+    """Build a minimal ``ModelMetadata`` for the patch."""
+    from models.persistence import ModelMetadata
+
+    return ModelMetadata(
+        region=region,
+        model_name=model_name,
+        version="v-test",
+        data_hash="h",
+        trained_at="2026-05-01T04:00:00+00:00",
+        train_rows=8000,
+        mape=mape,
+        lib_versions={},
+        extra={},
+    )
+
+
+def _meta_lookup(mape_by_model):
+    """Returns a stub ``get_model_metadata(region, model_name)``
+    function backed by ``{model_name: mape}``."""
+
+    def _stub(region, model_name):
+        if model_name in mape_by_model:
+            return _meta(model_name, mape_by_model[model_name], region)
+        return None
+
+    return _stub
+
+
+_REDIS_PAYLOAD_FAKE_METRICS = {
+    "metrics": {
+        # Same shape, different values — what `_simulate_forecasts`
+        # would yield for some particular seed
+        "prophet": {"mape": 4.20, "rmse": 555, "mae": 410, "r2": 0.91},
+        "arima": {"mape": 5.55, "rmse": 700, "mae": 525, "r2": 0.88},
+        "xgboost": {"mape": 3.30, "rmse": 480, "mae": 360, "r2": 0.94},
+        "ensemble": {"mape": 2.94, "rmse": 460, "mae": 340, "r2": 0.95},
+    },
+    "timestamps": ["2026-05-02T00:00:00"],
+    "ensemble": [50000.0],
+    "residuals": [100.0],
+    "hourly_error": {h: 1.0 for h in range(24)},
+    "feature_importance": {"temperature_2m": 0.5},
+}
+
+
+class TestRealMapeSource:
+    """The user's question: 'shoot those MAPE values are fake?' —
+    after this PR they're not. Real holdout MAPE per model comes from
+    each pickle's GCS meta.json (V0.2 / V3.ε wrote them)."""
+
+    def test_real_mape_overrides_simulated(self):
+        """Real holdout MAPE in meta.json wins over Redis simulated values."""
+        from models.model_service import get_model_metrics
+
+        real_mapes = {"prophet": 11.04, "arima": 5.19, "xgboost": 1.10}
+        with (
+            patch(
+                "models.persistence.get_model_metadata",
+                side_effect=_meta_lookup(real_mapes),
+            ),
+            patch("data.redis_client.redis_get", return_value=_REDIS_PAYLOAD_FAKE_METRICS),
+        ):
+            got = get_model_metrics("PJM")
+
+        assert got["prophet"]["mape"] == 11.04  # real, not 4.20 simulated
+        assert got["arima"]["mape"] == 5.19  # real, not 5.55 simulated
+        assert got["xgboost"]["mape"] == 1.10  # real, not 3.30 simulated
+
+    def test_redis_supplies_rmse_mae_r2_when_meta_lacks_them(self):
+        """Meta.json has only MAPE; RMSE/MAE/R² come from Redis."""
+        from models.model_service import get_model_metrics
+
+        real_mapes = {"prophet": 11.04, "arima": 5.19, "xgboost": 1.10}
+        with (
+            patch(
+                "models.persistence.get_model_metadata",
+                side_effect=_meta_lookup(real_mapes),
+            ),
+            patch("data.redis_client.redis_get", return_value=_REDIS_PAYLOAD_FAKE_METRICS),
+        ):
+            got = get_model_metrics("PJM")
+
+        assert got["xgboost"]["rmse"] == 480  # from Redis
+        assert got["xgboost"]["mae"] == 360
+        assert got["xgboost"]["r2"] == 0.94
+
+    def test_ensemble_mape_from_redis(self):
+        """Ensemble has no per-model meta.json — its MAPE must come
+        from the Redis diagnostics payload."""
+        from models.model_service import get_model_metrics
+
+        real_mapes = {"prophet": 11.04, "arima": 5.19, "xgboost": 1.10}
+        with (
+            patch(
+                "models.persistence.get_model_metadata",
+                side_effect=_meta_lookup(real_mapes),
+            ),
+            patch("data.redis_client.redis_get", return_value=_REDIS_PAYLOAD_FAKE_METRICS),
+        ):
+            got = get_model_metrics("PJM")
+
+        assert got["ensemble"]["mape"] == 2.94  # Redis ensemble MAPE
+        assert got["ensemble"]["rmse"] == 460
+
+
+class TestResolutionOrderFallthrough:
+    def test_redis_only_when_meta_missing(self):
+        from models.model_service import get_model_metrics
+
+        with (
+            patch("models.persistence.get_model_metadata", return_value=None),
+            patch("data.redis_client.redis_get", return_value=_REDIS_PAYLOAD_FAKE_METRICS),
+        ):
+            got = get_model_metrics("PJM")
+
+        # No meta → Redis values for everything
+        assert got["xgboost"]["mape"] == 3.30  # Redis
+        assert got["ensemble"]["mape"] == 2.94
+
+    def test_simulated_when_everything_missing(self):
+        from models.model_service import get_model_metrics
+
+        with (
+            patch("models.persistence.get_model_metadata", return_value=None),
+            patch("data.redis_client.redis_get", return_value=None),
+            patch("models.model_service._load_cached_models", return_value=None),
+        ):
+            got = get_model_metrics("PJM")
+
+        # Hardcoded last-resort defaults
+        assert got["xgboost"]["mape"] == 2.1
+        assert got["ensemble"]["mape"] == 1.9
+
+    def test_meta_with_null_mape_falls_through(self):
+        """A model whose meta.json has ``mape=None`` (training failed
+        to record) shouldn't show up in the output unless Redis or
+        simulated layer fills it in."""
+        from models.model_service import get_model_metrics
+
+        # Only xgboost has real MAPE; prophet/arima have null in meta
+        def _stub(region, model_name):
+            return (
+                _meta(model_name, mape=None)
+                if model_name != "xgboost"
+                else _meta(model_name, mape=1.10)
+            )
+
+        with (
+            patch("models.persistence.get_model_metadata", side_effect=_stub),
+            patch("data.redis_client.redis_get", return_value=_REDIS_PAYLOAD_FAKE_METRICS),
+        ):
+            got = get_model_metrics("PJM")
+
+        assert got["xgboost"]["mape"] == 1.10  # real
+        # prophet / arima fall through to Redis
+        assert got["prophet"]["mape"] == 4.20
+        assert got["arima"]["mape"] == 5.55
+
+    def test_meta_with_inf_mape_falls_through(self):
+        """``inf`` MAPE means the holdout failed; treat as missing."""
+        from models.model_service import get_model_metrics
+
+        with (
+            patch(
+                "models.persistence.get_model_metadata",
+                side_effect=_meta_lookup({"xgboost": float("inf")}),
+            ),
+            patch("data.redis_client.redis_get", return_value=_REDIS_PAYLOAD_FAKE_METRICS),
+        ):
+            got = get_model_metrics("PJM")
+
+        # inf → ignore; fall through to Redis
+        assert got["xgboost"]["mape"] == 3.30
+
+
+class TestLeaderboardTableConsistency:
+    """The user-reported divergence — leaderboard and table can't show
+    different MAPEs anymore because they both call ``get_model_metrics``."""
+
+    def test_leaderboard_calls_get_model_metrics(self):
+        from components import callbacks as cb
+
+        spy = MagicMock(return_value={"xgboost": {"mape": 1.10}})
+        with patch("models.model_service.get_model_metrics", spy):
+            cb._build_models_leaderboard("PJM")
+        spy.assert_called_once_with("PJM")
+
+    def test_redis_path_table_uses_shared_metrics(self):
+        """``_models_tab_from_redis`` reads metrics through
+        ``get_model_metrics`` so it can't diverge from the leaderboard."""
+        import inspect
+
+        from components import callbacks as cb
+
+        src = inspect.getsource(cb._models_tab_from_redis)
+        assert "get_model_metrics(region)" in src
+
+    def test_v1_fallback_uses_shared_metrics(self):
+        """The v1 compute fallback in ``update_models_tab`` also reads
+        through ``get_model_metrics`` so cold-Redis dev mode stays
+        consistent with the (also-fallback) leaderboard."""
+        import inspect
+
+        from components import callbacks as cb
+
+        src = inspect.getsource(cb.register_callbacks)
+        assert "get_model_metrics(region) or forecasts.get" in src


### PR DESCRIPTION
## Summary

User reported the Models tab leaderboard MAPEs didn't match the diagnostics table below. Investigation surfaced a deeper issue: **both surfaces were showing simulated values**, even though the daily training job writes real holdout MAPE per model to GCS at `cache/models/{region}/{model}/{version}.meta.json` (V0.2 / V3.ε).

- **Real MAPE source**: `get_model_metrics` is now meta.json-first. Pulls real holdout MAPE per model from `models.persistence.get_model_metadata`, supplements RMSE/MAE/R² (and ensemble MAPE) from Redis diagnostics, and falls back to local pickles + simulated baseline only when nothing else is available.
- **Leaderboard ↔ table parity**: Both Models-tab surfaces (`_models_tab_from_redis` and the v1 compute fallback in `update_models_tab`) now route through `get_model_metrics` so they can't diverge. Previously the leaderboard called `get_model_metrics` while the table read `cached.get('metrics')` directly — same shape, different paths into "fake."
- **Resolution order** (documented in the docstring):
  1. `meta.json` per model (real holdout MAPE — written by training job)
  2. Redis diagnostics (RMSE/MAE/R² + ensemble MAPE)
  3. Local pickle (dev mode)
  4. Simulated baseline (last resort)

## What this means in production

After this lands, the FPL leaderboard will show the actual training MAPEs we logged in V0.2 (e.g. prophet ≈ 7.88, arima ≈ 5.19, xgboost ≈ 1.10), not the `_simulate_forecasts` seeds. Ensemble MAPE still comes from Redis (no own meta.json), as do all RMSE/MAE/R² values until the scoring-job diagnostics path is unified with GCS pickles.

## Test plan

- [x] `pytest tests/unit/test_models_tab_consistency.py` — 10 new tests pass
  - Real MAPE wins over Redis simulated values
  - Redis supplies RMSE/MAE/R² when meta has only MAPE
  - Ensemble MAPE comes from Redis (no own meta.json)
  - Resolution-order fallthrough (Redis-only, simulated-only, null/inf MAPE)
  - Source-assert that leaderboard, `_models_tab_from_redis`, and v1 fallback all call `get_model_metrics`
- [x] Full unit + integration suite green (1642 tests)
- [x] `ruff check` + `ruff format --check` clean
- [ ] Smoke test the deployed Models tab — leaderboard top row matches table below for FPL/PJM/CISO

🤖 Generated with [Claude Code](https://claude.com/claude-code)