### PR TITLE
feat(models): real holdout metrics — RMSE / MAE / R² / ensemble from training

### DIFF
--- a/jobs/training_job.py
+++ b/jobs/training_job.py
@@ -37,51 +37,61 @@ def _compute_data_hash(region_data: phases.RegionData) -> str:
     return _compute_data_hash(region_data.demand_df, region_data.weather_df, region_data.region)
 
 
-def _train_xgboost(region_data: phases.RegionData) -> str | None:
-    """Train + persist an XGBoost model. Returns the saved version or ``None``."""
-    from models.xgboost_model import train_xgboost
-
-    region = region_data.region
-    assert region_data.featured_df is not None
-    try:
-        model_dict = train_xgboost(region_data.featured_df, n_splits=3)
-    except Exception as e:
-        log.warning("training_xgboost_failed", region=region, error=str(e))
-        return None
-
-    mape = None
-    cv_scores = model_dict.get("cv_scores") if isinstance(model_dict, dict) else None
-    if cv_scores is not None and len(cv_scores) > 0:
-        try:
-            mape = float(np.mean(cv_scores))
-        except Exception:
-            mape = None
-
-    return save_model(
-        region=region,
-        model_name="xgboost",
-        model_obj=model_dict,
-        data_hash=_compute_data_hash(region_data),
-        train_rows=len(region_data.featured_df),
-        mape=mape,
-        extra={"cv_scores": cv_scores if cv_scores is not None else []},
-    )
-
-
 _HOLDOUT_HOURS = 168
 _MIN_TRAIN_HOURS = 720  # need at least 30 days of training before a 7-day holdout
 
 
-def _holdout_mape_prophet(featured_df, region: str) -> float | None:
-    """Compute Prophet's MAPE on the last ``_HOLDOUT_HOURS`` of ``featured_df``.
+def _holdout_metrics_xgboost(featured_df, region: str) -> dict | None:
+    """Train a holdout XGBoost on ``featured_df[:-_HOLDOUT_HOURS]`` and score
+    it on the final 168-hour window. Returns ``{metrics: {mape, rmse, mae, r2},
+    forecast: ndarray, actual: ndarray}`` or ``None`` if the window is too
+    short / the holdout fit fails.
 
-    Returns ``None`` when the window is too short or the holdout train/predict
-    fails for any reason — the caller still trains a production model on the
-    full data; only the saved MAPE is missing in that case.
+    The forecast / actual arrays are kept on the return so the ensemble metric
+    can be computed from the SAME holdout predictions later, no recomputation.
     """
     import numpy as np
 
-    from models.evaluation import compute_mape
+    from models.evaluation import compute_all_metrics
+    from models.xgboost_model import predict_xgboost, train_xgboost
+
+    if len(featured_df) <= _HOLDOUT_HOURS + _MIN_TRAIN_HOURS:
+        return None
+    train_df = featured_df.iloc[:-_HOLDOUT_HOURS]
+    val_df = featured_df.iloc[-_HOLDOUT_HOURS:]
+    try:
+        holdout_model = train_xgboost(train_df, n_splits=3)
+        forecast = np.asarray(predict_xgboost(holdout_model, val_df), dtype=float)[: len(val_df)]
+        y_val = np.asarray(val_df["demand_mw"].values, dtype=float)
+        if not np.isfinite(forecast).all():
+            return None
+        metrics = compute_all_metrics(y_val, forecast)
+        if not np.isfinite(metrics["mape"]) or metrics["mape"] <= 0:
+            return None
+        log.info(
+            "training_xgboost_holdout_metrics",
+            region=region,
+            mape=round(metrics["mape"], 3),
+            rmse=round(metrics["rmse"], 1),
+            mae=round(metrics["mae"], 1),
+            r2=round(metrics["r2"], 4),
+        )
+        return {"metrics": metrics, "forecast": forecast, "actual": y_val}
+    except Exception as e:
+        log.warning("training_xgboost_holdout_failed", region=region, error=str(e))
+        return None
+
+
+def _holdout_metrics_prophet(featured_df, region: str) -> dict | None:
+    """Compute Prophet's full holdout metric set on the last 168 hours.
+
+    Replaces the earlier ``_holdout_mape_prophet`` which only returned MAPE.
+    Returns ``{metrics: {mape, rmse, mae, r2}, forecast: ndarray, actual: ndarray}``
+    so the ensemble can be computed from the same predictions.
+    """
+    import numpy as np
+
+    from models.evaluation import compute_all_metrics
     from models.prophet_model import predict_prophet, train_prophet
 
     if len(featured_df) <= _HOLDOUT_HOURS + _MIN_TRAIN_HOURS:
@@ -93,22 +103,35 @@ def _holdout_mape_prophet(featured_df, region: str) -> float | None:
         pred = predict_prophet(holdout_model, val_df, periods=len(val_df))
         forecast = np.asarray(pred["forecast"], dtype=float)[: len(val_df)]
         y_val = np.asarray(val_df["demand_mw"].values, dtype=float)
-        mape = float(compute_mape(y_val, forecast))
-        if not np.isfinite(mape) or mape <= 0:
+        if not np.isfinite(forecast).all():
             return None
-        log.info("training_prophet_holdout_mape", region=region, mape=round(mape, 3))
-        return mape
+        metrics = compute_all_metrics(y_val, forecast)
+        if not np.isfinite(metrics["mape"]) or metrics["mape"] <= 0:
+            return None
+        log.info(
+            "training_prophet_holdout_metrics",
+            region=region,
+            mape=round(metrics["mape"], 3),
+            rmse=round(metrics["rmse"], 1),
+            mae=round(metrics["mae"], 1),
+            r2=round(metrics["r2"], 4),
+        )
+        return {"metrics": metrics, "forecast": forecast, "actual": y_val}
     except Exception as e:
         log.warning("training_prophet_holdout_failed", region=region, error=str(e))
         return None
 
 
-def _holdout_mape_arima(featured_df, region: str) -> float | None:
-    """Compute SARIMAX's MAPE on the last ``_HOLDOUT_HOURS`` of ``featured_df``."""
+def _holdout_metrics_arima(featured_df, region: str) -> dict | None:
+    """Compute SARIMAX's full holdout metric set on the last 168 hours.
+
+    Replaces the earlier ``_holdout_mape_arima`` (MAPE only). See
+    :func:`_holdout_metrics_prophet` for return shape.
+    """
     import numpy as np
 
     from models.arima_model import predict_arima, train_arima
-    from models.evaluation import compute_mape
+    from models.evaluation import compute_all_metrics
 
     if len(featured_df) <= _HOLDOUT_HOURS + _MIN_TRAIN_HOURS:
         return None
@@ -121,33 +144,152 @@ def _holdout_mape_arima(featured_df, region: str) -> float | None:
             dtype=float,
         )[: len(val_df)]
         y_val = np.asarray(val_df["demand_mw"].values, dtype=float)
-        mape = float(compute_mape(y_val, forecast))
-        if not np.isfinite(mape) or mape <= 0:
+        if not np.isfinite(forecast).all():
             return None
