### PR TITLE
docs(roadmap): V4 audience inflection + callbacks.py decomposition plan

### DIFF
--- a/docs/internal/CALLBACKS_DECOMPOSITION_PLAN.md
+++ b/docs/internal/CALLBACKS_DECOMPOSITION_PLAN.md
@@ -1,0 +1,108 @@
+# `callbacks.py` decomposition plan
+
+_Drafted 2026-05-06. Targets GitHub issue #87. Execution scoped for a single fresh-focus session._
+
+## Why this is queued, not shipped
+
+Tonight's session shipped 13 PRs across V3.η, real-metrics, training parallelism, portfolio updates. Attempting a 7,167-line refactor at end-of-day with 40 import-site dependencies is the move that ships a subtle bug nobody catches for a week. Deferring to fresh focus is the senior call. This document captures the design so tomorrow's session is execution, not planning.
+
+## Current state
+
+- `components/callbacks.py` — 7,167 lines
+- `register_callbacks(app)` — 2,013 lines (lines 2089–4100ish)
+- 64 module-level functions
+- ~40 symbols imported by `app.py` and `tests/`
+
+## Target structure
+
+A `components/callbacks/` package replaces the single file. Public import surface unchanged via re-export in `__init__.py`.
+
+```
+components/
+  callbacks/
+    __init__.py        # re-exports everything for backward compat
+                       # owns top-level register_callbacks(app) orchestrator
+    shared.py          # caches, constants, color tokens, _layout helper,
+                       # _compute_data_hash, _is_real_positive, _empty_figure,
+                       # _format_metric, _latest_real_demand, _MAP_* constants,
+                       # PLOT_LAYOUT, COLORS, _EIA_FUEL_MAP
+    overview.py        # _build_overview_* helpers + register_overview_callbacks
+    us_grid.py         # _build_us_grid_*, _collect_us_grid_region_data,
+                       # _load_ba_polygons + register_us_grid_callbacks
+    forecast.py        # _run_forecast_outlook (367 lines!), _confidence_*,
+                       # _collect_backtest_residuals, _empirical_interval_*,
+                       # _build_forecast_exog_fold, _add_confidence_bands,
+                       # _add_trailing_actuals, _create_future_features,
+                       # _outlook_tab_from_redis + register_forecast_callbacks
+    backtest.py        # _run_backtest_for_horizon (308 lines),
+                       # _predict_single_fold, _ensemble_fold,
+                       # _backtest_tab_from_redis
+                       # (hidden tab but still called via v1 fallback)
+    models.py          # _models_tab_from_redis (206 lines),
+                       # _get_feature_importance
+    alerts.py          # _alerts_tab_from_redis (180 lines)
+    generation.py      # _fetch_generation_cached, _generation_tab_from_redis
+                       # (hidden tab; still called via v1 fallback)
+    weather.py         # _weather_tab_from_redis (hidden tab)
+    data.py            # _load_data_from_redis (shared data path)
+```
+
+## File-allocation principles
+
+- **Shared.py is for code with no tab affinity** — caches, layout helpers, evaluation utilities, design tokens. If a helper is used by exactly one tab, it goes in that tab's module.
+- **Hidden-tab modules still exist** — `backtest.py`, `generation.py`, `weather.py`, `scenarios.py` (if present). The tabs are removed from the visible IA per V2.1, but the logic is still called via the v1-inline-compute fallback path and is tested.
+- **Each tab module exports a `register_<tab>_callbacks(app)`** — the per-tab portion of the current 2K-line `register_callbacks`. The top-level orchestrator calls each in sequence.
+- **No tab module imports from another tab module.** Cross-tab needs go through `shared.py`. Prevents circular imports.
+- **`__init__.py` re-exports every public symbol** that the test suite or `app.py` imports today. Backward-compat shim. No test or app code needs to change.
+
+## Risks to plan around
+
+1. **Circular imports.** Risk: tab module A imports from tab module B because they share a helper. Mitigation: anything shared between tabs goes in `shared.py`. The discipline: if you're about to write `from components.callbacks.overview import X` inside `forecast.py`, the answer is no — promote X to `shared.py` instead.
+
+2. **The 2,013-line `register_callbacks`.** Splitting this is the highest-risk step. The callbacks reference module-level helpers; if those helpers moved to per-tab modules, the imports inside the closure functions need updating too. Mitigation: do this AFTER the helper-extraction step, as the second commit in the PR. Each step's tests run independently.
+
+3. **`from components.callbacks import X` import sites.** 40 known sites. Risk: a private helper that was incidentally importable is no longer re-exported. Mitigation: `__init__.py` does `from .shared import *; from .overview import *; ...` so all public symbols flow through. Then run the full test suite — any `ImportError` is a missing re-export.
+
+4. **`app.py:179` imports `_BACKTEST_CACHE, _MODEL_CACHE, _PREDICTION_CACHE` for the `/health` endpoint.** These caches must live in `shared.py` and be re-exported. They're module-level singletons used across tabs.
+
+## Execution checklist
+
+1. Create `components/callbacks/` directory with empty `__init__.py`
+2. Create `shared.py`. Move:
+   - All module-level constants (`_CACHE_VERSION`, caches, `PLOT_LAYOUT`, `COLORS`, `_EIA_FUEL_MAP`, `BACKTEST_EXOG_MODES`, `_STRESS_RELIABLE_CEILING`, `_MAP_*`)
+   - Cross-cutting helpers (`_layout`, `_compute_data_hash`, `_empty_figure`, `_is_real_positive`, `_format_metric`, `_latest_real_demand`)
+   - `_cache_lock`
+3. `__init__.py` does `from .shared import *`. Run tests. Fix any missing re-exports.
+4. Create `us_grid.py`. Move all `_build_us_grid_*` helpers + `_collect_us_grid_region_data` + `_load_ba_polygons` + `_build_us_grid_choropleth`. Inside `us_grid.py`, replace any reference to a moved helper with `from .shared import X`.
+5. `__init__.py` adds `from .us_grid import *`. Run tests.
+6. Repeat for each remaining tab: `models`, `alerts`, `overview`, `forecast`, `backtest`, `generation`, `weather`, `data`.
+7. After all helpers are extracted, callbacks.py is reduced to just `register_callbacks(app)` (~2K lines). Now split that function:
+   - Each tab gets a `register_<tab>_callbacks(app)` function in its module
+   - The top-level `register_callbacks(app)` in `__init__.py` calls each in sequence
+   - Inner `@app.callback` decorators move with their tab
+8. Delete the original `components/callbacks.py` file (its contents are now in the package).
+9. Run full test suite. Target: 1688 passing, no behavioral changes.
+10. Run `app.py` locally, click each visible tab, verify no console errors.
+
+## Acceptance
+
+- [ ] No file in `components/callbacks/` over ~800 lines
+- [ ] `__init__.py` is a thin orchestrator < 100 lines
+- [ ] All existing tests pass without modification (no `from components.callbacks import` line is updated in tests)
+- [ ] App boots locally, every visible tab renders, no console errors
+- [ ] `ruff check` + `ruff format --check` clean
+- [ ] `app.py:179` (`from components.callbacks import _BACKTEST_CACHE, _MODEL_CACHE, _PREDICTION_CACHE`) still works without modification
+
+## Estimated effort
+
+- Helper extraction: 2–3 hours of careful work
+- `register_callbacks` split: 1–2 hours
+- Test + iterate: 1 hour
+- **Total: half-day of focused work**, single PR
+
+## What's intentionally out of scope
+
+- **No behavior changes.** Pure code motion.
+- **No new tests.** The existing 1688 tests are the safety net.
+- **No callback signature changes.** All `@app.callback` decorators preserved.
+- **No `dash_bootstrap_components` or `dash` version bumps.**

