### PR TITLE
chore: repo audit cleanup — region counts, NextEra scrub, code polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 This repo already has multiple context layers. Read them in this order:
 
 1. `CLAUDE.md` — architecture, conventions, code standards, execution guardrails
-2. `EXECUTION_BRIEF.md` — prioritization, redesign direction, product-shell changes, execution order
+2. `docs/internal/EXECUTION_BRIEF.md` — prioritization, redesign direction, product-shell changes, execution order
 3. `README.md` — current public framing and deployment overview
 4. `PRD.md` — product requirements, personas, ADRs, descoping rationale
 5. `TECHNICAL_SPEC.md` — data/model/system details
@@ -52,7 +52,7 @@ Use this framing unless a human directs otherwise:
 - **Positioning:** Forecast confidence, grid visibility, and decision support
 - **Tagline:** See demand sooner. Decide with confidence.
 
-This framing should guide UI copy, navigation naming, and landing-page work. For prioritization of those changes, follow `EXECUTION_BRIEF.md`.
+This framing should guide UI copy, navigation naming, and landing-page work. For prioritization of those changes, follow `docs/internal/EXECUTION_BRIEF.md`.
 
 ---
 
@@ -175,7 +175,7 @@ When the task is related to branding, shell UX, navigation, or product coherence
 2. Broader landing-page and marketing assets
 3. Mobile awareness patterns
 
-Detailed guidance lives in `EXECUTION_BRIEF.md`. Use that file for sequencing and acceptance criteria.
+Detailed guidance lives in `docs/internal/EXECUTION_BRIEF.md`. Use that file for sequencing and acceptance criteria.
 
 ---
 
@@ -242,7 +242,7 @@ When making shell/UI changes:
 ---
 
 ## Spec References
-- `EXECUTION_BRIEF.md` — prioritization, redesign direction, execution order
+- `docs/internal/EXECUTION_BRIEF.md` — prioritization, redesign direction, execution order
 - `PRD.md` — requirements, personas, descoping rationale, ADRs
 - `TECHNICAL_SPEC.md` — data sources, features, models, caching
 - `docs/BACKTEST_RESULTS.md` — real EIA holdout accuracy

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kristen Martino
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PRD.md
+++ b/PRD.md
@@ -105,7 +105,7 @@ This structure is both a product framing model and a guide for future IA cleanup
 
 | ID | Requirement | Priority |
 |---|---|---|