-        log.info("training_arima_holdout_mape", region=region, mape=round(mape, 3))
-        return mape
+        metrics = compute_all_metrics(y_val, forecast)
+        if not np.isfinite(metrics["mape"]) or metrics["mape"] <= 0:
+            return None
+        log.info(
+            "training_arima_holdout_metrics",
+            region=region,
+            mape=round(metrics["mape"], 3),
+            rmse=round(metrics["rmse"], 1),
+            mae=round(metrics["mae"], 1),
+            r2=round(metrics["r2"], 4),
+        )
+        return {"metrics": metrics, "forecast": forecast, "actual": y_val}
     except Exception as e:
         log.warning("training_arima_holdout_failed", region=region, error=str(e))
         return None
 
 
-def _train_prophet(region_data: phases.RegionData) -> str | None:
+def _ensemble_holdout_metrics(
+    per_model_holdouts: dict[str, dict],
+) -> tuple[dict[str, float], dict[str, float]] | None:
+    """Combine per-model holdout predictions into an ensemble forecast,
+    score it against the shared holdout actuals, and return
+    ``(metrics, weights)``. Returns ``None`` when fewer than two models
+    produced finite holdout predictions (the ensemble degenerates to a
+    single model and adds nothing).
+
+    Weights are inverse-MAPE — same formula the scoring job uses to
+    combine the FORWARD-LOOKING forecasts, applied here to the
+    holdout window so the persisted ensemble metric reflects the
+    same combination rule that runs in production.
+    """
+    import numpy as np
+
+    from models.ensemble import compute_ensemble_weights, ensemble_combine
+    from models.evaluation import compute_all_metrics
+
+    valid = {name: payload for name, payload in per_model_holdouts.items() if payload is not None}
+    if len(valid) < 2:
+        return None
+
+    # Every per-model holdout uses the same train/val split so actuals
+    # are identical across models — assert this defensively.
+    actuals = next(iter(valid.values()))["actual"]
+    for name, payload in valid.items():
+        if len(payload["actual"]) != len(actuals):
+            log.warning(
+                "ensemble_holdout_actuals_mismatch",
+                model=name,
+                expected=len(actuals),
+                got=len(payload["actual"]),
+            )
+            return None
+
+    mape_scores = {name: payload["metrics"]["mape"] for name, payload in valid.items()}
+    weights = compute_ensemble_weights(mape_scores)
+    total = sum(weights.values()) or 1.0
+    weights = {k: v / total for k, v in weights.items()}
+
+    forecasts = {name: payload["forecast"] for name, payload in valid.items()}
+    ensemble_pred = np.asarray(ensemble_combine(forecasts, weights), dtype=float)
+
+    metrics = compute_all_metrics(actuals, ensemble_pred)
+    if not np.isfinite(metrics["mape"]) or metrics["mape"] <= 0:
+        return None
+    return metrics, weights
+
+
+def _train_xgboost(
+    region_data: phases.RegionData,
+    holdout: dict | None = None,
+) -> str | None:
+    """Train + persist an XGBoost model. Returns the saved version or ``None``.
+
+    When ``holdout`` is supplied (the dict from
+    :func:`_holdout_metrics_xgboost`), its full metric set is persisted in
+    the meta's ``extra["holdout_metrics"]`` so ``get_model_metrics`` can
+    surface real RMSE / MAE / R² (not just MAPE) on the Models tab.
+    """
+    from models.xgboost_model import train_xgboost
+
+    region = region_data.region
+    assert region_data.featured_df is not None
+    try:
+        model_dict = train_xgboost(region_data.featured_df, n_splits=3)
+    except Exception as e:
+        log.warning("training_xgboost_failed", region=region, error=str(e))
+        return None
+
+    # Holdout MAPE wins over CV-mean MAPE when available — same window
+    # as the prophet/arima holdouts so the inverse-MAPE ensemble weights
+    # are computed against a consistent metric basis.
+    cv_scores = model_dict.get("cv_scores") if isinstance(model_dict, dict) else None
+    cv_mape = None
+    if cv_scores is not None and len(cv_scores) > 0:
+        try:
+            cv_mape = float(np.mean(cv_scores))
+        except Exception:
+            cv_mape = None
+
+    holdout_metrics = holdout["metrics"] if holdout else None
+    saved_mape = (holdout_metrics or {}).get("mape") or cv_mape
+
+    extra: dict = {"cv_scores": cv_scores if cv_scores is not None else []}
+    if holdout_metrics is not None:
+        extra["holdout_metrics"] = holdout_metrics
+
+    return save_model(
+        region=region,
+        model_name="xgboost",
+        model_obj=model_dict,
+        data_hash=_compute_data_hash(region_data),
+        train_rows=len(region_data.featured_df),
+        mape=saved_mape,
+        extra=extra,
+    )
+
+
+def _train_prophet(
+    region_data: phases.RegionData,
+    holdout: dict | None = None,
+) -> str | None:
     """Best-effort Prophet training. Returns the saved version or ``None``.
 
-    Trains twice: once on the train portion to score a holdout MAPE that
-    drives ensemble weighting at scoring time, and once on the full window
-    for the production model that gets persisted to GCS.
+    Trains twice: once on the train portion (to score the full holdout
+    metric set used for ensemble weighting + Models-tab display), and
+    once on the full window for the production model that gets persisted
+    to GCS. ``holdout`` is the payload from :func:`_holdout_metrics_prophet`
+    — stashed here as ``extra["holdout_metrics"]`` so RMSE / MAE / R² are
+    real at display time.
     """
     from models.prophet_model import train_prophet
 
     region = region_data.region
     assert region_data.featured_df is not None
-    mape = _holdout_mape_prophet(region_data.featured_df, region)
     try:
         prophet_obj = train_prophet(region_data.featured_df)
     except Exception as e:
         log.warning("training_prophet_failed", region=region, error=str(e))
         return None
+
+    holdout_metrics = holdout["metrics"] if holdout else None
+    extra: dict = {}
+    if holdout_metrics is not None:
+        extra["holdout_metrics"] = holdout_metrics
 
     return save_model(
         region=region,
@@ -155,25 +297,34 @@ def _train_prophet(region_data: phases.RegionData) -> str | None:
         model_obj=prophet_obj,
         data_hash=_compute_data_hash(region_data),
         train_rows=len(region_data.featured_df),
-        mape=mape,
+        mape=(holdout_metrics or {}).get("mape"),
+        extra=extra,
     )
 
 
-def _train_arima(region_data: phases.RegionData) -> str | None:
+def _train_arima(
+    region_data: phases.RegionData,
+    holdout: dict | None = None,
+) -> str | None:
     """Best-effort SARIMAX training. Returns the saved version or ``None``.
 
-    Holdout-MAPE computation mirrors :func:`_train_prophet`.
+    Holdout-metric extraction mirrors :func:`_train_prophet` — full
+    {mape, rmse, mae, r2} dict persisted in ``extra["holdout_metrics"]``.
     """
     from models.arima_model import train_arima
 
     region = region_data.region
     assert region_data.featured_df is not None
-    mape = _holdout_mape_arima(region_data.featured_df, region)
     try:
         arima_dict = train_arima(region_data.featured_df)
     except Exception as e:
         log.warning("training_arima_failed", region=region, error=str(e))
         return None
