### PR TITLE
feat(ui): polygon view — coverage caption disambiguates dark-fill gaps

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -2398,3 +2398,11 @@ body.briefing #meeting-mode-btn.gp-header__link:hover {
     color: var(--text-tertiary);
     font-size: var(--text-sm);
 }
+
+.gp-region-map__coverage-caption {
+    color: var(--text-tertiary);
+    font-size: var(--text-xs);
+    text-align: center;
+    margin-top: var(--space-2);
+    line-height: 1.4;
+}

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -7123,12 +7123,29 @@ def _build_us_grid_choropleth(region_data: dict) -> html.Div:
         },
     )
 
+    # Coverage caption — disambiguates the dark-fill gaps in the
+    # Polygons view (Idaho, parts of Montana / Wyoming / the Plains,
+    # AK + HI insets) as intentional unmapped territory, not a
+    # rendering bug. EIA-930 has ~64 BAs in the lower 48; we ship
+    # polygons for ~51 (~80% of demand). Renders only inside the
+    # Polygons view body — Cards / Map don't have coverage gaps to
+    # disclose.
+    n_covered = len(regions)
+    caption = html.Div(
+        f"{n_covered} of ~64 lower-48 balancing authorities mapped · "
+        "dark areas are EIA-930 BAs not yet covered here.",
+        className="gp-region-map__coverage-caption",
+    )
+
     return html.Div(
-        dcc.Graph(
-            id="us-grid-map",
-            figure=fig,
-            config={"displayModeBar": False, "responsive": True},
-            style={"height": "480px"},
-        ),
+        [
+            dcc.Graph(
+                id="us-grid-map",
+                figure=fig,
+                config={"displayModeBar": False, "responsive": True},
+                style={"height": "480px"},
+            ),
+            caption,
+        ],
         className="gp-region-map",
     )

--- a/tests/unit/test_us_grid_choropleth.py
+++ b/tests/unit/test_us_grid_choropleth.py
@@ -193,6 +193,66 @@ class TestChoroplethRender:
         assert graph.figure.data[0].type == "scattergeo"
 
 
+class TestPolygonCoverageCaption:
+    """The Polygons view has visible dark-fill gaps where we don't yet
+    ship a BA polygon (Idaho, parts of Montana / Wyoming, AK + HI
+    insets). Without a caption a first-time viewer reads those as
+    "broken." Caption converts them into honest "unmapped" indicators.
+    """
+
+    def test_caption_renders_in_polygon_body(self):
+        from components.callbacks import _build_us_grid_choropleth
+
+        body = _build_us_grid_choropleth(
+            {
+                "PJM": {"current_mw": 70_000.0},
+                "ERCOT": {"current_mw": 50_000.0},
+            }
+        )
+
+        def find_text(node, predicate):
+            children = getattr(node, "children", None)
+            if isinstance(children, str):
+                return children if predicate(children) else None
+            if isinstance(children, (list, tuple)):
+                for c in children:
+                    found = find_text(c, predicate)
+                    if found is not None:
+                        return found
+            elif children is not None:
+                return find_text(children, predicate)
+            return None
+
+        caption = find_text(body, lambda s: "balancing authorities mapped" in s)
+        assert caption is not None, (
+            "Polygon view body should contain a coverage caption that "
+            "names how many BAs are mapped vs unmapped."
+        )
+        # The covered count comes from the populated dict — 2 in this test.
+        assert "2 of " in caption
+
+    def test_caption_absent_in_cold_state(self):
+        """When all regions are warming, the choropleth returns an
+        empty-state placeholder — caption shouldn't appear there
+        (there's nothing mapped to count, and the empty-state copy
+        already explains the situation)."""
+        from components.callbacks import _build_us_grid_choropleth
+
+        body = _build_us_grid_choropleth({"PJM": {"current_mw": None}})
+
+        def has_text(node, target):
+            children = getattr(node, "children", None)
+            if isinstance(children, str):
+                return target in children
+            if isinstance(children, (list, tuple)):
+                return any(has_text(c, target) for c in children)
+            if children is not None:
+                return has_text(children, target)
+            return False
+
+        assert not has_text(body, "balancing authorities mapped")
+
+
 class TestPolygonWindingOrder:
     """Regression for the user-reported "all green" bug. Plotly's
     underlying renderer (D3-geo) treats a polygon's outer ring as the


### PR DESCRIPTION
## Summary

The Polygons view has visible dark-fill gaps where we don't yet ship a BA polygon (Idaho, parts of Montana / Wyoming / the Plains, AK + HI insets). To a first-time viewer those gaps read as "broken." Caption converts them into honest "unmapped territory" indicators — same trust-calibration move as a chart that captions its own data source.

## What renders

A small line under the polygon graph:

> **51 of ~64 lower-48 balancing authorities mapped · dark areas are EIA-930 BAs not yet covered here.**

(The 51 is `len(populated)` at render time — auto-tracks future BA additions.)

Only renders inside the Polygons-view body. Cards and Map don't have coverage gaps to disclose.

## Test plan

- [x] `TestPolygonCoverageCaption.test_caption_renders_in_polygon_body` — caption present, count correct
- [x] `TestPolygonCoverageCaption.test_caption_absent_in_cold_state` — empty-state placeholder doesn't render the caption
- [x] All 1612 existing unit tests still pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] Smoke-test deployed Polygons view: caption appears below the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)