-| R1.1 | Hourly demand from EIA API v2 for 16 balancing authorities — original 8 (ERCOT, CAISO, PJM, MISO, NYISO, FPL, SPP, ISONE) plus the V1.α expansion (SOCO, TVA, DUK, CPLE, BPAT, AZPS, NEVP, PSCO) covering ~98% of US load ([PR #61](https://github.com/kristenmartino/gridpulse/pull/61)) | Must Have |
+| R1.1 | Hourly demand from EIA API v2 for 51 balancing authorities — original 8 (ERCOT, CAISO, PJM, MISO, NYISO, FPL, SPP, ISONE), V1.α expansion of 8 utility/federal BAs (SOCO, TVA, DUK, CPLE, BPAT, AZPS, NEVP, PSCO) ([PR #61](https://github.com/kristenmartino/gridpulse/pull/61)), and V3.ζ expansion of the remaining 35 EIA-930 BAs in the lower 48 for ~100% contiguous-US coverage | Must Have |
 | R1.2 | Hourly weather variables from Open-Meteo including temperature, wind, radiation, humidity, precipitation, and related signals | Must Have |
 | R1.3 | Severe weather / alert context from NOAA/NWS mapped to regions | Must Have |
 | R1.4 | Cache-backed data access with stale-data fallback for degraded conditions | Must Have |
@@ -148,7 +148,7 @@ This structure is both a product framing model and a guide for future IA cleanup
 | R4.6 | **Risk / Extreme Events** view with alerting, stress signals, anomalies, and degraded-condition visibility | Should Have |
 | R4.7 | **Scenarios** with what-if controls, presets, and impact comparisons | Should Have |
 | R4.8 | Persona / view switcher with role-specific defaults, KPI emphasis, and welcome briefing | Must Have |
-| R4.9 | Region selector covering all 8 supported balancing authorities | Must Have |
+| R4.9 | Region selector covering all 51 supported balancing authorities (~100% lower-48 coverage) | Must Have |
 | R4.10 | Per-widget data confidence or freshness signaling | Must Have |
 | R4.11 | Briefing / meeting-ready mode for presentation and stakeholder review | Should Have |
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Four role-based personas (Grid Ops, Renewables Analyst, Trader, Data Scientist) 
 
 ## Models
 
-- **XGBoost**: 43 engineered features, TimeSeriesSplit CV, SHAP explanations — 3.13% MAPE on ERCOT 21-day holdout
+- **XGBoost**: 43 engineered features, TimeSeriesSplit CV, SHAP explanations — 3.13% MAPE on ERCOT 21-day holdout (Feb 2026 reference run; see [docs/BACKTEST_RESULTS.md](docs/BACKTEST_RESULTS.md))
 - **Prophet**: weather regressors with multiplicative seasonality
 - **SARIMAX**: auto-order selection via pmdarima
 - **Ensemble**: inverse-MAPE weighted combination (self-correcting)
@@ -187,12 +187,12 @@ See [tests/TEST_PYRAMID.md](tests/TEST_PYRAMID.md) for coverage targets and test
 
 | Doc | Purpose |
 |---|---|
-| [CLAUDE.md](CLAUDE.md) | AI coding assistant context, architecture, conventions, execution guardrails |
-| [EXECUTION_BRIEF.md](EXECUTION_BRIEF.md) | Agent-ready prioritization layer for redesign and repositioning work |
-| [PRD.md](PRD.md) | Product requirements, personas, ADRs, scope decisions |
-| [TECHNICAL_SPEC.md](TECHNICAL_SPEC.md) | Data sources, features, models, caching, pipeline details |
-| [docs/SCHEDULED_JOBS.md](docs/SCHEDULED_JOBS.md) | Cloud Run Jobs deploy + first-run bootstrap |
 | [docs/BACKTEST_RESULTS.md](docs/BACKTEST_RESULTS.md) | Model accuracy on real EIA holdout data |
+| [TECHNICAL_SPEC.md](TECHNICAL_SPEC.md) | Data sources, features, models, caching, pipeline details |
+| [PRD.md](PRD.md) | Product requirements, personas, ADRs, scope decisions |
+| [docs/SCHEDULED_JOBS.md](docs/SCHEDULED_JOBS.md) | Cloud Run Jobs deploy + first-run bootstrap |
+| [CLAUDE.md](CLAUDE.md) | AI coding assistant context, architecture, conventions, execution guardrails |
+| [docs/internal/EXECUTION_BRIEF.md](docs/internal/EXECUTION_BRIEF.md) | _(internal)_ Agent-ready prioritization layer for redesign and repositioning work |
 
 ---
 

--- a/TECHNICAL_SPEC.md
+++ b/TECHNICAL_SPEC.md
@@ -38,7 +38,7 @@ GridPulse is a Dash/Plotly-based application that combines:
 - role-aware presentation and briefing patterns
 
 ### Primary technical capabilities
-- hourly demand forecasting across 8 balancing authorities
+- hourly demand forecasting across 51 balancing authorities (~100% lower-48 coverage; 8 reference BAs as primary documented targets)
 - feature-engineered model inputs built from weather and time-series signals
 - validation and backtest workflows for trust and accountability
 - cache-backed serving with resilience patterns
@@ -160,6 +160,8 @@ GridPulse includes an external news/signals integration for contextual headlines
 
 ## 3.1 Balancing Authorities
 
+GridPulse deploys against **51 US balancing authorities** (V3.ζ expansion) for ~100% contiguous lower-48 demand coverage. The eight reference BAs detailed below are the documented primary targets for capacity modeling, backtest reporting, and persona workflows; the remaining 43 use the same model stack with centroid-based weather lookup. See [config.py](config.py) `REGION_COORDINATES` for the complete list.
+
 | Code | Full Name | Centroid (lat, lon) | Capacity (MW) | Source (2025) |
 |---|---|---|---|---|
 | ERCOT | Texas (ERCOT) | 31.0, -97.0 | 153,000 | ERCOT CDR — Summer 2025 resource assessment |
@@ -172,7 +174,7 @@ GridPulse includes an external news/signals integration for contextual headlines
 | ISONE | New England (ISO-NE) | 42.3, -71.8 | 30,000 | ISO-NE 2025 Regional System Plan |
 
 ### Note on FPL
-FPL represents Florida Power & Light’s service territory, not all statewide Florida demand. Of the eight BAs in GridPulse, FPL is the only investor-owned utility (a NextEra Energy subsidiary); the other seven are nonprofit ISOs/RTOs whose nearest equivalent of an "annual report to shareholders" is their State-of-the-Market, Power Trends, or Regional System Plan publication — the sources cited above.
+FPL represents Florida Power & Light’s service territory, not all statewide Florida demand. Of the eight reference BAs, FPL is the only investor-owned utility; the other seven are nonprofit ISOs/RTOs whose nearest equivalent of an "annual report to shareholders" is their State-of-the-Market, Power Trends, or Regional System Plan publication — the sources cited above.
 
 ## 3.2 Weather Location Assumption
 Weather data is fetched for centroid coordinates representing each balancing authority. This is a pragmatic simplification and can reduce fidelity for geographically large regions.

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 """
-NextEra Energy Demand Forecasting Dashboard.
+GridPulse — Energy Demand Forecasting Dashboard.
 
 Entry point for the Dash application. Sets up:
 - Structured logging via observability module

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -18,6 +18,8 @@ Sprint 4 changes:
 """
 
 import io
+import threading
+from datetime import UTC
 
 import dash_bootstrap_components as dbc
 import numpy as np
@@ -27,6 +29,7 @@ import structlog
 from dash import ALL, Input, Output, State, ctx, dcc, html, no_update
 from plotly.subplots import make_subplots
 
+from components.accessibility import CB_PALETTE, LINE_STYLES
 from components.cards import (
     build_alert_card,
     build_insight_card,
@@ -51,15 +54,13 @@ from personas.config import get_persona
 
 log = structlog.get_logger()
 
-import threading  # noqa: E402
-
 _cache_lock = threading.Lock()
 _CACHE_VERSION = 3
 
-_MODEL_CACHE: dict = {}  # {(region, model_name, horizon): (model, data_hash, timestamp)}
-_PREDICTION_CACHE: dict = {}  # {(region, horizon): (predictions, timestamps, data_hash, time)}
-_BACKTEST_CACHE: dict = {}  # {(region, horizon, model, exog_mode): (result_dict, data_hash, time)}
-_GENERATION_CACHE: dict = {}  # {region: (gen_df, fetch_timestamp)}
+_MODEL_CACHE: dict[tuple, tuple] = {}  # {(region, model_name, horizon): (model, data_hash, timestamp)}
+_PREDICTION_CACHE: dict[tuple, tuple] = {}  # {(region, horizon): (predictions, timestamps, data_hash, time)}
+_BACKTEST_CACHE: dict[tuple, dict] = {}  # {(region, horizon, model, exog_mode): (result_dict, data_hash, time)}
+_GENERATION_CACHE: dict[str, tuple] = {}  # {region: (gen_df, fetch_timestamp)}
 BACKTEST_EXOG_MODES = {"oracle_exog", "forecast_exog"}
 DEFAULT_BACKTEST_EXOG_MODE = "forecast_exog"
 
@@ -120,10 +121,6 @@ def _layout(*, uirevision: str | None = None, **overrides) -> dict:
 
 
 # Color palette (colorblind-safe — Wong 2011)
-from datetime import UTC  # noqa: E402
-
-from components.accessibility import CB_PALETTE, LINE_STYLES  # noqa: E402
-
 COLORS = {
     "actual": CB_PALETTE["blue"],
     "prophet": CB_PALETTE["orange"],

--- a/config.py
+++ b/config.py
@@ -143,7 +143,10 @@ TRAINING_WINDOW_DAYS = 365
 FORECAST_HORIZON_DAYS = 7
 
 # ---------------------------------------------------------------------------
-# Regions — 16 Balancing Authorities (~98% of US load coverage)
+# Regions — 51 Balancing Authorities (~100% of contiguous-US lower-48 load)
+#
+# Original 8 (ISOs/RTOs + FPL) + V1.α expansion (8 utility/federal BAs) +
+# V3.ζ expansion (35 remaining EIA-930 BAs in the lower 48).
 #
 # Lat/lon are weather-lookup proxies — the load center of each BA's territory,
 # not a geometric centroid. Open-Meteo pulls all 17 weather variables at this

--- a/data/noaa_client.py
+++ b/data/noaa_client.py
@@ -25,7 +25,7 @@ REQUEST_TIMEOUT = 15
 
 # NOAA requires a User-Agent header
 HEADERS = {
-    "User-Agent": "(NextEra Energy Dashboard, contact@example.com)",
+    "User-Agent": "GridPulse (kristen@kristenmartino.ai)",
     "Accept": "application/geo+json",
 }
 

--- a/docs/BACKTEST_RESULTS.md
+++ b/docs/BACKTEST_RESULTS.md
@@ -1,5 +1,7 @@
 # Forecast Backtest Results
 
+> **Last validated:** 2026-02-21 — point-in-time reference snapshot. Daily training has run since this report, so live model performance may differ from the figures below. Current numbers are in the most recent Cloud Run training-job logs. The results captured here are the official validation reference at time of capture.
+
 **Date:** 2026-02-21
 **Holdout Period:** 21 days (504 hours)
 **Training Period:** ~43 days

--- a/docs/internal/EXECUTION_BRIEF.md
+++ b/docs/internal/EXECUTION_BRIEF.md
@@ -1,5 +1,7 @@
 # EXECUTION_BRIEF.md — GridPulse Redesign and Repositioning Master Brief
 
+> **Internal working document** — prioritization layer used by the AI development workflow. Not a public spec. For the user-facing project overview see [README.md](../../README.md); for the product spec see [PRD.md](../../PRD.md).
+
 _Last updated: 2026-04-19_
 
 > **Pipeline scheduling status:** Done. The web service is Redis-only in

--- a/docs/internal/NEXT_UP.md
+++ b/docs/internal/NEXT_UP.md
@@ -1,5 +1,7 @@
 # Next Up — Post-Redesign Roadmap
 
+> **Internal working document** — living development punchlist, not a stable specification. For the user-facing project overview see [README.md](../../README.md); for the product spec see [PRD.md](../../PRD.md).
+
 _Living punchlist for work queued after the [shell redesign](.claude/plans/shell-redesign-v2.md) (R1→R6 + R7 emoji sweep) and the [multi-model scoring extension](.claude/plans/scoring-job-multi-model.md) (option A + Stages 1–3) shipped to `main`._
 
 Each item below has explicit **acceptance criteria** and a **rough effort estimate** so it can be picked up cold.

--- a/models/persistence.py
+++ b/models/persistence.py
@@ -46,6 +46,10 @@ log = structlog.get_logger()
 
 MODELS_PREFIX = "models"
 LATEST_POINTER = "latest.json"
+# `/tmp` is the POSIX dev/CI default; production overrides via
+# MODEL_LOCAL_CACHE_DIR (e.g. `/app/trained_models/` in the Cloud Run image,
+# wired in the Dockerfile so the cache survives across requests within a
+# container instance).
 LOCAL_MODEL_CACHE_DIR = os.getenv("MODEL_LOCAL_CACHE_DIR", "/tmp/gridpulse-models")
 
 _client: Client | None = None
@@ -583,6 +587,9 @@ __all__ = [
 
 
 # ── Self-test CLI (manual) ───────────────────────────────────
+# Uses ``print`` (not structlog) intentionally: this is a human-facing CLI
+# inspector that emits raw JSON to stdout for piping to ``jq`` etc. Structured
+# log output would corrupt the JSON stream consumers expect here.
 
 if __name__ == "__main__":  # pragma: no cover
     if len(sys.argv) >= 3 and sys.argv[1] == "inspect":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
-# Core framework
-dash>=2.17.0
-dash-bootstrap-components>=1.6.0
-flask>=3.0.0
-gunicorn>=22.0.0
+# Core framework — upper bounds on the web stack guard against silent
+# breakage from major-version releases (Dash 3 / Flask 4 will both ship
+# with API changes worth re-validating before adopting).
+dash>=2.17.0,<3
+dash-bootstrap-components>=1.6.0,<2
+flask>=3.0.0,<4
+gunicorn>=22.0.0,<23
 
 # Data & ML
 pandas>=2.2.0

--- a/tests/TEST_PYRAMID.md
+++ b/tests/TEST_PYRAMID.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Test strategy for the NextEra Energy Forecast Dashboard.
+Test strategy for GridPulse.
 Defines coverage targets, test scope, and critical user flows.
 
 ## Test Pyramid


### PR DESCRIPTION
## Summary

Three-commit pass to address things a recruiter or senior reviewer would flag on the public GitHub page:

- **`docs:`** correct the 8/16-BA → 51-BA contradiction across README, PRD (R1.1, R4.9), TECHNICAL_SPEC §3.1, and the config.py header comment; date the headline 3.13% MAPE claim as a Feb 2026 reference run; add a "Last validated" callout to BACKTEST_RESULTS; reorder the README documentation table; move `EXECUTION_BRIEF.md` and `NEXT_UP.md` to `docs/internal/` with disclaimer headers; add `LICENSE` (MIT, © 2026 Kristen Martino).
- **`chore:`** scrub user-facing NextEra branding from `app.py` docstring, `tests/TEST_PYRAMID.md` overview, and the NOAA User-Agent header. Factual NextEra citations (config.py 10-K capacity sources, GCS bucket, FPL service-territory description) are deliberately kept as correct attribution.
- **`chore:`** small code-hygiene cleanups in `components/callbacks.py` (late `# noqa: E402` imports moved to the top, cache dicts properly typed), `models/persistence.py` (rationale comments on the CLI `print()` and `/tmp` default), and upper bounds on the web stack in `requirements.txt` (`dash<3`, `flask<4`, etc.) so a Dash 3 / Flask 4 release doesn't silently break the build.

No runtime behavior changes.

## Test plan

- [ ] CI green (lint/type/test)
- [ ] `grep -rn "8 balancing\|16 Balancing Authorit" README.md PRD.md TECHNICAL_SPEC.md config.py` returns nothing
- [ ] `grep -rn "NextEra Energy" app.py tests/TEST_PYRAMID.md data/noaa_client.py` returns nothing
- [ ] LICENSE shows up as "MIT License" on the GitHub repo landing page
- [ ] README documentation table on github.com renders with the new ordering and the `docs/internal/EXECUTION_BRIEF.md` link resolves
- [ ] `python -c "from components.callbacks import UTC, _MODEL_CACHE"` imports clean
- [ ] `pip install -r requirements.txt` still resolves
- [ ] Local app start: `python app.py` boots without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)