+
+    holdout_metrics = holdout["metrics"] if holdout else None
+    extra: dict = {}
+    if holdout_metrics is not None:
+        extra["holdout_metrics"] = holdout_metrics
 
     return save_model(
         region=region,
@@ -181,7 +332,8 @@ def _train_arima(region_data: phases.RegionData) -> str | None:
         model_obj=arima_dict,
         data_hash=_compute_data_hash(region_data),
         train_rows=len(region_data.featured_df),
-        mape=mape,
+        mape=(holdout_metrics or {}).get("mape"),
+        extra=extra,
     )
 
 
@@ -201,12 +353,67 @@ def _train_region(region: str) -> dict:
         summary["elapsed_s"] = round(time.time() - t0, 2)
         return summary
 
-    xgb_version = _train_xgboost(region_data)
+    # Score every model on the SAME 168-hour holdout window before
+    # persisting production models. This is the only time predictions
+    # against real ground truth are produced for the Models tab — the
+    # scoring job's diagnostics path used to do this against
+    # ``_simulate_forecasts`` and write fake RMSE / MAE / R² to Redis;
+    # now those numbers come from here, persisted into each meta's
+    # ``extra["holdout_metrics"]``. The ensemble metric is computed
+    # off the same predictions and stashed in xgboost's meta extra.
+    featured = region_data.featured_df
+    xgb_holdout = _holdout_metrics_xgboost(featured, region)
+    prophet_holdout = _holdout_metrics_prophet(featured, region)
+    arima_holdout = _holdout_metrics_arima(featured, region)
+
+    # Compute ensemble metric BEFORE persisting xgboost so we can
+    # stash it in xgboost's extra. xgboost is the canonical "primary"
+    # model; if other models drop out, the ensemble row degrades to
+    # whatever survived.
+    ensemble_summary = _ensemble_holdout_metrics(
+        {
+            "xgboost": xgb_holdout,
+            "prophet": prophet_holdout,
+            "arima": arima_holdout,
+        }
+    )
+
+    xgb_version = _train_xgboost(region_data, holdout=xgb_holdout)
     summary["models"]["xgboost"] = xgb_version
-    prophet_version = _train_prophet(region_data)
+    prophet_version = _train_prophet(region_data, holdout=prophet_holdout)
     summary["models"]["prophet"] = prophet_version
-    arima_version = _train_arima(region_data)
+    arima_version = _train_arima(region_data, holdout=arima_holdout)
     summary["models"]["arima"] = arima_version
+
+    # Persist the ensemble metric into xgboost's meta if both succeeded
+    # — keeps the meta-as-display-source contract intact (no separate
+    # ensemble blob to introduce here). ``get_model_metrics`` checks
+    # this key when building the ensemble row for the Models tab.
+    if xgb_version and ensemble_summary is not None:
+        ensemble_metrics, ensemble_weights = ensemble_summary
+        try:
+            from models.persistence import write_extra_to_meta
+
+            write_extra_to_meta(
+                region=region,
+                model_name="xgboost",
+                version=xgb_version,
+                key_updates={
+                    "ensemble_holdout_metrics": ensemble_metrics,
+                    "ensemble_weights": ensemble_weights,
+                },
+            )
+            summary["ensemble"] = {
+                "mape": round(ensemble_metrics["mape"], 3),
+                "rmse": round(ensemble_metrics["rmse"], 1),
+                "weights": ensemble_weights,
+            }
+        except Exception as e:
+            log.warning(
+                "ensemble_extra_persist_failed",
+                region=region,
+                error=str(e),
+            )
 
     # Recompute backtests against the freshly fetched data — these become
     # the values the Validation tab reads out of Redis.

