### PR TITLE
docs(ops): record training-job timeout bump 2h → 5h after V3.ζ

### DIFF
--- a/docs/NEXT_UP.md
+++ b/docs/NEXT_UP.md
@@ -250,6 +250,8 @@ _Scoped 2026-05-01. Each item now has explicit acceptance criteria, files, and e
 - Scoring time: ~90 sec for 16 BAs → estimate ~5 min for 51. Comfortable on the hourly cron.
 - Cloud Run training memory may need a bump from 8 → 16 GB if peak RSS spikes; monitor first run.
 
+**Empirical correction (2026-05-03)**: the ~95 min estimate above was optimistic. The 2026-05-01 manual run took **2h48m** for the first full 51-BA training, and three subsequent scheduled runs hit the 7,200s (2h) `--task-timeout` cap. Job timeout bumped to **5h** (`gcloud run jobs update gridpulse-training-job --region us-east1 --task-timeout=5h` → `timeoutSeconds: 18000`). Memory and CPU unchanged (8 Gi / 4 CPU were never the bottleneck — training is sequential per BA). Until the next 04:00 UTC scheduled run, the 35 V3.ζ-added BAs have no trained models in GCS, so their Models-tab metrics fall back to the simulated baseline and their Forecast tab shows the warming state.
+
 **Follow-ups** (not in V3.ζ scope):
 - Forecast-quality gate that hides BAs whose backtest MAPE exceeds a threshold from the dropdown. Today they appear but render whatever the model produces.
 - Re-source the V1.α 8 BAs against EIA-860M so capacity methodology is uniform across all 51.


### PR DESCRIPTION
## Summary

V3.ζ tripled the BA count (16 → 51). The training-job's 2h timeout was based on a ~95-min estimate that turned out to be wrong:

| Run | Date | Outcome |
|---|---|---|
| Manual full run | 2026-05-01 12:28 | ✓ 2h48m (51 BAs) |
| Scheduled | 2026-05-01 08:00 | ✗ timeout at 2h |
| Scheduled | 2026-05-02 08:00 | ✗ timeout at 2h |
| Scheduled | 2026-05-02 08:01 | ✗ timeout at 2h |

Net effect: only the 16 pre-V3.ζ BAs have trained pickles in GCS. The other 35 fall back to the simulated baseline on the Models tab and to the warming state on the Forecast tab.

## What changed

```bash
gcloud run jobs update gridpulse-training-job --region us-east1 --task-timeout=5h
# → timeoutSeconds: 18000
```

5h gives 30-min headroom over the empirical 2h48m baseline plus room for adversarial slow runs (cold cache, weather-API throttling, etc.).

Memory (8 Gi) and CPU (4) **unchanged** — training is sequential per BA, so per-step footprint is constant regardless of the BA count.

## Test plan

- [ ] Next scheduled training run (04:00 UTC) completes without timeout
- [ ] First scoring run after that (05:00 UTC) emits `ensemble_weights_computed` for all 51 BAs (currently 16 of 51)
- [ ] Models tab leaderboard shows real holdout MAPEs for all 51 BAs (currently 16 of 51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)