### PR TITLE
feat(regions): V3.η — import-dominated BA tagging + capacity correction

### DIFF
--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -39,6 +39,7 @@ from components.cards import (
 from config import (
     CACHE_TTL_SECONDS,
     EIA_API_KEY,
+    IS_IMPORT_DOMINATED,
     REGION_CAPACITY_MW,
     REGION_COORDINATES,
     REGION_NAMES,
@@ -6602,15 +6603,19 @@ def _build_us_grid_metrics_items(region_data: dict[str, dict]) -> list[dict]:
         region: d["current_mw"] / cap
         for region, d in populated.items()
         if (cap := REGION_CAPACITY_MW.get(region, 0)) > 0
+        # V3.η: structurally import-dominated BAs (CPLW, HST, SPA) are
+        # never valid candidates for "highest stress" — their capacity
+        # is a peak × 1.15 estimate, not a measured plate, so the stress
+        # ratio against it is too noisy to rank against truly-stressed
+        # vertically integrated BAs. Filter at source rather than at
+        # the reliability ceiling.
+        and region not in IS_IMPORT_DOMINATED
     }
-    # Drop import-dominated BAs whose ``REGION_CAPACITY_MW`` (sourced
-    # from EIA-860M, counts only in-territory operating generators) is
-    # smaller than the BA's served demand. Observed in V3.ζ: CPLW had
-    # 449 MW served vs 42 MW of in-territory generation, producing a
-    # nonsensical "Highest-Stress: CPLW · 1071%". Anything above the
-    # ``_STRESS_RELIABLE_CEILING`` is structural (the BA imports most
-    # of its power), not real stress — exclude from the ranking. The
-    # underlying-data fix lives in the V3.η follow-up.
+    # Belt-and-braces fallback: anything above the reliability ceiling
+    # is structural (sustained > 100% means the BA imports most of its
+    # power), not real stress. Today this cap should never trip after
+    # the V3.η filter above, but keeps the KPI honest if a future BA
+    # gets misclassified or if EIA-860M data drifts.
     reliable_stress = {r: s for r, s in stress_by_region.items() if s <= _STRESS_RELIABLE_CEILING}
     if reliable_stress:
         top_region = max(reliable_stress, key=reliable_stress.get)
@@ -6762,18 +6767,25 @@ def _build_us_grid_region_card(region: str, data: dict) -> html.Div:
     stress_chip = None
     if capacity_mw > 0:
         stress_ratio = current_mw / capacity_mw
-        if stress_ratio > _STRESS_RELIABLE_CEILING:
-            # Import-dominated BA — capacity figure is wrong for this
-            # purpose (counts only in-territory generators). Show a
-            # qualitative "imports" chip instead of a misleading
-            # "1071%" number. See ``_STRESS_RELIABLE_CEILING`` comment.
+        # V3.η: structurally import-dominated BAs (CPLW, HST, SPA) get
+        # the qualitative "imports" chip whether or not their stress
+        # ratio happens to land above the ceiling on a given hour. The
+        # capacity figure for these BAs is a peak × 1.15 estimate, not
+        # measured plate, so the percentage isn't meaningful even when
+        # it's mathematically below 100%.
+        is_import_dominated = (
+            region in IS_IMPORT_DOMINATED or stress_ratio > _STRESS_RELIABLE_CEILING
+        )
+        if is_import_dominated:
             stress_chip = html.Span(
                 "imports",
                 className="gp-region-card__stress gp-region-card__stress--imports",
                 title=(
-                    f"Demand ({current_mw:,.0f} MW) far exceeds in-territory "
-                    f"generators ({capacity_mw:,.0f} MW). This BA imports nearly "
-                    f"all its power; stress ratio is not meaningful here."
+                    f"{name} is an import-dominated balancing authority — "
+                    f"its served demand routinely exceeds in-territory generation "
+                    f"and is supplied via inter-BA transfers. The utilization % "
+                    f"is calculated against an estimated capacity pool, not a "
+                    f"measured plate."
                 ),
             )
         else:
@@ -6891,9 +6903,14 @@ def _build_us_grid_map(region_data: dict) -> html.Div:
     max_demand = max(demand_gw)
     sizes = [10 + (d / max_demand) * 30 for d in demand_gw]
 
+    # V3.η: append " · imports" suffix to the BA name for structurally
+    # import-dominated BAs (CPLW, HST, SPA) so users understand what
+    # the utilization % is measured against (a peak × 1.15 estimate,
+    # not a measured plate capacity).
     hover_text = [
-        f"<b>{name}</b><br>Demand: {d:.1f} GW<br>Utilization: {s:.0f}%"
-        for name, d, s in zip(names, demand_gw, stress_pct, strict=False)
+        f"<b>{name}{' · imports' if r in IS_IMPORT_DOMINATED else ''}</b>"
+        f"<br>Demand: {d:.1f} GW<br>Utilization: {s:.0f}%"
+        for r, name, d, s in zip(regions, names, demand_gw, stress_pct, strict=False)
     ]
 
     fig = go.Figure(
@@ -7039,7 +7056,11 @@ def _build_us_grid_choropleth(region_data: dict) -> html.Div:
 
     names = [REGION_NAMES.get(r, r) for r in regions]
     demand_gw = [populated[r]["current_mw"] / 1000 for r in regions]
-    customdata = list(zip(regions, names, demand_gw, strict=False))
+    # V3.η: customdata[3] = " · imports" suffix for import-dominated
+    # BAs, empty string for everyone else. Plotly hovertemplate renders
+    # the empty string invisibly so we don't need separate templates.
+    import_tag = [" · imports" if r in IS_IMPORT_DOMINATED else "" for r in regions]
+    customdata = list(zip(regions, names, demand_gw, import_tag, strict=False))
 
     fig = go.Figure(
         go.Choropleth(
@@ -7069,7 +7090,7 @@ def _build_us_grid_choropleth(region_data: dict) -> html.Div:
             # callback handles it without changes.
             customdata=customdata,
             hovertemplate=(
-                "<b>%{customdata[1]}</b><br>"
+                "<b>%{customdata[1]}</b>%{customdata[3]}<br>"
                 "Demand: %{customdata[2]:.1f} GW<br>"
                 "Utilization: %{z:.0f}%<extra></extra>"
             ),

--- a/config.py
+++ b/config.py
@@ -361,15 +361,20 @@ REGION_CAPACITY_MW: dict[str, int] = {
     "FPL": 35_963,
     "SPP": 102_376,
     "ISONE": 30_000,
-    # V1.α — 8 new BAs.
-    "SOCO": 46_000,
+    # V1.α — 8 new BAs. V3.η (2026-05-02) corrected SOCO / DUK / CPLE /
+    # PSCO from EIA-860M generator capacity to peak-demand × 1.15
+    # reserve margin because in-territory generation is below served
+    # demand for these net-importer utility BAs (capacity / peak ratios
+    # were 0.93–0.96, indicating regular imports). Peak source: EIA-930
+    # 12-month max demand per ``data/eia_client.fetch_demand``.
+    "SOCO": 54_980,  # was 46,000 (EIA-860M); peak 47,809 × 1.15
     "TVA": 35_000,
-    "DUK": 20_800,
-    "CPLE": 13_700,
+    "DUK": 25_513,  # was 20,800 (EIA-860M); peak 22,186 × 1.15
+    "CPLE": 16_478,  # was 13,700 (EIA-860M); peak 14,329 × 1.15
     "BPAT": 17_462,
     "AZPS": 9_400,
     "NEVP": 15_445,
-    "PSCO": 9_080,
+    "PSCO": 12_238,  # was 9,080 (EIA-860M); peak 10,642 × 1.15
     # V3.ζ — 35 remaining EIA-930 BAs in the contiguous US. Capacities
     # all sourced from EIA-860M Feb 2026 (one batch query, methodology
     # mirrors V3.ε for NEVP — sum nameplate-capacity-mw rows filtered
@@ -380,15 +385,22 @@ REGION_CAPACITY_MW: dict[str, int] = {
     # Southeast (11):
     "FPC": 16_535,
     "TEC": 8_747,
-    "FMPP": 3_908,
+    "FMPP": 4_574,  # V3.η: was 3,908 (EIA-860M); peak 3,978 × 1.15
     "JEA": 3_214,
     "TAL": 1_024,
     "GVL": 600,
     "SEC": 2_826,
-    "HST": 36,
+    # V3.η: Homestead is import-dominated (peak 147 MW vs 36 MW
+    # in-territory generation = 4.08×). Corrected to peak × 1.15 and
+    # tagged in IS_IMPORT_DOMINATED so the UI hides its stress chip.
+    "HST": 169,  # was 36; peak 147 × 1.15
     "SC": 5_968,
     "SCEG": 8_122,
-    "CPLW": 42,
+    # V3.η: DEP-West (CPLW, NC mountains) is severely import-dominated
+    # (peak 1,261 MW vs 42 MW in-territory generators = 30×). User-
+    # reported 2026-05-02 as "Highest-Stress: CPLW · 1071%". Corrected
+    # to peak × 1.15 and tagged in IS_IMPORT_DOMINATED.
+    "CPLW": 1_450,  # was 42; peak 1,261 × 1.15
     # Central (4):
     "LGEE": 9_074,
     "AECI": 6_650,
@@ -416,6 +428,41 @@ REGION_CAPACITY_MW: dict[str, int] = {
     "PNM": 7_544,
     "WALC": 7_096,
 }
+
+# ---------------------------------------------------------------------------
+# Import-dominated BAs
+# ---------------------------------------------------------------------------
+# Some EIA-930 balancing authorities serve far more demand than their
+# in-territory generators can produce — they're structurally dependent on
+# imports from neighbours. Showing these BAs' "stress" against their
+# nameplate capacity is misleading: a 30× import multiplier (CPLW) makes
+# every reading look critical, and even after the V3.η peak × 1.15
+# capacity correction, the underlying number is still an *estimate* of
+# the resource pool the BA can draw on, not a measured plate capacity.
+#
+# The UI uses this set to:
+#   1. Suppress the BA from the "highest-stress" KPI candidate pool so
+#      a 30× multiplier doesn't always win (PR #76 capped the display
+#      at 100% but didn't fix candidacy).
+#   2. Annotate the polygon hover + drilldown with an "import-dominated
+#      · capacity is estimated" footnote so users understand what the
+#      utilization % is actually measured against.
+#
+# Inclusion criterion: in-territory generation < ~50% of 12-month peak
+# demand (i.e. multiplier ≥ 2×). Sourced from EIA-860M generator rows
+# vs EIA-930 demand peaks. Re-evaluate annually as new generators
+# come online.
+IS_IMPORT_DOMINATED: frozenset[str] = frozenset(
+    {
+        "CPLW",  # DEP-West, NC mountains. Peak 1,261 MW vs 42 MW gen = 30×.
+        "HST",  # Homestead, FL. Peak 147 MW vs 36 MW gen = 4.08×.
+        "SPA",  # Southwestern Power Admin — federal hydro *marketer*,
+        #        not a vertically integrated utility. Its 2,559 MW
+        #        nameplate is the federal dam fleet; the served load
+        #        is far larger via long-term power contracts.
+    }
+)
+
 
 # ---------------------------------------------------------------------------
 # NOAA State → Balancing Authority Mapping

--- a/tests/unit/test_import_dominated_bas.py
+++ b/tests/unit/test_import_dominated_bas.py
@@ -1,0 +1,233 @@
+"""V3.η — import-dominated BA tagging + capacity correction.
+
+Background. EIA-860M reports nameplate capacity for *in-territory*
+generators. For most BAs that's a fine proxy for the resource pool the
+operator can draw on, but a handful of EIA-930 BAs serve far more
+demand than they generate locally — they're effectively pure
+distribution / wires utilities buying wholesale from neighbours.
+
+CPLW (DEP-West, NC mountains) was the smoking gun: 42 MW of in-territory
+generation vs ~1,261 MW peak demand (a 30× multiplier). On the dashboard
+this surfaced as "Highest-Stress Region: CPLW · 1071%". PR #76 capped
+the *display*; this V3.η work fixes the *underlying classification*:
+
+1. Re-source capacity for the import-dominated BAs as `peak × 1.15`
+   (12-month peak demand × standard reserve margin) — a realistic
+   proxy for the resource pool, not a lower-bound count of in-territory
+   generators.
+2. Tag the structurally import-dominated BAs in
+   ``IS_IMPORT_DOMINATED`` so the UI:
+     - Excludes them from "highest stress" candidate ranking
+     - Annotates their hover with a " · imports" suffix
+     - Renders the "imports" qualitative chip on their region card
+       even when their (corrected) ratio happens to be below the
+       reliability ceiling on a given hour.
+"""
+
+from __future__ import annotations
+
+
+class TestImportDominatedSet:
+    """The set itself: who's in it, what shape, and why."""
+
+    def test_set_is_a_frozenset(self):
+        from config import IS_IMPORT_DOMINATED
+
+        assert isinstance(IS_IMPORT_DOMINATED, frozenset)
+
+    def test_known_import_dominated_bas_are_tagged(self):
+        """The three BAs identified as structurally import-dependent
+        (multiplier ≥ 2× in-territory generation vs 12-month peak)."""
+        from config import IS_IMPORT_DOMINATED
+
+        # CPLW: 30× multiplier (42 MW gen vs 1,261 MW peak)
+        # HST: 4.08× multiplier (36 MW gen vs 147 MW peak)
+        # SPA: federal hydro marketer — has no local generation in the
+        #      vertically-integrated-utility sense; it's pure wires.
+        assert "CPLW" in IS_IMPORT_DOMINATED
+        assert "HST" in IS_IMPORT_DOMINATED
+        assert "SPA" in IS_IMPORT_DOMINATED
+
+    def test_normal_bas_not_tagged(self):
+        """Sanity check — vertically integrated BAs with their own
+        generation fleets must NOT be tagged. Tagging them would hide
+        them from the highest-stress KPI (and they'd never contend for
+        it again, hiding real grid stress events)."""
+        from config import IS_IMPORT_DOMINATED
+
+        for ba in ("PJM", "ERCOT", "CAISO", "MISO", "SPP", "SOCO", "DUK", "PSCO"):
+            assert ba not in IS_IMPORT_DOMINATED, (
+                f"{ba} is a generation-rich BA — must not be marked import-dominated"
+            )
+
+    def test_all_tagged_bas_exist_in_capacity_dict(self):
+        """A tagged BA that isn't in REGION_CAPACITY_MW would silently
+        render as a zero-capacity card. Belt-and-braces."""
+        from config import IS_IMPORT_DOMINATED, REGION_CAPACITY_MW
+
+        for ba in IS_IMPORT_DOMINATED:
+            assert ba in REGION_CAPACITY_MW, (
+                f"{ba} tagged as import-dominated but missing from REGION_CAPACITY_MW"
+            )
+
+
+class TestV3EtaCapacityCorrections:
+    """The seven capacity bumps — peak × 1.15 for BAs whose previous
+    EIA-860M figure was below the served peak."""
+
+    def test_cplw_capacity_corrected(self):
+        """CPLW was 42 MW (in-territory generators only) — produced the
+        1,071% stress reading. Now: peak 1,261 × 1.15 ≈ 1,450 MW."""
+        from config import REGION_CAPACITY_MW
+
+        assert REGION_CAPACITY_MW["CPLW"] >= 1_400, (
+            f"CPLW capacity {REGION_CAPACITY_MW['CPLW']} too low — "
+            "the peak × 1.15 correction lifts it to ~1,450 MW"
+        )
+
+    def test_hst_capacity_corrected(self):
+        """HST (Homestead, FL) was 36 MW. Peak 147 × 1.15 ≈ 169 MW."""
+        from config import REGION_CAPACITY_MW
+
+        assert REGION_CAPACITY_MW["HST"] >= 150
+
+    def test_soco_capacity_corrected(self):
+        """SOCO peak 47,809 × 1.15 ≈ 54,980 MW (was 46,000 MW)."""
+        from config import REGION_CAPACITY_MW
+
+        assert REGION_CAPACITY_MW["SOCO"] >= 54_000
+
+    def test_duk_cple_psco_corrected(self):
+        """The three other peak-bumped BAs from V3.η. Each was below its
+        served peak under EIA-860M; corrected via peak × 1.15."""
+        from config import REGION_CAPACITY_MW
+
+        # DUK 22,186 × 1.15 ≈ 25,513
+        assert REGION_CAPACITY_MW["DUK"] >= 25_000
+        # CPLE 14,329 × 1.15 ≈ 16,478
+        assert REGION_CAPACITY_MW["CPLE"] >= 16_000
+        # PSCO 10,642 × 1.15 ≈ 12,238
+        assert REGION_CAPACITY_MW["PSCO"] >= 12_000
+
+
+class TestKpiSuppressesImportDominated:
+    """The "Highest-Stress Region" KPI must drop import-dominated BAs
+    from candidacy regardless of where their (corrected) ratio lands.
+    The capacity is an estimate — even a benign 60% ratio against an
+    estimated pool isn't comparable to a 60% ratio against measured
+    plate at PJM."""
+
+    def test_cplw_excluded_from_top_stress_even_when_ratio_is_normal(self):
+        """With the V3.η correction CPLW's ratio sits in the normal
+        band, but it must STILL be filtered out — the IS_IMPORT_DOMINATED
+        tag is the authoritative signal, not the ratio threshold."""
+        from components.callbacks import _build_us_grid_metrics_items
+
+        # CPLW corrected capacity ≈ 1,450 MW. Demand 1,000 MW → 69% — a
+        # mathematically reliable ratio. Without IS_IMPORT_DOMINATED
+        # filter, CPLW would beat PJM (~38%) for top stress.
+        region_data = {
+            "CPLW": {"current_mw": 1_000.0, "today_mw": [1_000.0] * 24},
+            "PJM": {"current_mw": 70_000.0, "today_mw": [70_000.0] * 24},
+        }
+        items = _build_us_grid_metrics_items(region_data)
+        top = next(i for i in items if i["label"] == "Highest-Stress Region")
+        assert "PJM" in top["value"]
+        assert "CPLW" not in top["value"]
+
+    def test_spa_excluded_even_with_low_ratio(self):
+        """SPA (federal hydro marketer) capacity is real plate but
+        served demand is wrong shape — exclude regardless of ratio."""
+        from components.callbacks import _build_us_grid_metrics_items
+
+        region_data = {
+            "SPA": {"current_mw": 500.0, "today_mw": [500.0] * 24},
+            "PJM": {"current_mw": 30_000.0, "today_mw": [30_000.0] * 24},
+        }
+        items = _build_us_grid_metrics_items(region_data)
+        top = next(i for i in items if i["label"] == "Highest-Stress Region")
+        assert "SPA" not in top["value"]
+
+
+class TestCardImportsChip:
+    """The region-card stress chip should render "imports" for every
+    IS_IMPORT_DOMINATED BA, regardless of whether the ratio is above
+    or below the reliability ceiling on the rendered hour."""
+
+    def test_card_renders_imports_chip_for_low_ratio_cplw(self):
+        """V3.η scenario: CPLW corrected capacity 1,450 MW. At 60%
+        ratio (870 MW demand) the OLD code would have shown "60%" —
+        misleading because the 1,450 is an estimate, not a plate.
+        New code shows the qualitative "imports" chip."""
+        from components.callbacks import _build_us_grid_region_card
+
+        card = _build_us_grid_region_card(
+            "CPLW",
+            {"current_mw": 870.0, "today_mw": [870.0] * 24},
+        )
+
+        # Walk for the "imports" chip
+        def find_text(node, target):
+            from dash import html as _html  # noqa: F401
+
+            children = getattr(node, "children", None)
+            if children is None:
+                return False
+            if isinstance(children, str):
+                return target in children
+            if isinstance(children, (list, tuple)):
+                for c in children:
+                    if find_text(c, target):
+                        return True
+            else:
+                return find_text(children, target)
+            return False
+
+        assert find_text(card, "imports"), (
+            "CPLW card should render the 'imports' chip even when its "
+            "ratio is in the reliable band — the IS_IMPORT_DOMINATED "
+            "tag is the authoritative signal."
+        )
+
+
+class TestPolygonHoverImportTag:
+    """The polygon view's hover should append " · imports" to the BA
+    name for IS_IMPORT_DOMINATED entries — surfaces the structural
+    classification in the most clicked drilldown surface."""
+
+    def test_customdata_carries_import_tag(self):
+        from components.callbacks import _build_us_grid_choropleth
+
+        region_data = {
+            "PJM": {"current_mw": 70_000.0},
+            "CPLW": {"current_mw": 870.0},
+        }
+        body = _build_us_grid_choropleth(region_data)
+
+        # Walk for the dcc.Graph
+        def find_graph(c):
+            from dash import dcc
+
+            if isinstance(c, dcc.Graph):
+                return c
+            children = getattr(c, "children", None)
+            if isinstance(children, (list, tuple)):
+                for x in children:
+                    g = find_graph(x)
+                    if g is not None:
+                        return g
+            elif children is not None:
+                return find_graph(children)
+            return None
+
+        graph = find_graph(body)
+        cd = graph.figure.data[0].customdata
+        # Plotly stores customdata as nd.array of objects — each row
+        # has [region, name, demand_gw, import_tag]
+        rows = {row[0]: row for row in cd}
+        assert " · imports" in str(rows["CPLW"][3]), (
+            "CPLW customdata should carry the import tag suffix"
+        )
+        assert str(rows["PJM"][3]) == "", (
+            "PJM customdata should have an empty import tag (renders invisibly)"
+        )


### PR DESCRIPTION
## Summary

Closes the misleading "CPLW · 1071%" KPI surfaced in PR #76 at its **root cause** rather than at the display layer. EIA-860M reports nameplate capacity for *in-territory* generators only. For most BAs that's a fine proxy for the resource pool, but three EIA-930 BAs (CPLW, HST, SPA) serve far more demand than they generate locally — they're structurally net importers. PR #76 capped their *display* at 100%; this PR fixes the *classification*.

## Two layered fixes

### 1. Capacity re-source — 7 BAs

For BAs where EIA-860M nameplate was below served peak, switch to `peak × 1.15` (12-month max demand × standard reserve margin):

| BA   | Before | After  | Multiplier |
|------|--------|--------|------------|
| SOCO | 46,000 | 54,980 | 1.20×      |
| DUK  | 20,800 | 25,513 | 1.23×      |
| CPLE | 13,700 | 16,478 | 1.20×      |
| PSCO | 9,080  | 12,238 | 1.35×      |
| FMPP | 3,908  | 4,574  | 1.17×      |
| HST  | 36     | 169    | 4.69×      |
| CPLW | 42     | 1,450  | 34.5×      |

### 2. `IS_IMPORT_DOMINATED` tag — 3 BAs

`CPLW`, `HST`, `SPA` are structurally net importers (≥ 2× multiplier). The UI now:

- **Excludes** them from "highest stress" candidate ranking — even with the corrected capacity, the ratio is against an estimated pool, not measured plate, so it's not comparable to a real vertically-integrated BA's stress.
- **Annotates** polygon + scatter hover with a " · imports" suffix.
- **Renders** the qualitative "imports" chip on the region card whether or not the ratio happens to be below the reliability ceiling on the rendered hour. The structural classification is the authoritative signal.

## What the user sees after this lands

- The red CPLW dot in NC disappears from "Highest-Stress" candidacy.
- Hovering CPLW on the polygon view shows: **DEP-West · imports**.
- The CPLW region card shows the "imports" chip with a tooltip explaining what that means, instead of "100%".

## Test plan

- [x] `tests/unit/test_import_dominated_bas.py` — 12 new tests
  - Set shape (frozenset, expected members, no false positives)
  - Per-BA capacity corrections
  - KPI suppression (CPLW excluded even when ratio is normal; SPA same)
  - Card "imports" chip renders for tagged BAs at low ratios
  - Polygon hover customdata carries the import tag
- [x] All 1598 existing unit tests still pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] Smoke-test deployed Polygons view: hovering CPLW shows " · imports"; KPI bar's Highest-Stress is no longer CPLW

🤖 Generated with [Claude Code](https://claude.com/claude-code)