--- a/models/model_service.py
+++ b/models/model_service.py
@@ -60,30 +60,38 @@ def get_forecasts(
     return _simulate_forecasts(region, actual, models_shown)
 
 
+_HOLDOUT_FIELDS = ("mape", "rmse", "mae", "r2")
+
+
 def get_model_metrics(region: str) -> dict[str, dict[str, float]]:
     """
     Get validation metrics for a region's trained models.
 
-    **MAPE is the authoritative metric** — pulled per-model from each
-    pickle's `.meta.json` in GCS, written by the daily training job
-    (V0.2 / V3.ε). Other fields (RMSE / MAE / R²) come from the
-    Redis diagnostics payload when present; that payload is computed
-    from actual demand vs scoring-job forecasts and is currently
-    simulation-derived in production (the scoring job's diagnostics
-    path uses `_simulate_forecasts` because it doesn't share GCS
-    pickles with the in-process model cache). Treat RMSE / MAE / R²
-    as approximations until that path is unified.
+    **All four metrics (MAPE / RMSE / MAE / R²) are training-time
+    holdout values** — each model's last 168-hour holdout, computed
+    by the daily training job and persisted in
+    ``meta.extra["holdout_metrics"]``. The ensemble row is computed
+    from the SAME holdout predictions and stashed in xgboost's meta
+    extra under ``ensemble_holdout_metrics``. Provenance is uniform:
+    no metric is silently sourced from a different distribution
+    than its siblings.
 
     Resolution order:
-    1. Per-model holdout MAPE from ``models.persistence.get_model_metadata``
-       (real training-time values, prophet / arima / xgboost only —
-       ensemble has no own meta.json so its MAPE comes from Redis).
-    2. ``wattcast:diagnostics:{region}`` for RMSE / MAE / R² and the
-       ensemble's MAPE; supplements layer 1 without overwriting it.
-    3. In-process trained pickle (dev mode running with the local
-       precompute thread).
-    4. Simulated baseline (consistent defaults). Last-resort dev
-       fallback when none of the above produce data.
+    1. ``meta.extra["holdout_metrics"]`` per model — full {mape, rmse,
+       mae, r2} dict, real training-time holdout. This is the canonical
+       path for any BA whose models trained on the new code path.
+    2. Top-level ``meta.mape`` per model — backward-compat for pickles
+       trained before this path landed (only MAPE is real; RMSE/MAE/R²
+       are still supplemented from Redis below).
+    3. Ensemble metrics from xgboost's meta extra
+       (``ensemble_holdout_metrics``).
+    4. Redis diagnostics ``wattcast:diagnostics:{region}`` —
+       fallback ONLY for fields not provided by the meta path.
+       In production this content is currently
+       ``_simulate_forecasts``-derived; the meta-first ordering means
+       a viewer never sees a simulated value when a real one exists.
+    5. Local pickle (dev mode with in-process precompute).
+    6. Hardcoded simulated baseline — last-resort dev fallback.
 
     Returns:
         Dict of model_name → {mape?, rmse?, mae?, r2?}. Empty fields
@@ -91,7 +99,8 @@ def get_model_metrics(region: str) -> dict[str, dict[str, float]]:
     """
     out: dict[str, dict[str, float]] = {}
 
-    # 1. Real holdout MAPE per model — written by jobs/training_job.py.
+    # 1 + 2. Per-model holdout metrics from meta extras.
+    ensemble_from_xgb_meta: dict[str, float] | None = None
     try:
         from models.persistence import get_model_metadata
 
@@ -102,13 +111,48 @@ def get_model_metrics(region: str) -> dict[str, dict[str, float]]:
                 meta = None
             if meta is None:
                 continue
-            mape = getattr(meta, "mape", None)
-            if mape is not None and np.isfinite(mape) and mape > 0:
-                out[model_name] = {"mape": float(mape)}
+            base: dict[str, float] = {}
+
+            # Layer 1: full holdout metrics from extra (preferred).
+            extra = getattr(meta, "extra", None) or {}
+            holdout = extra.get("holdout_metrics") if isinstance(extra, dict) else None
+            if isinstance(holdout, dict):
+                for field in _HOLDOUT_FIELDS:
+                    val = holdout.get(field)
+                    if val is not None and np.isfinite(val):
+                        base[field] = float(val)
+
+            # Layer 2: legacy fallback — top-level meta.mape only.
+            if "mape" not in base:
+                mape = getattr(meta, "mape", None)
+                if mape is not None and np.isfinite(mape) and mape > 0:
+                    base["mape"] = float(mape)
+
+            if base:
+                out[model_name] = base
+
+            # Layer 3: ensemble metrics ride along on xgboost's extra.
+            if model_name == "xgboost" and isinstance(extra, dict):
+                ens = extra.get("ensemble_holdout_metrics")
+                if isinstance(ens, dict):
+                    candidate = {
+                        f: float(ens[f])
+                        for f in _HOLDOUT_FIELDS
+                        if f in ens and np.isfinite(ens[f])
+                    }
+                    if candidate:
+                        ensemble_from_xgb_meta = candidate
     except Exception as e:  # pragma: no cover — defensive (GCS outage)
         log.debug("get_model_metrics_meta_miss", region=region, error=str(e))
 
-    # 2. Supplement with Redis diagnostics (RMSE / MAE / R² + ensemble MAPE).
+    if ensemble_from_xgb_meta:
+        out["ensemble"] = ensemble_from_xgb_meta
+
+    # 4. Redis diagnostics — supplements ONLY fields the meta path
+    # didn't provide. In production this is currently
+    # ``_simulate_forecasts``-derived, so we only fall back to it
+    # for legacy pickles or the ensemble row when xgboost's meta
+    # didn't carry ensemble_holdout_metrics.
     try:
         from data.redis_client import redis_get
 
@@ -118,12 +162,7 @@ def get_model_metrics(region: str) -> dict[str, dict[str, float]]:
                 if not isinstance(redis_m, dict):
                     continue
                 base = out.get(model_name, {})
-                # MAPE from Redis only when meta.json didn't provide one
-                # (currently true only for the ensemble row).
-                if "mape" not in base and "mape" in redis_m:
-                    base["mape"] = redis_m["mape"]
-                # RMSE / MAE / R² supplement layer 1.
-                for field in ("rmse", "mae", "r2"):
+                for field in _HOLDOUT_FIELDS:
                     if field in redis_m and field not in base:
                         base[field] = redis_m[field]
                 if base:
@@ -134,12 +173,12 @@ def get_model_metrics(region: str) -> dict[str, dict[str, float]]:
     if out:
         return out
 
-    # 3. Local pickle — dev mode.
+    # 5. Local pickle — dev mode.
     model_data = _load_cached_models(region)
     if model_data and "metrics" in model_data:
         return model_data["metrics"]
 
-    # 4. Simulated baseline — last resort.
+    # 6. Simulated baseline — last resort.
     return {
         "prophet": {"mape": 2.8, "rmse": 450, "mae": 320, "r2": 0.967},
         "arima": {"mape": 3.5, "rmse": 580, "mae": 410, "r2": 0.945},

--- a/models/persistence.py
+++ b/models/persistence.py
@@ -349,6 +349,72 @@ def save_model(
     return version
 
 
+def write_extra_to_meta(
+    region: str,
+    model_name: str,
+    version: str,
+    key_updates: dict[str, Any],
+) -> bool:
+    """Merge ``key_updates`` into a saved model's ``extra`` dict in GCS.
+
+    Round-trips the existing meta JSON, deep-merges the new keys on top of
+    the existing ``extra`` (other top-level fields are preserved verbatim),
+    and writes the result back to the same blob. Returns ``True`` on
+    success, ``False`` if GCS is disabled / the blob is missing / the
+    upload fails.
+
+    Used by the training job to attach ensemble-level holdout metrics +
+    weights to the xgboost meta after both per-model persistence and
+    ensemble computation are done. Avoids a separate "ensemble meta"
+    blob (which would need its own latest.json plumbing) at the cost
+    of a single follow-up GCS write per region per training run.
+    """
+    client = _get_client()
+    if client is None:
+        log.info(
+            "model_meta_extra_skipped_gcs_disabled",
+            region=region,
+            model=model_name,
+        )
+        return False
+    try:
+        bucket = client.bucket(GCS_BUCKET_NAME)
+        blob = bucket.blob(_blob_path(region, model_name, version, ".meta.json"))
+        if not blob.exists():
+            log.warning(
+                "model_meta_extra_missing",
+                region=region,
+                model=model_name,
+                version=version,
+            )
+            return False
+        meta_dict = json.loads(blob.download_as_text())
+        extra = dict(meta_dict.get("extra") or {})
+        extra.update(key_updates)
+        meta_dict["extra"] = extra
+        blob.upload_from_string(
+            json.dumps(meta_dict, indent=2),
+            content_type="application/json",
+        )
+        log.info(
+            "model_meta_extra_updated",
+            region=region,
+            model=model_name,
+            version=version,
+            keys=sorted(key_updates.keys()),
+        )
+        return True
+    except Exception as e:
+        log.warning(
+            "model_meta_extra_failed",
+            region=region,
+            model=model_name,
+            version=version,
+            error=str(e),
+        )
+        return False
+
+
 def get_model_metadata(region: str, model_name: str) -> ModelMetadata | None:
     """Fetch metadata for the latest version of ``(region, model_name)``.
 

--- a/tests/unit/test_model_persistence.py
+++ b/tests/unit/test_model_persistence.py
@@ -464,6 +464,91 @@ class TestGetModelMetadata:
             assert mp.get_model_metadata("SPP", "arima") is None
 
 
+class TestWriteExtraToMeta:
+    """``write_extra_to_meta`` round-trips an existing meta blob,
+    deep-merges new keys into ``extra``, and writes the result back.
+    Used by the training job to attach ensemble-level holdout metrics
+    to the xgboost meta after both per-model persistence and ensemble
+    computation are done."""
+
+    def _setup(self, tmp_path):
+        import models.persistence as mp
+
+        _reset_persistence_state(str(tmp_path / "cache"))
+        store: dict[str, bytes] = {}
+        client = _make_fake_client(store)
+        return mp, store, client
+
+    def test_merges_new_keys_into_extra(self, tmp_path) -> None:
+        mp, store, client = self._setup(tmp_path)
+        with (
+            patch.object(mp, "GCS_ENABLED", True),
+            patch.object(mp, "GCS_BUCKET_NAME", "test-bucket"),
+            patch.object(mp, "GCS_PATH_PREFIX", "cache"),
+            patch.object(mp, "_get_client", return_value=client),
+        ):
+            version = mp.save_model(
+                "PJM",
+                "xgboost",
+                {"k": "v"},
+                "h",
+                100,
+                mape=1.10,
+                extra={"cv_scores": [1.0, 1.2]},
+            )
+            assert version is not None
+
+            ok = mp.write_extra_to_meta(
+                "PJM",
+                "xgboost",
+                version,
+                {
+                    "ensemble_holdout_metrics": {
+                        "mape": 0.94,
+                        "rmse": 119.0,
+                        "mae": 71.0,
+                        "r2": 0.994,
+                    },
+                    "ensemble_weights": {
+                        "xgboost": 0.6,
+                        "prophet": 0.25,
+                        "arima": 0.15,
+                    },
+                },
+            )
+            assert ok is True
+
+            mp.invalidate_latest_cache()
+            meta = mp.get_model_metadata("PJM", "xgboost")
+            assert meta is not None
+
+            # Existing keys preserved, new keys merged in.
+            assert meta.extra["cv_scores"] == [1.0, 1.2]
+            assert meta.extra["ensemble_holdout_metrics"]["mape"] == 0.94
+            assert meta.extra["ensemble_holdout_metrics"]["rmse"] == 119.0
+            assert meta.extra["ensemble_weights"]["xgboost"] == 0.6
+            # Top-level fields unchanged.
+            assert meta.mape == 1.10
+            assert meta.region == "PJM"
+
+    def test_returns_false_when_blob_missing(self, tmp_path) -> None:
+        mp, store, client = self._setup(tmp_path)
+        with (
+            patch.object(mp, "GCS_ENABLED", True),
+            patch.object(mp, "GCS_BUCKET_NAME", "test-bucket"),
+            patch.object(mp, "GCS_PATH_PREFIX", "cache"),
+            patch.object(mp, "_get_client", return_value=client),
+        ):
+            ok = mp.write_extra_to_meta("PJM", "xgboost", "v-nonexistent", {"foo": "bar"})
+            assert ok is False
+
+    def test_returns_false_when_gcs_disabled(self, tmp_path) -> None:
+        mp, _, _ = self._setup(tmp_path)
+        with patch.object(mp, "_get_client", return_value=None):
+            ok = mp.write_extra_to_meta("PJM", "xgboost", "v1", {"foo": "bar"})
+            assert ok is False
+
+
 # ---------------------------------------------------------------------------
 # Pickle failure does not crash
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_models_tab_consistency.py
+++ b/tests/unit/test_models_tab_consistency.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 
-def _meta(model_name, mape, region="PJM"):
+def _meta(model_name, mape, region="PJM", extra=None):
     """Build a minimal ``ModelMetadata`` for the patch."""
     from models.persistence import ModelMetadata
 
@@ -41,7 +41,23 @@ def _meta(model_name, mape, region="PJM"):
         train_rows=8000,
         mape=mape,
         lib_versions={},
-        extra={},
+        extra=extra or {},
+    )
+
+
+def _meta_with_holdout(model_name, holdout_metrics, region="PJM", ensemble=None):
+    """Build a ModelMetadata with full holdout_metrics in extra. The
+    optional ``ensemble`` dict (only meaningful for xgboost) goes into
+    ``extra["ensemble_holdout_metrics"]``.
+    """
+    extra = {"holdout_metrics": holdout_metrics}
+    if ensemble is not None:
+        extra["ensemble_holdout_metrics"] = ensemble
+    return _meta(
+        model_name,
+        mape=holdout_metrics.get("mape"),
+        region=region,
+        extra=extra,
     )
 
 
@@ -72,6 +88,122 @@ _REDIS_PAYLOAD_FAKE_METRICS = {
     "hourly_error": {h: 1.0 for h in range(24)},
     "feature_importance": {"temperature_2m": 0.5},
 }
+
+
+class TestHoldoutMetricsFromMetaExtra:
+    """The new training-job path persists full {mape, rmse, mae, r2}
+    holdout dicts to each model's ``meta.extra["holdout_metrics"]``
+    and the ensemble's metrics to xgboost's
+    ``meta.extra["ensemble_holdout_metrics"]``. After this lands the
+    Models tab's RMSE / MAE / R² numbers stop being
+    ``_simulate_forecasts`` output and become real training-time
+    holdout values with the same provenance as MAPE."""
+
+    def _meta_lookup_with_holdouts(self, holdouts_by_model, ensemble=None):
+        def _stub(region, model_name):
+            if model_name in holdouts_by_model:
+                if model_name == "xgboost" and ensemble is not None:
+                    return _meta_with_holdout(
+                        model_name,
+                        holdouts_by_model[model_name],
+                        region=region,
+                        ensemble=ensemble,
+                    )
+                return _meta_with_holdout(model_name, holdouts_by_model[model_name], region=region)
+            return None
+
+        return _stub
+
+    def test_real_rmse_mae_r2_overrides_simulated_redis(self):
+        """When holdout_metrics is in meta.extra, RMSE / MAE / R² come
+        from there — NOT from Redis (which is simulated in production)."""
+        from models.model_service import get_model_metrics
+
+        real_holdouts = {
+            "prophet": {"mape": 11.04, "rmse": 612.0, "mae": 481.0, "r2": 0.872},
+            "arima": {"mape": 5.19, "rmse": 388.0, "mae": 298.0, "r2": 0.943},
+            "xgboost": {"mape": 1.10, "rmse": 142.0, "mae": 89.0, "r2": 0.991},
+        }
+        with (
+            patch(
+                "models.persistence.get_model_metadata",
+                side_effect=self._meta_lookup_with_holdouts(real_holdouts),
+            ),
+            patch("data.redis_client.redis_get", return_value=_REDIS_PAYLOAD_FAKE_METRICS),
+        ):
+            got = get_model_metrics("PJM")
+
+        # MAPE remains real (existing behavior)
+        assert got["xgboost"]["mape"] == 1.10
+        # NEW: all three other metrics are now real holdout values too
+        assert got["xgboost"]["rmse"] == 142.0  # was 480 simulated
+        assert got["xgboost"]["mae"] == 89.0  # was 360 simulated
+        assert got["xgboost"]["r2"] == 0.991  # was 0.94 simulated
+        assert got["prophet"]["rmse"] == 612.0
+        assert got["arima"]["mae"] == 298.0
+
+    def test_ensemble_metrics_from_xgboost_extra(self):
+        """The ensemble row's metrics live on xgboost's
+        ``extra["ensemble_holdout_metrics"]`` — when the training job
+        computes ensemble holdout metrics, those flow through here."""
+        from models.model_service import get_model_metrics
+
+        real_holdouts = {
+            "prophet": {"mape": 11.04, "rmse": 612.0, "mae": 481.0, "r2": 0.872},
+            "arima": {"mape": 5.19, "rmse": 388.0, "mae": 298.0, "r2": 0.943},
+            "xgboost": {"mape": 1.10, "rmse": 142.0, "mae": 89.0, "r2": 0.991},
+        }
+        ensemble_holdout = {
+            "mape": 0.94,
+            "rmse": 119.0,
+            "mae": 71.0,
+            "r2": 0.994,
+        }
+        with (
+            patch(
+                "models.persistence.get_model_metadata",
+                side_effect=self._meta_lookup_with_holdouts(
+                    real_holdouts, ensemble=ensemble_holdout
+                ),
+            ),
+            patch("data.redis_client.redis_get", return_value=_REDIS_PAYLOAD_FAKE_METRICS),
+        ):
+            got = get_model_metrics("PJM")
+
+        # All four ensemble metrics from real holdout, not Redis simulated
+        assert got["ensemble"]["mape"] == 0.94  # was 2.94 simulated
+        assert got["ensemble"]["rmse"] == 119.0  # was 460 simulated
+        assert got["ensemble"]["mae"] == 71.0
+        assert got["ensemble"]["r2"] == 0.994
+
+    def test_legacy_meta_falls_back_to_redis_for_rmse(self):
+        """Backward-compat: a pickle trained before this code lands
+        has only top-level ``meta.mape`` (no holdout_metrics in extra).
+        For those, MAPE is real but RMSE / MAE / R² still supplement
+        from Redis — exactly the pre-PR behavior."""
+        from models.model_service import get_model_metrics
+
+        # Mix: prophet has holdout metrics; arima/xgboost are legacy
+        def _stub(region, model_name):
+            if model_name == "prophet":
+                return _meta_with_holdout(
+                    model_name,
+                    {"mape": 11.04, "rmse": 612.0, "mae": 481.0, "r2": 0.872},
+                )
+            return _meta(model_name, mape={"arima": 5.19, "xgboost": 1.10}.get(model_name))
+
+        with (
+            patch("models.persistence.get_model_metadata", side_effect=_stub),
+            patch("data.redis_client.redis_get", return_value=_REDIS_PAYLOAD_FAKE_METRICS),
+        ):
+            got = get_model_metrics("PJM")
+
+        # prophet: full real metrics from meta extra
+        assert got["prophet"]["rmse"] == 612.0
+        # arima / xgboost: real MAPE from meta, but RMSE supplements from Redis
+        assert got["arima"]["mape"] == 5.19
+        assert got["arima"]["rmse"] == 700  # Redis fallback for legacy meta
+        assert got["xgboost"]["mae"] == 360
 
 
 class TestRealMapeSource:

--- a/tests/unit/test_training_job_holdout_mape.py
+++ b/tests/unit/test_training_job_holdout_mape.py
@@ -1,12 +1,23 @@
-"""Unit tests for the holdout-MAPE flow in jobs/training_job.py.
+"""Unit tests for the holdout-metrics flow in jobs/training_job.py.
 
-Before this change, ``_train_prophet`` and ``_train_arima`` always passed
-``mape=None`` to ``save_model``. Scoring then dropped Prophet/ARIMA from
-the inverse-MAPE blend (because their MAPE was ``None``) and the
-"ensemble" forecast in Redis collapsed to xgboost-only. These tests
-verify the holdout MAPE computation path now feeds real values into
-``save_model``, and gracefully falls back when the holdout window is
-too short or predict raises.
+History:
+- Originally these tests covered ``_holdout_mape_prophet`` /
+  ``_holdout_mape_arima`` returning a float MAPE.
+- Real-metrics work renamed those to ``_holdout_metrics_*`` and
+  changed the return shape to a dict: ``{metrics: {mape, rmse, mae, r2},
+  forecast: ndarray, actual: ndarray}``. The richer payload powers two
+  things downstream:
+    1. Each per-model meta gets ``extra["holdout_metrics"]`` with the
+       full {mape, rmse, mae, r2} dict, so the Models tab can stop
+       supplementing RMSE / MAE / R² from ``_simulate_forecasts`` Redis.
+    2. The ensemble's holdout metric is computed from the SAME
+       predictions (no recomputation, no provenance drift) and stashed
+       in xgboost's meta extra.
+
+These tests verify per-model holdout still returns a finite metric set,
+gracefully skips on short windows, and that ``_train_prophet`` /
+``_train_arima`` thread the holdout payload through to ``save_model``
+with both top-level ``mape`` and ``extra["holdout_metrics"]``.
 """
 
 from __future__ import annotations
@@ -43,12 +54,14 @@ def featured_df_short():
     )
 
 
-class TestHoldoutMapeProphet:
-    def test_returns_mape_when_predict_succeeds(self, featured_df_long, monkeypatch) -> None:
-        """Train + predict succeed → returns finite positive MAPE."""
+class TestHoldoutMetricsProphet:
+    def test_returns_full_metric_set_when_predict_succeeds(
+        self, featured_df_long, monkeypatch
+    ) -> None:
+        """Train + predict succeed → returns ``{metrics, forecast, actual}`` with
+        finite MAPE / RMSE / MAE / R²."""
         import models.prophet_model as prophet_mod
 
-        # Forecast offset by a constant so MAPE is non-zero.
         def _fake_predict(model, df, periods=168):
             actuals = df["demand_mw"].values
             return {"forecast": actuals * 1.05}  # 5% bias → MAPE ≈ 5
@@ -56,22 +69,31 @@ class TestHoldoutMapeProphet:
         monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: object())
         monkeypatch.setattr(prophet_mod, "predict_prophet", _fake_predict)
 
-        from jobs.training_job import _holdout_mape_prophet
+        from jobs.training_job import _holdout_metrics_prophet
 
-        mape = _holdout_mape_prophet(featured_df_long, region="TEST")
-        assert mape is not None
-        assert mape == pytest.approx(5.0, abs=0.5)
+        result = _holdout_metrics_prophet(featured_df_long, region="TEST")
+        assert result is not None
+        assert set(result.keys()) >= {"metrics", "forecast", "actual"}
+        m = result["metrics"]
+        assert set(m.keys()) == {"mape", "rmse", "mae", "r2"}
+        assert m["mape"] == pytest.approx(5.0, abs=0.5)
+        assert m["rmse"] > 0
+        assert m["mae"] > 0
+        # 5% multiplicative bias creates residual variance comparable to the
+        # signal variance — R² lands around ~0.68 in this synthetic setup.
+        # Just assert it's positive (model beats predicting the mean).
+        assert m["r2"] > 0.0
 
     def test_short_window_returns_none(self, featured_df_short, monkeypatch) -> None:
-        """Insufficient data → skip holdout, return None (no spurious MAPE)."""
+        """Insufficient data → skip holdout, return None (no spurious metrics)."""
         import models.prophet_model as prophet_mod
 
         called: list[bool] = []
         monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: called.append(True))
 