--- a/docs/internal/NEXT_UP.md
+++ b/docs/internal/NEXT_UP.md
@@ -390,3 +390,44 @@ V3 was scoped on 2026-05-01. See §V3 above for the full plan per item. Recommen
 3. ~~**V3.β** Real BA-polygon choropleth~~ — ✅ shipped 2026-05-02
 4. **V3.γ** Hawaii coverage (3–5 days)
 5. **V3.δ** Multi-tenant — deferred
+
+---
+
+## V4 — Audience inflection point
+
+Open question (2026-05-06): the six-month audience for GridPulse isn't fixed. Two coherent futures, each with a different gap-list. This section makes the choice explicit so it's a decision rather than implicit drift.
+
+### Path A — Portfolio-grade complete
+
+**Audience**: recruiters, hiring managers, technical reviewers evaluating a portfolio piece. They click through the live URL, scan the GitHub repo, possibly read the case study.
+
+**State after the V3.ζ / V3.η / real-metrics work**: approximately done. The remaining backlog is the polish tail (#21 URL state refinements, #25 briefing background callback, #26 chart polish) plus #87 (`callbacks.py` decomposition) plus #91 (`wattcast:` Redis namespace rename). All are quality-of-life improvements; none changes what the project demonstrates.
+
+**Time to "complete" if this is the audience**: ~1–2 days of focused work.
+
+### Path B — Real production system
+
+**Audience**: an energy operator, analytics team, or trading desk actually using GridPulse for daily decisions. The current state is "could be real" not "is real."
+
+**Gap-list (in honest priority order):**
+
+1. **Model drift monitoring** — holdout metrics are training-time only. No continuous "this model's MAPE is degrading vs live actuals" loop. Without this, the inverse-MAPE ensemble weights become stale and the "real holdout metrics" claim becomes "real *when last trained*." Effort: ~1 week for scoring-job side comparison + alerting on drift threshold.
+2. **Observability infrastructure** — structured logs exist; no metrics dashboard for the data pipeline itself, no alerting on training-job failures or scoring-job staleness, no error-budget framework. Effort: ~3–5 days for Cloud Monitoring dashboards + alert policies + runbook.
+3. **Authentication + multi-tenant** — currently anonymous public read. No tenant scoping on Redis writes, no per-user state, no rate limiting. Effort: ~2 weeks (Workforce Identity Federation or Identity Platform + auth-gated callbacks + Redis namespacing + rate limiter).
+4. **API surface** — currently visualization only. A serious operator wants `GET /v1/forecast/{region}/{horizon}` to feed their own pipelines. Effort: ~1 week (FastAPI or extending Flask routes + OpenAPI spec + auth + rate limits).
+5. **Alerting beyond UI badges** — extreme-event detection exists in-app; no email/Slack/PagerDuty webhook for "your region just crossed the stress threshold." Effort: ~2–3 days for SNS or equivalent + subscription management.
+6. **Disaster-recovery story** — no backup strategy for GCS pickles, no Redis failover plan, no documented incident-response runbook. Effort: ~1 week for backup automation + DR runbook + first tabletop exercise.
+7. **Data quality monitoring** — `validate_dataframe` exists for ad-hoc checks; no continuous data-quality SLA against EIA / Open-Meteo / NOAA upstream. Effort: ~3 days for quality dashboards + alerts.
+8. **Cost monitoring** — Cloud Run + Memorystore + GCS bills grow with usage; no budget alerts or cost-attribution by region. Effort: ~1 day for budget configuration.
+
+**Time to "production-real" if this is the audience**: ~6–8 weeks of focused work, in priority order.
+
+### Recommendation
+
+**The choice isn't binary.** Path A is approximately one week of cleanup away — it can be closed out independent of which long-term direction this goes. Path B is a real investment that only makes sense if there's a real user (or a clear path to one) on the other side.
+
+**Right next moves regardless of which path:**
+- Close out the Path A polish tail (1–2 days)
+- Pick **one** Path B item as a proof-of-concept that the production-system arc is achievable — model drift monitoring is the highest-leverage candidate because it directly extends the V3.η / real-metrics integrity work that's the project's distinguishing strength
+
+**Defer until a real user signal arrives**: items 3–8 of Path B. They're real work but optionality-cost is low — they can be added in priority order whenever a real user surfaces.


### PR DESCRIPTION
Two doc additions to make decisions explicit rather than implicit drift.

## V4 — audience inflection (NEXT_UP.md)

Surfaces the question of GridPulse's 6-month direction:
- **Path A (portfolio-grade complete)** — ~1-2 days from done. Audience: recruiters, technical reviewers.
- **Path B (real production system)** — ~6-8 weeks if pursued in full. Audience: an energy operator/analytics team actually using GridPulse for daily decisions.

For Path B, the gap-list is honest and priority-ordered: drift monitoring → observability → auth → API → alerting → DR → data quality → cost monitoring. Recommendation in the doc: close Path A polish tail regardless, pick ONE Path B item as proof-of-concept that the production arc is achievable (model drift monitoring is the highest-leverage choice because it directly extends the V3.η real-metrics integrity work), defer items 3-8 until a real user signal arrives.

## Decomposition plan (CALLBACKS_DECOMPOSITION_PLAN.md)

Issue #87 (callbacks.py = 7,167 lines, register_callbacks = 2,013 lines) is real tech debt but attempting the refactor at end-of-day with 40 import-site dependencies is the move that ships subtle breakage nobody catches for a week. This doc captures the file-allocation design (`components/callbacks/` package with shared.py + per-tab modules), execution order, risks (circular imports, register_callbacks split, import-surface preservation), and acceptance criteria. Tomorrow's session is execution, not planning.

## Why two doc-only changes in one PR

Both are decision-surfacing: the V4 section makes the audience question visible; the decomposition plan makes the refactor's scope visible. Bundled because they're the same kind of work (sketch-the-decision-before-executing) and same audience (the next agent / human picking up the project).

## Test plan

Doc-only. No code touched. All 1688 tests still pass.

🤖 Generated with Claude Code