### PR TITLE
fix(ui): polygon view — visible borders + spread colorscale

### DIFF
--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -6832,11 +6832,22 @@ _MAP_LAND_COLOR = "#111113"  # --bg-raised
 _MAP_COASTLINE_COLOR = "#27272a"
 _MAP_SUBUNIT_COLOR = "#1f1f23"
 _MAP_AXIS_FONT_COLOR = "#71717a"  # --text-tertiary
-_MAP_BORDER_COLOR = "#1f1f23"
+# Polygon borders need to read against ANY colorscale fill — green, yellow,
+# or red. A near-black border (#1f1f23) was nearly identical to the
+# darkest polygon fill, so adjacent BAs visually fused into one blob on
+# the Polygons view. A translucent zinc reads against everything.
+_MAP_BORDER_COLOR = "rgba(228, 228, 231, 0.5)"
+# Five-stop colorscale: the previous three-stop scale (0.0 → 0.7 → 1.0,
+# green → yellow → red) put 30% and 60% utilization at nearly identical
+# greens because both fall on the long [0.0, 0.7] interpolation segment.
+# Most BAs operate in the 30–70% band, so spreading colors there is what
+# the eye actually needs.
 _MAP_COLORSCALE = [
-    [0.0, "#34d399"],  # --success — comfortable margin
-    [0.7, "#fbbf24"],  # --warning — getting tight
-    [1.0, "#f87171"],  # --danger — peak utilization
+    [0.00, "#10b981"],  # emerald-500 — idle / comfortable headroom
+    [0.40, "#84cc16"],  # lime-500 — running easy
+    [0.60, "#eab308"],  # yellow-500 — getting tight
+    [0.80, "#f97316"],  # orange-500 — warning
+    [1.00, "#dc2626"],  # red-600 — peak / stressed
 ]
 
 
@@ -7039,7 +7050,7 @@ def _build_us_grid_choropleth(region_data: dict) -> html.Div:
             colorscale=_MAP_COLORSCALE,
             zmin=0,
             zmax=100,
-            marker={"line": {"color": _MAP_BORDER_COLOR, "width": 0.6}},
+            marker={"line": {"color": _MAP_BORDER_COLOR, "width": 1.0}},
             colorbar={
                 "title": {
                     "text": "Utilization %",

--- a/tests/unit/test_us_grid_choropleth.py
+++ b/tests/unit/test_us_grid_choropleth.py
@@ -193,6 +193,60 @@ class TestChoroplethRender:
         assert graph.figure.data[0].type == "scattergeo"
 
 
+class TestPolygonVisibility:
+    """Regression tests for the user-reported "all green - no real lines"
+    bug. Previously ``_MAP_BORDER_COLOR = "#1f1f23"`` was indistinguishable
+    from ``_MAP_LAND_COLOR = "#111113"``, so adjacent BAs visually fused
+    into one green blob and the user could only see Florida (where the
+    BAs differ enough in stress to show distinct fills)."""
+
+    def test_border_color_distinct_from_land_color(self):
+        """Border must be perceptually different from the basemap fill —
+        otherwise polygons have no visible edges against the unfilled
+        background, and adjacent same-stress BAs merge visually."""
+        from components.callbacks import _MAP_BORDER_COLOR, _MAP_LAND_COLOR
+
+        # Same string would mean the bug is back.
+        assert _MAP_BORDER_COLOR != _MAP_LAND_COLOR
+        # _MAP_LAND_COLOR is a hex; _MAP_BORDER_COLOR is now an rgba()
+        # with non-zero alpha. The simple string-inequality check above
+        # catches the regression that motivated this test (both being
+        # near-black hex). The alpha check below catches a different
+        # regression (border accidentally set fully transparent).
+        if _MAP_BORDER_COLOR.startswith("rgba"):
+            # rgba(r, g, b, a) — alpha must be > 0
+            alpha_str = _MAP_BORDER_COLOR.rsplit(",", 1)[1].rstrip(") ")
+            assert float(alpha_str) > 0.0
+
+    def test_colorscale_has_distinct_midrange_stops(self):
+        """Most BAs operate at 30–70% utilization. With only [0.0, 0.7, 1.0]
+        stops, 30% and 60% mapped to nearly identical greens. Need at
+        least 4 stops so mid-range values are visually distinct."""
+        from components.callbacks import _MAP_COLORSCALE
+
+        assert len(_MAP_COLORSCALE) >= 4, (
+            f"colorscale only has {len(_MAP_COLORSCALE)} stops — "
+            "mid-range utilization values won't be visually distinct"
+        )
+        # Stops must be sorted, span [0.0, 1.0], and have unique colors.
+        positions = [stop[0] for stop in _MAP_COLORSCALE]
+        assert positions == sorted(positions)
+        assert positions[0] == 0.0
+        assert positions[-1] == 1.0
+        colors = [stop[1] for stop in _MAP_COLORSCALE]
+        assert len(set(colors)) == len(colors), "duplicate colors in colorscale"
+
+    def test_choropleth_border_width_is_visible(self):
+        """0.6 px renders as a hairline that disappears against same-shade
+        neighbors. Bump to ≥ 0.8 px so polygon edges always read."""
+        from components.callbacks import _build_us_grid_choropleth
+
+        body = _build_us_grid_choropleth({"PJM": {"current_mw": 70_000.0}})
+        graph = _find_graph(body)
+        width = graph.figure.data[0].marker.line.width
+        assert width >= 0.8, f"border width {width} too thin to read"
+
+
 class TestDrilldownTolerance:
     """The drilldown callback should accept both customdata shapes:
     1-D string (scatter) and list/tuple (choropleth)."""


### PR DESCRIPTION
## Summary

User report: Polygons view rendered as one giant green field — only Florida + a few small shapes visible, the rest of CONUS indistinguishable.

Root cause was purely Plotly trace styling. Geojson coverage (51/51), capacity coverage (51/51), and region data are all correct. Three layered fixes:

1. **Border color** `#1f1f23` → `rgba(228, 228, 231, 0.5)`. The old border was near-identical to the `#111113` basemap fill; against any green polygon it became invisible, fusing adjacent BAs.
2. **Border width** 0.6 → 1.0 px. A hairline 0.6 disappears against same-shade neighbors.
3. **Colorscale** 3 stops → 5 stops. Old `[0.0, 0.7, 1.0]` put 30% utilization at color position 0.43 and 60% at 0.86 — both on the same green→yellow segment, so they looked identical. New stops at `0.0 / 0.4 / 0.6 / 0.8 / 1.0` (emerald → lime → yellow → orange → red) give real visual separation in the 30–70% band where most BAs operate.

## Visual delta

Before:
- Adjacent BAs at similar utilization → one green blob
- 30% vs 60% utilization → indistinguishable
- Hairline borders → invisible

After:
- Every BA polygon has a visible edge against any fill
- Each ~10% utilization step has a noticeable color shift
- Same constants drive the centroid scatter (Map view) — gets the upgrade too

The two empty rectangles below the visible polygons are Plotly's `albers usa` Alaska + Hawaii insets (we have no AK/HI BA polygons). Out of scope for this fix.

## Test plan

- [x] `TestPolygonVisibility` (3 new regressions): border ≠ land, ≥4 colorscale stops, width ≥ 0.8
- [x] Existing 20 choropleth tests still pass (no behavioral changes — only styling)
- [x] `ruff check` + `ruff format --check` clean
- [ ] Smoke-test deployed Polygons view: BA outlines visible, mid-stress regions distinguishable from low-stress

🤖 Generated with [Claude Code](https://claude.com/claude-code)