-        from jobs.training_job import _holdout_mape_prophet
+        from jobs.training_job import _holdout_metrics_prophet
 
-        assert _holdout_mape_prophet(featured_df_short, region="TEST") is None
+        assert _holdout_metrics_prophet(featured_df_short, region="TEST") is None
         assert called == []  # train should not even be invoked
 
     def test_predict_failure_returns_none(self, featured_df_long, monkeypatch) -> None:
@@ -84,28 +106,29 @@ class TestHoldoutMapeProphet:
         monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: object())
         monkeypatch.setattr(prophet_mod, "predict_prophet", _broken_predict)
 
-        from jobs.training_job import _holdout_mape_prophet
+        from jobs.training_job import _holdout_metrics_prophet
 
-        assert _holdout_mape_prophet(featured_df_long, region="TEST") is None
+        assert _holdout_metrics_prophet(featured_df_long, region="TEST") is None
 
-    def test_non_finite_mape_returns_none(self, featured_df_long, monkeypatch) -> None:
-        """Forecast with zero actuals → MAPE blows up → return None."""
+    def test_non_finite_forecast_returns_none(self, featured_df_long, monkeypatch) -> None:
+        """NaN forecast → return None (don't persist garbage)."""
         import models.prophet_model as prophet_mod
 
         def _fake_predict(model, df, periods=168):
-            # NaN forecast → compute_mape returns NaN
             return {"forecast": np.full(len(df), np.nan)}
 
         monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: object())
         monkeypatch.setattr(prophet_mod, "predict_prophet", _fake_predict)
 
-        from jobs.training_job import _holdout_mape_prophet
+        from jobs.training_job import _holdout_metrics_prophet
 
-        assert _holdout_mape_prophet(featured_df_long, region="TEST") is None
+        assert _holdout_metrics_prophet(featured_df_long, region="TEST") is None
 
 
-class TestHoldoutMapeArima:
-    def test_returns_mape_when_predict_succeeds(self, featured_df_long, monkeypatch) -> None:
+class TestHoldoutMetricsArima:
+    def test_returns_full_metric_set_when_predict_succeeds(
+        self, featured_df_long, monkeypatch
+    ) -> None:
         import models.arima_model as arima_mod
 
         def _fake_predict(model_dict, exog, periods=168):
@@ -115,16 +138,19 @@ class TestHoldoutMapeArima:
         monkeypatch.setattr(arima_mod, "train_arima", lambda df: {"params": []})
         monkeypatch.setattr(arima_mod, "predict_arima", _fake_predict)
 
-        from jobs.training_job import _holdout_mape_arima
+        from jobs.training_job import _holdout_metrics_arima
 
-        mape = _holdout_mape_arima(featured_df_long, region="TEST")
-        assert mape is not None
-        assert mape == pytest.approx(3.0, abs=0.5)
+        result = _holdout_metrics_arima(featured_df_long, region="TEST")
+        assert result is not None
+        assert result["metrics"]["mape"] == pytest.approx(3.0, abs=0.5)
+        # See prophet test for why R² is moderate, not near-1, in this
+        # synthetic setup.
+        assert result["metrics"]["r2"] > 0.0
 
     def test_short_window_returns_none(self, featured_df_short) -> None:
-        from jobs.training_job import _holdout_mape_arima
+        from jobs.training_job import _holdout_metrics_arima
 
-        assert _holdout_mape_arima(featured_df_short, region="TEST") is None
+        assert _holdout_metrics_arima(featured_df_short, region="TEST") is None
 
     def test_predict_failure_returns_none(self, featured_df_long, monkeypatch) -> None:
         import models.arima_model as arima_mod
@@ -135,18 +161,17 @@ class TestHoldoutMapeArima:
         monkeypatch.setattr(arima_mod, "train_arima", lambda df: {"params": []})
         monkeypatch.setattr(arima_mod, "predict_arima", _broken_predict)
 
-        from jobs.training_job import _holdout_mape_arima
+        from jobs.training_job import _holdout_metrics_arima
 
-        assert _holdout_mape_arima(featured_df_long, region="TEST") is None
+        assert _holdout_metrics_arima(featured_df_long, region="TEST") is None
 
 
-class TestTrainPersistsMape:
-    """End-to-end: train_prophet/_train_arima pass real MAPE to save_model.
-
-    This is the key behavior the scoring-side fix relies on — without a
-    real MAPE in the saved metadata, scoring's inverse-MAPE blend has
-    nothing to weight by and falls back to equal weights.
-    """
+class TestTrainPersistsHoldoutMetrics:
+    """End-to-end: ``_train_prophet`` / ``_train_arima`` pass the full
+    holdout-metric dict through to ``save_model`` — both as the
+    top-level ``mape`` (used for inverse-MAPE ensemble weighting) and
+    as ``extra["holdout_metrics"]`` (powers the Models tab's RMSE /
+    MAE / R²)."""
 
     def _make_region_data(self, df) -> object:
         from jobs.phases import RegionData
@@ -158,7 +183,9 @@ class TestTrainPersistsMape:
             featured_df=df,
         )
 
-    def test_prophet_passes_holdout_mape_to_save_model(self, featured_df_long, monkeypatch) -> None:
+    def test_prophet_passes_full_holdout_metrics_to_save_model(
+        self, featured_df_long, monkeypatch
+    ) -> None:
         import models.prophet_model as prophet_mod
 
         monkeypatch.setattr(prophet_mod, "train_prophet", lambda df: object())
@@ -177,18 +204,30 @@ class TestTrainPersistsMape:
             return "v-test"
 
         monkeypatch.setattr("jobs.training_job.save_model", _save_model)
-        # Stub the data hash helper to avoid pulling in the full feature pipeline.
         monkeypatch.setattr("jobs.training_job._compute_data_hash", lambda region_data: "h")
 
-        from jobs.training_job import _train_prophet
+        from jobs.training_job import _holdout_metrics_prophet, _train_prophet
 
-        version = _train_prophet(self._make_region_data(featured_df_long))
+        holdout = _holdout_metrics_prophet(featured_df_long, region="TEST")
+        version = _train_prophet(self._make_region_data(featured_df_long), holdout=holdout)
+
         assert version == "v-test"
         assert captured["model_name"] == "prophet"
+
+        # Top-level mape — drives ensemble weighting at scoring time.
         assert captured["mape"] is not None
         assert captured["mape"] == pytest.approx(4.0, abs=0.5)
 
-    def test_arima_passes_holdout_mape_to_save_model(self, featured_df_long, monkeypatch) -> None:
+        # extra["holdout_metrics"] — drives Models-tab RMSE / MAE / R².
+        extra = captured.get("extra") or {}
+        holdout_in_extra = extra.get("holdout_metrics")
+        assert holdout_in_extra is not None
+        assert set(holdout_in_extra.keys()) == {"mape", "rmse", "mae", "r2"}
+        assert holdout_in_extra["mape"] == pytest.approx(4.0, abs=0.5)
+
+    def test_arima_passes_full_holdout_metrics_to_save_model(
+        self, featured_df_long, monkeypatch
+    ) -> None:
         import models.arima_model as arima_mod
 
         monkeypatch.setattr(arima_mod, "train_arima", lambda df: {"params": []})
@@ -209,10 +248,100 @@ class TestTrainPersistsMape:
         monkeypatch.setattr("jobs.training_job.save_model", _save_model)
         monkeypatch.setattr("jobs.training_job._compute_data_hash", lambda region_data: "h")
 
-        from jobs.training_job import _train_arima
+        from jobs.training_job import _holdout_metrics_arima, _train_arima
 
-        version = _train_arima(self._make_region_data(featured_df_long))
+        holdout = _holdout_metrics_arima(featured_df_long, region="TEST")
+        version = _train_arima(self._make_region_data(featured_df_long), holdout=holdout)
+
         assert version == "v-test"
         assert captured["model_name"] == "arima"
         assert captured["mape"] is not None
         assert captured["mape"] == pytest.approx(4.0, abs=0.5)
+
+        extra = captured.get("extra") or {}
+        holdout_in_extra = extra.get("holdout_metrics")
+        assert holdout_in_extra is not None
+        assert holdout_in_extra["mape"] == pytest.approx(4.0, abs=0.5)
+
+
+class TestEnsembleHoldoutMetrics:
+    """The ensemble's holdout metric is computed from the SAME 168-hour
+    holdout predictions used by each per-model holdout — no separate
+    train, no Redis, no simulation. ``_ensemble_holdout_metrics`` takes
+    the per-model dicts and returns ``(metrics, weights)``.
+    """
+
+    def test_combines_two_models_with_inverse_mape_weights(self) -> None:
+        from jobs.training_job import _ensemble_holdout_metrics
+
+        n = 168
+        actual = np.full(n, 50_000.0)
+        per_model_holdouts = {
+            # 5% over-forecast → mape ≈ 5
+            "prophet": {
+                "metrics": {"mape": 5.0, "rmse": 2500.0, "mae": 2500.0, "r2": 0.0},
+                "forecast": actual * 1.05,
+                "actual": actual,
+            },
+            # 1% over-forecast → mape ≈ 1 (much better)
+            "xgboost": {
+                "metrics": {"mape": 1.0, "rmse": 500.0, "mae": 500.0, "r2": 0.0},
+                "forecast": actual * 1.01,
+                "actual": actual,
+            },
+        }
+        result = _ensemble_holdout_metrics(per_model_holdouts)
+        assert result is not None
+        metrics, weights = result
+
+        # Weights normalize to 1.0
+        assert weights["prophet"] + weights["xgboost"] == pytest.approx(1.0, abs=0.001)
+        # xgboost (1% MAPE) gets ≥ 5× the weight of prophet (5% MAPE)
+        assert weights["xgboost"] > weights["prophet"]
+
+        # Ensemble MAPE is between the worst (5) and the best (1)
+        assert 1.0 < metrics["mape"] < 5.0
+        assert metrics["rmse"] > 0
+        assert metrics["mae"] > 0
+
+    def test_single_model_returns_none(self) -> None:
+        """One model isn't an ensemble — return None so the caller
+        doesn't persist a misleading 'ensemble' metric that's just
+        the lone model under a different name."""
+        from jobs.training_job import _ensemble_holdout_metrics
+
+        n = 168
+        actual = np.full(n, 50_000.0)
+        result = _ensemble_holdout_metrics(
+            {
+                "xgboost": {
+                    "metrics": {"mape": 1.0, "rmse": 500.0, "mae": 500.0, "r2": 0.0},
+                    "forecast": actual * 1.01,
+                    "actual": actual,
+                },
+                "prophet": None,
+                "arima": None,
+            }
+        )
+        assert result is None
+
+    def test_returns_none_when_actuals_mismatch(self) -> None:
+        """If two models report different ``actual`` lengths, something
+        upstream is broken — bail rather than silently misalign."""
+        from jobs.training_job import _ensemble_holdout_metrics
+
+        result = _ensemble_holdout_metrics(
+            {
+                "prophet": {
+                    "metrics": {"mape": 5.0, "rmse": 1.0, "mae": 1.0, "r2": 0.5},
+                    "forecast": np.ones(168),
+                    "actual": np.ones(168),
+                },
+                "xgboost": {
+                    "metrics": {"mape": 2.0, "rmse": 1.0, "mae": 1.0, "r2": 0.5},
+                    "forecast": np.ones(100),
+                    "actual": np.ones(100),
+                },
+            }
+        )
+        assert result is None


### PR DESCRIPTION
## Summary

User asked the integrity question: *are the model performance numbers real or falsified?* Answer was mixed. After PR #77, the **per-model MAPE** for trained BAs was real (read from `meta.json`). Everything else was simulated:

- Per-model RMSE / MAE / R² came from `wattcast:diagnostics:{region}`
- That payload's metrics are computed in `phases.write_diagnostics` → `get_forecasts(region, demand_df)`
- `get_forecasts` → `_load_cached_models` → reads **local disk only** (not GCS), which is empty in production
- → falls through to `_simulate_forecasts`, deterministically seeded by region hash

So in production, every RMSE / MAE / R² and the ensemble MAPE were stable plausible-looking but **simulated** numbers.

This PR replaces the simulation path entirely. The training job now computes all four metrics on the same 168-hour holdout window already used for MAPE, and persists them to GCS where `get_model_metrics` reads them. No more provenance drift between the leaderboard's MAPE and the table's RMSE.

## What landed

**1. Training-job holdout API** (`jobs/training_job.py`)
- Renamed `_holdout_mape_{prophet,arima}` → `_holdout_metrics_*`, return `{metrics: {mape, rmse, mae, r2}, forecast, actual}`
- Added `_holdout_metrics_xgboost` (xgboost also gets a real 168h holdout, was CV-mean MAPE only)
- Added `_ensemble_holdout_metrics` — combines per-model forecasts via inverse-MAPE weights (same formula as production scoring), scores against shared actuals
- `_train_*(region_data, holdout=...)` threads the metric dict into `save_model`'s `extra["holdout_metrics"]`
- `_train_region` orchestrates: compute holdouts → train production models → compute ensemble → `write_extra_to_meta` to attach ensemble metrics + weights to xgboost's meta

**2. Persistence helper** (`models/persistence.py`)
- New `write_extra_to_meta(region, model_name, version, key_updates)` deep-merges keys into an existing meta blob's `extra`. Avoids inventing a separate "ensemble meta" blob (which would need its own `latest.json` plumbing).

**3. Service path** (`models/model_service.py`)
- `get_model_metrics` resolution is now:
  1. `meta.extra["holdout_metrics"]` per model
  2. Top-level `meta.mape` (legacy fallback for pre-PR pickles)
  3. `xgboost.extra["ensemble_holdout_metrics"]` for the ensemble row
  4. Redis diagnostics — only fills fields the meta path didn't provide
  5. Local pickle (dev mode), then hardcoded simulated baseline

A viewer never sees a simulated value when a real one exists.

## What the user sees after the next training run

| Metric | Before | After |
|---|---|---|
| Per-model MAPE | Real (PR #77) | Real |
| Per-model RMSE / MAE / R² | Simulated | **Real** |
| Ensemble MAPE | Simulated | **Real** |
| Ensemble RMSE / MAE / R² | Simulated | **Real** |

Pre-PR pickles degrade gracefully: real MAPE from meta, simulated supplement from Redis. After the next 04:00 UTC run all 51 BAs will have full real metrics.

## Test plan

- [x] `tests/unit/test_training_job_holdout_mape.py` — 12 tests (per-model holdout returns full metric set, short-window / predict-failure / non-finite handling, end-to-end persistence of `extra["holdout_metrics"]`, ensemble combination + weight math)
- [x] `tests/unit/test_models_tab_consistency.py` — 3 new tests for meta-extra-first resolution + ensemble metrics from xgboost extra + legacy fallback
- [x] `tests/unit/test_model_persistence.py` — 3 new tests for `write_extra_to_meta` (merge, missing blob, GCS-disabled)
- [x] Full unit suite: 1621 passed
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)