### PR TITLE
refactor(callbacks): extract US Grid tab helpers to _callbacks_us_grid.py

### DIFF
--- a/components/_callbacks_shared.py
+++ b/components/_callbacks_shared.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 
 import threading
 
+import numpy as np
+
 from components.accessibility import CB_PALETTE
 
 # ── Cache state ──────────────────────────────────────────────────────
@@ -151,6 +153,48 @@ _MODEL_BAND_COLORS = {
 }
 
 
+# ── Demand-series helpers ────────────────────────────────────────────
+
+
+def _latest_real_demand(values, *, offset: int = 0):
+    """Return the most recent real demand reading from a list / Series.
+
+    Walks backward and returns the first value that is finite (not NaN
+    or inf) and strictly positive. ``offset=0`` finds "now"; ``offset=24``
+    finds "24 hours ago" while still skipping any NaN / zero rows that
+    fall on the chosen position — so a NaN spike doesn't silently shift
+    a trend baseline.
+
+    Returns ``None`` when no usable reading exists in the window — the
+    caller should render an ``"—"`` placeholder rather than a numeric.
+
+    Cross-tab helper: consumed by both the Overview hero chart and the
+    US Grid card-grid collector. Lives in shared because both tabs
+    depend on the same NaN-guard semantics.
+    """
+    if values is None:
+        return None
+    try:
+        n = len(values)
+    except TypeError:
+        return None
+    if n == 0:
+        return None
+    skipped = 0
+    for i in range(n - 1, -1, -1):
+        try:
+            v = float(values.iloc[i] if hasattr(values, "iloc") else values[i])
+        except (TypeError, ValueError):
+            continue
+        if not np.isfinite(v) or v <= 0:
+            continue
+        if skipped < offset:
+            skipped += 1
+            continue
+        return v
+    return None
+
+
 # ── Stress / reliability tokens ──────────────────────────────────────
 #
 # Stress ratios above this threshold are treated as structural import-
@@ -224,6 +268,8 @@ __all__ = [
     # Color palette
     "COLORS",
     "_MODEL_BAND_COLORS",
+    # Demand-series helpers
+    "_latest_real_demand",
     # Stress thresholds
     "_STRESS_RELIABLE_CEILING",
     # Map tokens

--- a/components/_callbacks_us_grid.py
+++ b/components/_callbacks_us_grid.py
@@ -1,0 +1,720 @@
+"""US Grid tab helpers — extracted from ``callbacks.py`` per issue #87.
+
+Owns the data-collection + rendering helpers for the US Grid tab's
+three view modes:
+
+- **Cards** — per-region small-multiples grid (``_build_us_grid_region_card``)
+- **Map** — Plotly ``scatter_geo`` of BA centroids (``_build_us_grid_map``)
+- **Polygons** — Plotly ``Choropleth`` of BA service-territory shapes
+  (``_build_us_grid_choropleth``) backed by ``assets/ba_polygons.geojson``
+
+Cross-cutting infrastructure (caches, layout helpers, color tokens,
+map basemap constants, ``_latest_real_demand``) lives in
+``components/_callbacks_shared.py``. ``REGION_*`` config dicts come
+from ``config.py``. Redis access goes through ``data.redis_client``.
+
+The module is imported back into ``components/callbacks.py`` via an
+explicit re-import block so existing
+``from components.callbacks import <X>`` import sites (notably
+``tests/unit/test_us_grid_choropleth.py``,
+``tests/unit/test_us_grid_nan_guard.py``,
+``tests/unit/test_us_grid_stress_cap.py``) resolve unchanged.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import plotly.graph_objects as go
+import structlog
+from dash import dcc, html
+
+from components._callbacks_shared import (
+    _MAP_AXIS_FONT_COLOR,
+    _MAP_BORDER_COLOR,
+    _MAP_COASTLINE_COLOR,
+    _MAP_COLORSCALE,
+    _MAP_LAND_COLOR,
+    _MAP_SUBUNIT_COLOR,
+    _STRESS_RELIABLE_CEILING,
+    _latest_real_demand,
+)
+from components.cards import build_page_title
+from config import (
+    IS_IMPORT_DOMINATED,
+    REGION_CAPACITY_MW,
+    REGION_COORDINATES,
+    REGION_NAMES,
+)
+from data.redis_client import redis_get
+
+log = structlog.get_logger()
+
+
+# ── V1.β: US GRID TAB HELPERS ────────────────────────────────
+
+
+def _collect_us_grid_region_data() -> dict[str, dict]:
+    """Pull per-region snapshots from Redis for the US Grid card grid.
+
+    Returns ``{region_code: {"current_mw", "prev_mw", "today_mw",
+    "interchange"}}`` for every region in ``REGION_NAMES`` that **passes
+    the V3.ζ forecast quality gate**. Regions without a Redis entry
+    (cold pipeline, new BAs awaiting their first scoring run) — or
+    whose demand tail is NaN / zero (EIA-930 publishing lag for the
+    most recent hour) — get a dict with ``current_mw=None`` so the
+    caller can render an ``"—"`` placeholder card without ever exposing
+    a NaN to downstream sums or divisions. ``interchange`` is the V3.α
+    ``wattcast:interchange:{region}:1h`` payload, or ``None`` if absent.
+
+    Regions failing the quality gate (XGBoost holdout MAPE in the
+    ``rollback`` grade per ``mape_grade()``) are omitted from the
+    return entirely so all downstream consumers (cards, metrics, map)
+    see the same filtered set. The dropdown gate in ``layout.py``
+    independently filters the same way; the hidden-count surfaced in
+    the page title comes from ``hidden_regions()``.
+    """
+    from models.model_service import is_forecast_quality_acceptable
+
+    out: dict[str, dict] = {}
+    for region in REGION_NAMES:
+        if not is_forecast_quality_acceptable(region):
+            continue
+        actuals = redis_get(f"wattcast:actuals:{region}")
+        demand = (actuals or {}).get("demand_mw") or []
+        interchange = redis_get(f"wattcast:interchange:{region}:1h")
+        if not demand:
+            out[region] = {"interchange": interchange} if interchange else {}
+            continue
+
+        current_mw = _latest_real_demand(demand)
+        prev_mw = _latest_real_demand(demand, offset=1) if current_mw is not None else None
+        # Sparkline is rendered tolerant of NaN (gp-region-card__sparkline
+        # uses raw values), so we keep the trailing-24h slice as-is — but
+        # the headline number paths read ``current_mw`` / ``prev_mw``.
+        out[region] = {
+            "current_mw": current_mw,
+            "prev_mw": prev_mw,
+            "today_mw": demand[-24:],
+            "interchange": interchange,
+        }
+    return out
+
+
+def _build_us_grid_title(region_data: dict[str, dict]) -> html.Div:
+    """Page title block: 'US Grid' + '<N> BAs · X.X GW total demand'.
+
+    V3.ζ follow-up: when the forecast-quality gate hides one or more
+    BAs from the visible set, append a small annotation to the
+    subtitle ("· N hidden") with a hover tooltip listing the affected
+    codes. Hidden BAs are not in ``region_data`` (the collector skips
+    them), so the count is the difference between ``REGION_NAMES`` and
+    the gate's view of acceptable regions.
+    """
+    from models.model_service import hidden_regions
+
+    n_regions = len(REGION_NAMES)
+    # Filter to finite, positive values only — ``_collect_us_grid_region_data``
+    # already returns ``None`` for regions whose demand tail is NaN, but
+    # the explicit ``np.isfinite`` here is a safety net so a future
+    # regression in the collector can't poison the sum with NaN.
+    real_demands = [
+        v for v in (d.get("current_mw") for d in region_data.values()) if _is_real_positive(v)
+    ]
+    n_with_data = len(real_demands)
+    total_mw = sum(real_demands)
+    hidden = hidden_regions(REGION_NAMES.keys())
+    n_visible = n_regions - len(hidden)
+
+    if total_mw > 0:
+        subtitle = (
+            f"{n_with_data} of {n_visible} balancing authorities reporting · "
+            f"{total_mw / 1000:.1f} GW total demand"
+        )
+    else:
+        subtitle = f"{n_visible} balancing authorities · pipeline warming up"
+    tooltip: str | None = None
+    if hidden:
+        subtitle += f" · {len(hidden)} hidden"
+        tooltip = (
+            "Hidden by the forecast quality gate (XGBoost holdout MAPE > 22%, "
+            "the 7-day rollback grade): " + ", ".join(sorted(hidden))
+        )
+    return build_page_title(title="US Grid", subtitle=subtitle, subtitle_tooltip=tooltip)
+
+
+def _is_real_positive(value) -> bool:
+    """Strict guard for downstream arithmetic: True only when ``value`` is
+    a finite (non-NaN, non-inf) strictly positive number. Used everywhere
+    that sums or divides by a region's ``current_mw``.
+
+    Rejects strings outright (no silent coercion) and normalizes numpy
+    bool returns to Python ``bool`` so callers can use ``is True / is False``.
+    """
+    if value is None or isinstance(value, (str, bytes)):
+        return False
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return False
+    return bool(np.isfinite(f) and f > 0)
+
+
+# ``_STRESS_RELIABLE_CEILING`` lives in ``_callbacks_shared.py`` — re-exported
+# via the module-level star-import. Belt-and-braces fallback for any BA not
+# explicitly tagged in ``IS_IMPORT_DOMINATED``; structurally above this
+# ratio means the capacity figure is unreliable and the row should be
+# excluded from stress rankings.
+
+
+def _build_us_grid_metrics_items(region_data: dict[str, dict]) -> list[dict]:
+    """4-up MetricsBar items: Total Demand · Peak Today · Top-Stress BA · Lowest Reserve."""
+    populated = {r: d for r, d in region_data.items() if _is_real_positive(d.get("current_mw"))}
+    if not populated:
+        return [
+            {"label": "Total Demand", "value": "—", "tone": "primary", "hero": True},
+            {"label": "National Peak (24h)", "value": "—"},
+            {"label": "Highest-Stress Region", "value": "—"},
+            {"label": "Lowest Reserve", "value": "—"},
+        ]
+
+    total_mw = sum(d["current_mw"] for d in populated.values())
+    # ``today_mw`` is the raw sparkline window — strip NaN before max()
+    # so a single bad hour can't poison the National Peak metric.
+    peak_24h_mw = max(
+        (
+            max(filter(_is_real_positive, d.get("today_mw") or []), default=0)
+            for d in populated.values()
+        ),
+        default=0,
+    )
+
+    stress_by_region = {
+        region: d["current_mw"] / cap
+        for region, d in populated.items()
+        if (cap := REGION_CAPACITY_MW.get(region, 0)) > 0
+        # V3.η: structurally import-dominated BAs (CPLW, HST, SPA) are
+        # never valid candidates for "highest stress" — their capacity
+        # is a peak × 1.15 estimate, not a measured plate, so the stress
+        # ratio against it is too noisy to rank against truly-stressed
+        # vertically integrated BAs. Filter at source rather than at
+        # the reliability ceiling.
+        and region not in IS_IMPORT_DOMINATED
+    }
+    # Belt-and-braces fallback: anything above the reliability ceiling
+    # is structural (sustained > 100% means the BA imports most of its
+    # power), not real stress. Today this cap should never trip after
+    # the V3.η filter above, but keeps the KPI honest if a future BA
+    # gets misclassified or if EIA-860M data drifts.
+    reliable_stress = {r: s for r, s in stress_by_region.items() if s <= _STRESS_RELIABLE_CEILING}
+    if reliable_stress:
+        top_region = max(reliable_stress, key=reliable_stress.get)
+        # Cap displayed stress at 100% so a tight-day reading of 110%
+        # doesn't render as e.g. "PJM · 110%". Matches the map's
+        # cap (``_build_us_grid_map`` line ~6821).
+        top_stress_pct = min(reliable_stress[top_region], 1.0) * 100
+        # Floor reserve at 0% — a BA running at or above its capacity
+        # has zero operator reserve, never negative.
+        lowest_reserve_pct = max(0.0, (1 - max(reliable_stress.values())) * 100)
+        top_tone = "negative" if top_stress_pct >= 85 else "secondary"
+        reserve_tone = "negative" if lowest_reserve_pct < 15 else "secondary"
+        top_value = f"{top_region} · {top_stress_pct:.0f}%"
+        reserve_value = f"{lowest_reserve_pct:.0f}%"
+    else:
+        top_value = "—"
+        reserve_value = "—"
+        top_tone = "secondary"
+        reserve_tone = "secondary"
+
+    return [
+        {
+            "label": "Total Demand",
+            "value": f"{total_mw / 1000:.1f}",
+            "unit": "GW",
+            "tone": "primary",
+            "hero": True,
+        },
+        {"label": "National Peak (24h)", "value": f"{peak_24h_mw / 1000:.1f}", "unit": "GW"},
+        {"label": "Highest-Stress Region", "value": top_value, "tone": top_tone},
+        {"label": "Lowest Reserve", "value": reserve_value, "tone": reserve_tone},
+    ]
+
+
+def _build_us_grid_sparkline(values: list[float]) -> html.Div:
+    """Inline-SVG sparkline for the last ~24h of a region's demand."""
+    if not values or len(values) < 2:
+        return html.Div("", className="gp-region-card__sparkline gp-region-card__sparkline--empty")
+
+    width, height = 100.0, 28.0
+    vmin = min(values)
+    vmax = max(values)
+    vrange = max(vmax - vmin, 1.0)
+    n = len(values)
+    points = " ".join(
+        f"{i * width / (n - 1):.1f},{height - (v - vmin) / vrange * height:.1f}"
+        for i, v in enumerate(values)
+    )
+    svg = (
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width:g} {height:g}" '
+        f'class="gp-region-card__sparkline-svg" preserveAspectRatio="none" '
+        f'aria-hidden="true">'
+        f'<polyline points="{points}" fill="none" stroke="currentColor" '
+        f'stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />'
+        f"</svg>"
+    )
+    return html.Div(
+        dcc.Markdown(svg, dangerously_allow_html=True),
+        className="gp-region-card__sparkline",
+    )
+
+
+def _build_interchange_chip(interchange: dict | None) -> html.Span | None:
+    """V3.α: net BA-to-BA interchange chip.
+
+    Renders ``+1.2 GW`` when exporting (positive net), ``-0.8 GW`` when
+    importing (negative net), or ``≈0`` when net is below the visual
+    threshold. Hover tooltip lists the top counterparty BAs and their
+    signed flows.
+    """
+    if not interchange or interchange.get("net_mw") is None:
+        return None
+
+    net_mw = float(interchange["net_mw"])
+    counterparties = interchange.get("counterparties") or []
+
+    # Below ±50 MW the sign isn't meaningful at GW resolution; render as ≈0
+    # to avoid noise. Real flows in the system are typically 100s–1000s MW.
+    if abs(net_mw) < 50:
+        label = "≈0"
+        tone = "neutral"
+    else:
+        gw = net_mw / 1000.0
+        sign = "+" if gw >= 0 else "−"
+        label = f"{sign}{abs(gw):.1f} GW"
+        tone = "export" if gw >= 0 else "import"
+
+    if counterparties:
+        parts = []
+        for cp in counterparties:
+            mw = float(cp["mw"])
+            cp_sign = "+" if mw >= 0 else "−"
+            parts.append(f"{cp_sign}{abs(mw):,.0f} MW → {cp['to_ba']}")
+        tooltip = "Top counterparties (last hour): " + " · ".join(parts)
+    else:
+        tooltip = f"Net interchange (last hour): {net_mw:+,.0f} MW"
+
+    return html.Span(
+        label,
+        className=f"gp-region-card__interchange gp-region-card__interchange--{tone}",
+        title=tooltip,
+    )
+
+
+def _build_us_grid_region_card(region: str, data: dict) -> html.Div:
+    """One region card for the US Grid small-multiples grid.
+
+    Empty ``data`` (no Redis row yet) renders an "—" placeholder card that's
+    still clickable — drilling down lands on the Forecast tab so the user
+    can see the warming state per region rather than guessing.
+    """
+    name = REGION_NAMES.get(region, region)
+    card_id = {"type": "us-grid-region-card", "region": region}
+
+    # ``_collect_us_grid_region_data`` returns ``None`` for unreal demand
+    # (NaN / non-finite / non-positive). The strict ``_is_real_positive``
+    # check is redundant given that source — kept as a safety net so a
+    # future regression in the collector can't render literal "nan" here.
+    if not data or not _is_real_positive(data.get("current_mw")):
+        return html.Div(
+            [
+                html.Div(
+                    [html.Span(name, className="gp-region-card__name")],
+                    className="gp-region-card__header",
+                ),
+                html.Div("—", className="gp-region-card__demand-empty"),
+            ],
+            id=card_id,
+            n_clicks=0,
+            className="gp-region-card gp-region-card--empty",
+            title=f"{name} · pipeline warming up",
+        )
+
+    current_mw = data["current_mw"]
+    prev_mw = data.get("prev_mw")
+    today_mw = data.get("today_mw") or []
+    capacity_mw = REGION_CAPACITY_MW.get(region, 0)
+
+    delta_chip = None
+    if prev_mw and prev_mw > 0:
+        delta_pct = (current_mw - prev_mw) / prev_mw * 100
+        sign = "+" if delta_pct >= 0 else ""
+        direction = "up" if delta_pct >= 0 else "down"
+        delta_chip = html.Span(
+            f"{sign}{delta_pct:.1f}%",
+            className=f"gp-region-card__delta gp-region-card__delta--{direction}",
+        )
+
+    stress_chip = None
+    if capacity_mw > 0:
+        stress_ratio = current_mw / capacity_mw
+        # V3.η: structurally import-dominated BAs (CPLW, HST, SPA) get
+        # the qualitative "imports" chip whether or not their stress
+        # ratio happens to land above the ceiling on a given hour. The
+        # capacity figure for these BAs is a peak × 1.15 estimate, not
+        # measured plate, so the percentage isn't meaningful even when
+        # it's mathematically below 100%.
+        is_import_dominated = (
+            region in IS_IMPORT_DOMINATED or stress_ratio > _STRESS_RELIABLE_CEILING
+        )
+        if is_import_dominated:
+            stress_chip = html.Span(
+                "imports",
+                className="gp-region-card__stress gp-region-card__stress--imports",
+                title=(
+                    f"{name} is an import-dominated balancing authority — "
+                    f"its served demand routinely exceeds in-territory generation "
+                    f"and is supplied via inter-BA transfers. The utilization % "
+                    f"is calculated against an estimated capacity pool, not a "
+                    f"measured plate."
+                ),
+            )
+        else:
+            # Cap displayed stress at 100% so a tight-day reading of
+            # 110% renders as "100%". Matches the choropleth and map.
+            stress_pct = min(stress_ratio, 1.0) * 100
+            if stress_pct >= 85:
+                tone = "high"
+            elif stress_pct >= 70:
+                tone = "mid"
+            else:
+                tone = "low"
+            stress_chip = html.Span(
+                f"{stress_pct:.0f}%",
+                className=f"gp-region-card__stress gp-region-card__stress--{tone}",
+                title=(f"Demand vs. capacity: {current_mw:,.0f} / {capacity_mw:,.0f} MW"),
+            )
+
+    demand_row_children: list = [
+        html.Span(
+            f"{current_mw / 1000:.1f}",
+            className="gp-region-card__demand-value tabular",
+        ),
+        html.Span("GW", className="gp-region-card__demand-unit"),
+    ]
+    if delta_chip is not None:
+        demand_row_children.append(delta_chip)
+
+    interchange_chip = _build_interchange_chip(data.get("interchange"))
+
+    header_children: list = [html.Span(name, className="gp-region-card__name")]
+    if stress_chip is not None:
+        header_children.append(stress_chip)
+    if interchange_chip is not None:
+        header_children.append(interchange_chip)
+
+    return html.Div(
+        [
+            html.Div(header_children, className="gp-region-card__header"),
+            html.Div(demand_row_children, className="gp-region-card__demand"),
+            _build_us_grid_sparkline(today_mw),
+        ],
+        id=card_id,
+        n_clicks=0,
+        className="gp-region-card",
+    )
+
+
+# ── V1.γ: US GRID MAP HELPERS ────────────────────────────────
+#
+# The ``_MAP_*`` tokens (land / coastline / subunit / border colors +
+# the colorscale) live in ``_callbacks_shared.py`` and are re-exported
+# via the module-level star-import. Plotly figures need the hex values
+# inline because Plotly doesn't read CSS custom properties; the shared
+# module keeps them in sync with ``:root`` in ``assets/custom.css``.
+
+
+def _build_us_grid_map(region_data: dict) -> html.Div:
+    """Plotly ``scatter_geo`` of BA centroids — sized by demand, colored by stress.
+
+    Cold or empty regions are dropped from the figure (rather than rendering
+    as zero-size markers). When every region is cold the function returns an
+    empty-state div — the page already has the warming language in the title.
+    """
+    # Drop NaN / non-finite / zero demand regions — they would render as
+    # zero-size markers and (worse) could push NaN into the colorscale
+    # via the stress percentage divide below.
+    populated = {r: d for r, d in region_data.items() if _is_real_positive(d.get("current_mw"))}
+
+    if not populated:
+        return html.Div(
+            html.Div(
+                "All regions warming up — switch to Cards view to see per-region status.",
+                className="gp-region-map__empty-message",
+            ),
+            className="gp-region-map gp-region-map--empty",
+        )
+
+    regions = list(populated.keys())
+    lats = [REGION_COORDINATES[r]["lat"] for r in regions]
+    lons = [REGION_COORDINATES[r]["lon"] for r in regions]
+    names = [REGION_NAMES.get(r, r) for r in regions]
+    demand_gw = [populated[r]["current_mw"] / 1000 for r in regions]
+
+    # Stress = demand / capacity (0..>1). Cap at 100% for the colorscale.
+    stress_pct: list[float] = []
+    for r in regions:
+        cap = REGION_CAPACITY_MW.get(r, 0)
+        if cap > 0:
+            stress_pct.append(min(populated[r]["current_mw"] / cap * 100, 100.0))
+        else:
+            stress_pct.append(0.0)
+
+    # Marker size: 10–40 px, scaled by demand. Linear is fine for 16 points.
+    max_demand = max(demand_gw)
+    sizes = [10 + (d / max_demand) * 30 for d in demand_gw]
+
+    # V3.η: append " · imports" suffix to the BA name for structurally
+    # import-dominated BAs (CPLW, HST, SPA) so users understand what
+    # the utilization % is measured against (a peak × 1.15 estimate,
+    # not a measured plate capacity).
+    hover_text = [
+        f"<b>{name}{' · imports' if r in IS_IMPORT_DOMINATED else ''}</b>"
+        f"<br>Demand: {d:.1f} GW<br>Utilization: {s:.0f}%"
+        for r, name, d, s in zip(regions, names, demand_gw, stress_pct, strict=False)
+    ]
+
+    fig = go.Figure(
+        go.Scattergeo(
+            lat=lats,
+            lon=lons,
+            mode="markers",
+            marker={
+                "size": sizes,
+                "color": stress_pct,
+                "colorscale": _MAP_COLORSCALE,
+                "cmin": 0,
+                "cmax": 100,
+                "colorbar": {
+                    "title": {
+                        "text": "Utilization %",
+                        "font": {"color": _MAP_AXIS_FONT_COLOR, "size": 10},
+                    },
+                    "tickfont": {"color": _MAP_AXIS_FONT_COLOR, "size": 10},
+                    "thickness": 10,
+                    "len": 0.6,
+                    "bgcolor": "rgba(0,0,0,0)",
+                    "bordercolor": _MAP_BORDER_COLOR,
+                    "borderwidth": 1,
+                    "x": 1.0,
+                },
+                "line": {"color": _MAP_BORDER_COLOR, "width": 1},
+            },
+            customdata=regions,
+            hovertext=hover_text,
+            hoverinfo="text",
+        )
+    )
+
+    fig.update_geos(
+        scope="usa",
+        projection_type="albers usa",
+        showland=True,
+        landcolor=_MAP_LAND_COLOR,
+        showcoastlines=True,
+        coastlinecolor=_MAP_COASTLINE_COLOR,
+        showsubunits=True,
+        subunitcolor=_MAP_SUBUNIT_COLOR,
+        showcountries=False,
+        showlakes=False,
+        bgcolor="rgba(0,0,0,0)",
+    )
+
+    fig.update_layout(
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+        margin={"l": 0, "r": 0, "t": 8, "b": 0},
+        font={"family": "Inter, system-ui, sans-serif", "color": _MAP_AXIS_FONT_COLOR, "size": 11},
+        height=480,
+        showlegend=False,
+        hoverlabel={
+            "bgcolor": _MAP_LAND_COLOR,
+            "bordercolor": _MAP_COASTLINE_COLOR,
+            "font": {"color": "#e4e4e7", "family": "Inter, system-ui, sans-serif", "size": 12},
+        },
+    )
+
+    return html.Div(
+        dcc.Graph(
+            id="us-grid-map",
+            figure=fig,
+            config={"displayModeBar": False, "responsive": True},
+            style={"height": "480px"},
+        ),
+        className="gp-region-map",
+    )
+
+
+# ── V3.β: Choropleth (real BA service-territory polygons) ────
+
+
+# In-memory cache for the polygon GeoJSON. Read once per process.
+# The asset is ~165 KB so the parse is cheap, but we don't want to
+# do it on every render.
+_BA_POLYGONS_CACHE: dict | None = None
+
+
+def _load_ba_polygons() -> dict | None:
+    """Load and cache the BA-polygon GeoJSON from ``assets/``.
+
+    Returns ``None`` if the file is missing or malformed — the
+    choropleth helper falls back to the centroid scatter in that case
+    so a corrupt asset doesn't black out the Map view entirely.
+    """
+    global _BA_POLYGONS_CACHE
+    if _BA_POLYGONS_CACHE is not None:
+        return _BA_POLYGONS_CACHE
+
+    import json as _json
+    from pathlib import Path
+
+    asset_path = Path(__file__).parent.parent / "assets" / "ba_polygons.geojson"
+    try:
+        with open(asset_path) as f:
+            _BA_POLYGONS_CACHE = _json.load(f)
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("ba_polygons_load_failed", error=str(exc))
+        _BA_POLYGONS_CACHE = None
+    return _BA_POLYGONS_CACHE
+
+
+def _build_us_grid_choropleth(region_data: dict) -> html.Div:
+    """Plotly ``Choropleth`` of BA service-territory polygons — colored
+    by demand-vs-capacity utilization. Same colorscale + drilldown as
+    the centroid scatter so users can switch between them seamlessly.
+
+    V3.β closes the deferral noted in V1.γ — centroids were "80% of the
+    visual punch for 10% of the cost"; this delivers the remaining 20%.
+    Polygons sourced from electricitymaps-contrib's world.geojson (MIT
+    license), filtered to our 51 BA codes via EIA-930 respondent
+    suffixes, ~165 KB pre-simplified.
+
+    Falls back to the centroid scatter when the GeoJSON asset is
+    missing or unreadable so a corrupt file can't black out the tab.
+    """
+    geojson = _load_ba_polygons()
+    if geojson is None:
+        return _build_us_grid_map(region_data)
+
+    populated = {r: d for r, d in region_data.items() if _is_real_positive(d.get("current_mw"))}
+    if not populated:
+        return html.Div(
+            html.Div(
+                "All regions warming up — switch to Cards view to see per-region status.",
+                className="gp-region-map__empty-message",
+            ),
+            className="gp-region-map gp-region-map--empty",
+        )
+
+    regions = list(populated.keys())
+    stress_pct: list[float] = []
+    for r in regions:
+        cap = REGION_CAPACITY_MW.get(r, 0)
+        if cap > 0:
+            stress_pct.append(min(populated[r]["current_mw"] / cap * 100, 100.0))
+        else:
+            stress_pct.append(0.0)
+
+    names = [REGION_NAMES.get(r, r) for r in regions]
+    demand_gw = [populated[r]["current_mw"] / 1000 for r in regions]
+    # V3.η: customdata[3] = " · imports" suffix for import-dominated
+    # BAs, empty string for everyone else. Plotly hovertemplate renders
+    # the empty string invisibly so we don't need separate templates.
+    import_tag = [" · imports" if r in IS_IMPORT_DOMINATED else "" for r in regions]
+    customdata = list(zip(regions, names, demand_gw, import_tag, strict=False))
+
+    fig = go.Figure(
+        go.Choropleth(
+            geojson=geojson,
+            featureidkey="properties.region",
+            locations=regions,
+            z=stress_pct,
+            colorscale=_MAP_COLORSCALE,
+            zmin=0,
+            zmax=100,
+            marker={"line": {"color": _MAP_BORDER_COLOR, "width": 1.0}},
+            colorbar={
+                "title": {
+                    "text": "Utilization %",
+                    "font": {"color": _MAP_AXIS_FONT_COLOR, "size": 10},
+                },
+                "tickfont": {"color": _MAP_AXIS_FONT_COLOR, "size": 10},
+                "thickness": 10,
+                "len": 0.6,
+                "bgcolor": "rgba(0,0,0,0)",
+                "bordercolor": _MAP_BORDER_COLOR,
+                "borderwidth": 1,
+                "x": 1.0,
+            },
+            # Drilldown reads ``customdata`` (the BA code) — same shape
+            # as the scatter so the existing ``us-grid-map.clickData``
+            # callback handles it without changes.
+            customdata=customdata,
+            hovertemplate=(
+                "<b>%{customdata[1]}</b>%{customdata[3]}<br>"
+                "Demand: %{customdata[2]:.1f} GW<br>"
+                "Utilization: %{z:.0f}%<extra></extra>"
+            ),
+        )
+    )
+    fig.update_geos(
+        scope="usa",
+        projection_type="albers usa",
+        showland=True,
+        landcolor=_MAP_LAND_COLOR,
+        showcoastlines=True,
+        coastlinecolor=_MAP_COASTLINE_COLOR,
+        showsubunits=True,
+        subunitcolor=_MAP_SUBUNIT_COLOR,
+        showcountries=False,
+        showlakes=False,
+        bgcolor="rgba(0,0,0,0)",
+    )
+    fig.update_layout(
+        paper_bgcolor="rgba(0,0,0,0)",
+        plot_bgcolor="rgba(0,0,0,0)",
+        margin={"l": 0, "r": 0, "t": 8, "b": 0},
+        font={"family": "Inter, system-ui, sans-serif", "color": _MAP_AXIS_FONT_COLOR, "size": 11},
+        height=480,
+        showlegend=False,
+        hoverlabel={
+            "bgcolor": _MAP_LAND_COLOR,
+            "bordercolor": _MAP_COASTLINE_COLOR,
+            "font": {"color": "#e4e4e7", "family": "Inter, system-ui, sans-serif", "size": 12},
+        },
+    )
+
+    # Coverage caption — disambiguates the dark-fill gaps in the
+    # Polygons view (Idaho, parts of Montana / Wyoming / the Plains,
+    # AK + HI insets) as intentional unmapped territory, not a
+    # rendering bug. EIA-930 has ~64 BAs in the lower 48; we ship
+    # polygons for ~51 (~80% of demand). Renders only inside the
+    # Polygons view body — Cards / Map don't have coverage gaps to
+    # disclose.
+    n_covered = len(regions)
+    caption = html.Div(
+        f"{n_covered} of ~64 lower-48 balancing authorities mapped · "
+        "dark areas are EIA-930 BAs not yet covered here.",
+        className="gp-region-map__coverage-caption",
+    )
+
+    return html.Div(
+        [
+            dcc.Graph(
+                id="us-grid-map",
+                figure=fig,
+                config={"displayModeBar": False, "responsive": True},
+                style={"height": "480px"},
+            ),
+            caption,
+        ],
+        className="gp-region-map",
+    )

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -44,22 +44,20 @@ from components._callbacks_shared import (
     _CACHE_VERSION,
     _EIA_FUEL_MAP,
     _GENERATION_CACHE,
-    _MAP_AXIS_FONT_COLOR,
-    _MAP_BORDER_COLOR,
-    _MAP_COASTLINE_COLOR,
-    _MAP_COLORSCALE,
-    _MAP_LAND_COLOR,
-    _MAP_SUBUNIT_COLOR,
+    _MAP_BORDER_COLOR,  # noqa: F401 — re-export (tests/unit/test_us_grid_*)
+    _MAP_COLORSCALE,  # noqa: F401 — re-export (tests/unit/test_us_grid_*)
+    _MAP_LAND_COLOR,  # noqa: F401 — re-export (tests/unit/test_us_grid_*)
     _MODEL_BAND_COLORS,
     _MODEL_CACHE,
     _PREDICTION_CACHE,
-    _STRESS_RELIABLE_CEILING,
+    _STRESS_RELIABLE_CEILING,  # noqa: F401 — re-export (tests/unit/test_us_grid_stress_cap)
     BACKTEST_EXOG_MODES,  # noqa: F401 — re-export
     COLORS,
     DEFAULT_BACKTEST_EXOG_MODE,
     PLOT_LAYOUT,  # noqa: F401 — re-export
     PLOT_TEMPLATE,  # noqa: F401 — re-export
     _cache_lock,  # noqa: F401 — re-export (app.py uses for cache stats)
+    _latest_real_demand,
     _layout,
 )
 from components.accessibility import CB_PALETTE, LINE_STYLES
@@ -75,9 +73,7 @@ from components.cards import (
 from config import (
     CACHE_TTL_SECONDS,
     EIA_API_KEY,
-    IS_IMPORT_DOMINATED,
     REGION_CAPACITY_MW,
-    REGION_COORDINATES,
     REGION_NAMES,
     REQUIRE_REDIS,
     WEATHER_VARIABLES,
@@ -2515,7 +2511,6 @@ def register_callbacks(app):
         """Page title for the Models tab."""
         if active_tab != "tab-models":
             return no_update
-        from config import REGION_NAMES
 
         region = region or "FPL"
         region_name = REGION_NAMES.get(region, region)
@@ -2758,7 +2753,6 @@ def register_callbacks(app):
         """Page-title block for the Risk tab."""
         if active_tab != "tab-alerts":
             return no_update
-        from config import REGION_NAMES
 
         region = region or "FPL"
         region_name = REGION_NAMES.get(region, region)
@@ -3569,7 +3563,6 @@ def register_callbacks(app):
         """Page-title block for the Forecast tab."""
         if active_tab != "tab-outlook":
             return no_update
-        from config import REGION_NAMES
 
         region = region or "FPL"
         region_name = REGION_NAMES.get(region, region)
@@ -4033,39 +4026,8 @@ def register_callbacks(app):
 # tabs (US Grid, Risk, Models) can't accidentally re-introduce the bug.
 
 
-def _latest_real_demand(values, *, offset: int = 0):
-    """Return the most recent real demand reading from a list / Series.
-
-    Walks backward and returns the first value that is finite (not NaN
-    or inf) and strictly positive. ``offset=0`` finds "now"; ``offset=24``
-    finds "24 hours ago" while still skipping any NaN / zero rows that
-    fall on the chosen position — so a NaN spike doesn't silently shift
-    a trend baseline.
-
-    Returns ``None`` when no usable reading exists in the window — the
-    caller should render an ``"—"`` placeholder rather than a numeric.
-    """
-    if values is None:
-        return None
-    try:
-        n = len(values)
-    except TypeError:
-        return None
-    if n == 0:
-        return None
-    skipped = 0
-    for i in range(n - 1, -1, -1):
-        try:
-            v = float(values.iloc[i] if hasattr(values, "iloc") else values[i])
-        except (TypeError, ValueError):
-            continue
-        if not np.isfinite(v) or v <= 0:
-            continue
-        if skipped < offset:
-            skipped += 1
-            continue
-        return v
-    return None
+# ``_latest_real_demand`` lives in ``_callbacks_shared.py`` — re-exported
+# via the explicit import block at the top of this module.
 
 
 # ── Overview helpers (R2 — v2 linear stack) ─────────────────────────
@@ -4073,7 +4035,6 @@ def _latest_real_demand(values, *, offset: int = 0):
 
 def _build_overview_title(region: str) -> html.Div:
     """Page-title block: region name + 1-line subtitle."""
-    from config import REGION_NAMES
 
     region_name = REGION_NAMES.get(region, region)
     subtitle = f"Demand forecast and grid intelligence · {region}"
@@ -6407,670 +6368,22 @@ def _run_backtest_for_horizon(
 
 
 # ── V1.β: US GRID TAB HELPERS ────────────────────────────────
-
-
-def _collect_us_grid_region_data() -> dict[str, dict]:
-    """Pull per-region snapshots from Redis for the US Grid card grid.
-
-    Returns ``{region_code: {"current_mw", "prev_mw", "today_mw",
-    "interchange"}}`` for every region in ``REGION_NAMES`` that **passes
-    the V3.ζ forecast quality gate**. Regions without a Redis entry
-    (cold pipeline, new BAs awaiting their first scoring run) — or
-    whose demand tail is NaN / zero (EIA-930 publishing lag for the
-    most recent hour) — get a dict with ``current_mw=None`` so the
-    caller can render an ``"—"`` placeholder card without ever exposing
-    a NaN to downstream sums or divisions. ``interchange`` is the V3.α
-    ``wattcast:interchange:{region}:1h`` payload, or ``None`` if absent.
-
-    Regions failing the quality gate (XGBoost holdout MAPE in the
-    ``rollback`` grade per ``mape_grade()``) are omitted from the
-    return entirely so all downstream consumers (cards, metrics, map)
-    see the same filtered set. The dropdown gate in ``layout.py``
-    independently filters the same way; the hidden-count surfaced in
-    the page title comes from ``hidden_regions()``.
-    """
-    from models.model_service import is_forecast_quality_acceptable
-
-    out: dict[str, dict] = {}
-    for region in REGION_NAMES:
-        if not is_forecast_quality_acceptable(region):
-            continue
-        actuals = redis_get(f"wattcast:actuals:{region}")
-        demand = (actuals or {}).get("demand_mw") or []
-        interchange = redis_get(f"wattcast:interchange:{region}:1h")
-        if not demand:
-            out[region] = {"interchange": interchange} if interchange else {}
-            continue
-
-        current_mw = _latest_real_demand(demand)
-        prev_mw = _latest_real_demand(demand, offset=1) if current_mw is not None else None
-        # Sparkline is rendered tolerant of NaN (gp-region-card__sparkline
-        # uses raw values), so we keep the trailing-24h slice as-is — but
-        # the headline number paths read ``current_mw`` / ``prev_mw``.
-        out[region] = {
-            "current_mw": current_mw,
-            "prev_mw": prev_mw,
-            "today_mw": demand[-24:],
-            "interchange": interchange,
-        }
-    return out
-
-
-def _build_us_grid_title(region_data: dict[str, dict]) -> html.Div:
-    """Page title block: 'US Grid' + '<N> BAs · X.X GW total demand'.
-
-    V3.ζ follow-up: when the forecast-quality gate hides one or more
-    BAs from the visible set, append a small annotation to the
-    subtitle ("· N hidden") with a hover tooltip listing the affected
-    codes. Hidden BAs are not in ``region_data`` (the collector skips
-    them), so the count is the difference between ``REGION_NAMES`` and
-    the gate's view of acceptable regions.
-    """
-    from models.model_service import hidden_regions
-
-    n_regions = len(REGION_NAMES)
-    # Filter to finite, positive values only — ``_collect_us_grid_region_data``
-    # already returns ``None`` for regions whose demand tail is NaN, but
-    # the explicit ``np.isfinite`` here is a safety net so a future
-    # regression in the collector can't poison the sum with NaN.
-    real_demands = [
-        v for v in (d.get("current_mw") for d in region_data.values()) if _is_real_positive(v)
-    ]
-    n_with_data = len(real_demands)
-    total_mw = sum(real_demands)
-    hidden = hidden_regions(REGION_NAMES.keys())
-    n_visible = n_regions - len(hidden)
-
-    if total_mw > 0:
-        subtitle = (
-            f"{n_with_data} of {n_visible} balancing authorities reporting · "
-            f"{total_mw / 1000:.1f} GW total demand"
-        )
-    else:
-        subtitle = f"{n_visible} balancing authorities · pipeline warming up"
-    tooltip: str | None = None
-    if hidden:
-        subtitle += f" · {len(hidden)} hidden"
-        tooltip = (
-            "Hidden by the forecast quality gate (XGBoost holdout MAPE > 22%, "
-            "the 7-day rollback grade): " + ", ".join(sorted(hidden))
-        )
-    return build_page_title(title="US Grid", subtitle=subtitle, subtitle_tooltip=tooltip)
-
-
-def _is_real_positive(value) -> bool:
-    """Strict guard for downstream arithmetic: True only when ``value`` is
-    a finite (non-NaN, non-inf) strictly positive number. Used everywhere
-    that sums or divides by a region's ``current_mw``.
-
-    Rejects strings outright (no silent coercion) and normalizes numpy
-    bool returns to Python ``bool`` so callers can use ``is True / is False``.
-    """
-    if value is None or isinstance(value, (str, bytes)):
-        return False
-    try:
-        f = float(value)
-    except (TypeError, ValueError):
-        return False
-    return bool(np.isfinite(f) and f > 0)
-
-
-# ``_STRESS_RELIABLE_CEILING`` lives in ``_callbacks_shared.py`` — re-exported
-# via the module-level star-import. Belt-and-braces fallback for any BA not
-# explicitly tagged in ``IS_IMPORT_DOMINATED``; structurally above this
-# ratio means the capacity figure is unreliable and the row should be
-# excluded from stress rankings.
-
-
-def _build_us_grid_metrics_items(region_data: dict[str, dict]) -> list[dict]:
-    """4-up MetricsBar items: Total Demand · Peak Today · Top-Stress BA · Lowest Reserve."""
-    populated = {r: d for r, d in region_data.items() if _is_real_positive(d.get("current_mw"))}
-    if not populated:
-        return [
-            {"label": "Total Demand", "value": "—", "tone": "primary", "hero": True},
-            {"label": "National Peak (24h)", "value": "—"},
-            {"label": "Highest-Stress Region", "value": "—"},
-            {"label": "Lowest Reserve", "value": "—"},
-        ]
-
-    total_mw = sum(d["current_mw"] for d in populated.values())
-    # ``today_mw`` is the raw sparkline window — strip NaN before max()
-    # so a single bad hour can't poison the National Peak metric.
-    peak_24h_mw = max(
-        (
-            max(filter(_is_real_positive, d.get("today_mw") or []), default=0)
-            for d in populated.values()
-        ),
-        default=0,
-    )
-
-    stress_by_region = {
-        region: d["current_mw"] / cap
-        for region, d in populated.items()
-        if (cap := REGION_CAPACITY_MW.get(region, 0)) > 0
-        # V3.η: structurally import-dominated BAs (CPLW, HST, SPA) are
-        # never valid candidates for "highest stress" — their capacity
-        # is a peak × 1.15 estimate, not a measured plate, so the stress
-        # ratio against it is too noisy to rank against truly-stressed
-        # vertically integrated BAs. Filter at source rather than at
-        # the reliability ceiling.
-        and region not in IS_IMPORT_DOMINATED
-    }
-    # Belt-and-braces fallback: anything above the reliability ceiling
-    # is structural (sustained > 100% means the BA imports most of its
-    # power), not real stress. Today this cap should never trip after
-    # the V3.η filter above, but keeps the KPI honest if a future BA
-    # gets misclassified or if EIA-860M data drifts.
-    reliable_stress = {r: s for r, s in stress_by_region.items() if s <= _STRESS_RELIABLE_CEILING}
-    if reliable_stress:
-        top_region = max(reliable_stress, key=reliable_stress.get)
-        # Cap displayed stress at 100% so a tight-day reading of 110%
-        # doesn't render as e.g. "PJM · 110%". Matches the map's
-        # cap (``_build_us_grid_map`` line ~6821).
-        top_stress_pct = min(reliable_stress[top_region], 1.0) * 100
-        # Floor reserve at 0% — a BA running at or above its capacity
-        # has zero operator reserve, never negative.
-        lowest_reserve_pct = max(0.0, (1 - max(reliable_stress.values())) * 100)
-        top_tone = "negative" if top_stress_pct >= 85 else "secondary"
-        reserve_tone = "negative" if lowest_reserve_pct < 15 else "secondary"
-        top_value = f"{top_region} · {top_stress_pct:.0f}%"
-        reserve_value = f"{lowest_reserve_pct:.0f}%"
-    else:
-        top_value = "—"
-        reserve_value = "—"
-        top_tone = "secondary"
-        reserve_tone = "secondary"
-
-    return [
-        {
-            "label": "Total Demand",
-            "value": f"{total_mw / 1000:.1f}",
-            "unit": "GW",
-            "tone": "primary",
-            "hero": True,
-        },
-        {"label": "National Peak (24h)", "value": f"{peak_24h_mw / 1000:.1f}", "unit": "GW"},
-        {"label": "Highest-Stress Region", "value": top_value, "tone": top_tone},
-        {"label": "Lowest Reserve", "value": reserve_value, "tone": reserve_tone},
-    ]
-
-
-def _build_us_grid_sparkline(values: list[float]) -> html.Div:
-    """Inline-SVG sparkline for the last ~24h of a region's demand."""
-    if not values or len(values) < 2:
-        return html.Div("", className="gp-region-card__sparkline gp-region-card__sparkline--empty")
-
-    width, height = 100.0, 28.0
-    vmin = min(values)
-    vmax = max(values)
-    vrange = max(vmax - vmin, 1.0)
-    n = len(values)
-    points = " ".join(
-        f"{i * width / (n - 1):.1f},{height - (v - vmin) / vrange * height:.1f}"
-        for i, v in enumerate(values)
-    )
-    svg = (
-        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width:g} {height:g}" '
-        f'class="gp-region-card__sparkline-svg" preserveAspectRatio="none" '
-        f'aria-hidden="true">'
-        f'<polyline points="{points}" fill="none" stroke="currentColor" '
-        f'stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />'
-        f"</svg>"
-    )
-    return html.Div(
-        dcc.Markdown(svg, dangerously_allow_html=True),
-        className="gp-region-card__sparkline",
-    )
-
-
-def _build_interchange_chip(interchange: dict | None) -> html.Span | None:
-    """V3.α: net BA-to-BA interchange chip.
-
-    Renders ``+1.2 GW`` when exporting (positive net), ``-0.8 GW`` when
-    importing (negative net), or ``≈0`` when net is below the visual
-    threshold. Hover tooltip lists the top counterparty BAs and their
-    signed flows.
-    """
-    if not interchange or interchange.get("net_mw") is None:
-        return None
-
-    net_mw = float(interchange["net_mw"])
-    counterparties = interchange.get("counterparties") or []
-
-    # Below ±50 MW the sign isn't meaningful at GW resolution; render as ≈0
-    # to avoid noise. Real flows in the system are typically 100s–1000s MW.
-    if abs(net_mw) < 50:
-        label = "≈0"
-        tone = "neutral"
-    else:
-        gw = net_mw / 1000.0
-        sign = "+" if gw >= 0 else "−"
-        label = f"{sign}{abs(gw):.1f} GW"
-        tone = "export" if gw >= 0 else "import"
-
-    if counterparties:
-        parts = []
-        for cp in counterparties:
-            mw = float(cp["mw"])
-            cp_sign = "+" if mw >= 0 else "−"
-            parts.append(f"{cp_sign}{abs(mw):,.0f} MW → {cp['to_ba']}")
-        tooltip = "Top counterparties (last hour): " + " · ".join(parts)
-    else:
-        tooltip = f"Net interchange (last hour): {net_mw:+,.0f} MW"
-
-    return html.Span(
-        label,
-        className=f"gp-region-card__interchange gp-region-card__interchange--{tone}",
-        title=tooltip,
-    )
-
-
-def _build_us_grid_region_card(region: str, data: dict) -> html.Div:
-    """One region card for the US Grid small-multiples grid.
-
-    Empty ``data`` (no Redis row yet) renders an "—" placeholder card that's
-    still clickable — drilling down lands on the Forecast tab so the user
-    can see the warming state per region rather than guessing.
-    """
-    name = REGION_NAMES.get(region, region)
-    card_id = {"type": "us-grid-region-card", "region": region}
-
-    # ``_collect_us_grid_region_data`` returns ``None`` for unreal demand
-    # (NaN / non-finite / non-positive). The strict ``_is_real_positive``
-    # check is redundant given that source — kept as a safety net so a
-    # future regression in the collector can't render literal "nan" here.
-    if not data or not _is_real_positive(data.get("current_mw")):
-        return html.Div(
-            [
-                html.Div(
-                    [html.Span(name, className="gp-region-card__name")],
-                    className="gp-region-card__header",
-                ),
-                html.Div("—", className="gp-region-card__demand-empty"),
-            ],
-            id=card_id,
-            n_clicks=0,
-            className="gp-region-card gp-region-card--empty",
-            title=f"{name} · pipeline warming up",
-        )
-
-    current_mw = data["current_mw"]
-    prev_mw = data.get("prev_mw")
-    today_mw = data.get("today_mw") or []
-    capacity_mw = REGION_CAPACITY_MW.get(region, 0)
-
-    delta_chip = None
-    if prev_mw and prev_mw > 0:
-        delta_pct = (current_mw - prev_mw) / prev_mw * 100
-        sign = "+" if delta_pct >= 0 else ""
-        direction = "up" if delta_pct >= 0 else "down"
-        delta_chip = html.Span(
-            f"{sign}{delta_pct:.1f}%",
-            className=f"gp-region-card__delta gp-region-card__delta--{direction}",
-        )
-
-    stress_chip = None
-    if capacity_mw > 0:
-        stress_ratio = current_mw / capacity_mw
-        # V3.η: structurally import-dominated BAs (CPLW, HST, SPA) get
-        # the qualitative "imports" chip whether or not their stress
-        # ratio happens to land above the ceiling on a given hour. The
-        # capacity figure for these BAs is a peak × 1.15 estimate, not
-        # measured plate, so the percentage isn't meaningful even when
-        # it's mathematically below 100%.
-        is_import_dominated = (
-            region in IS_IMPORT_DOMINATED or stress_ratio > _STRESS_RELIABLE_CEILING
-        )
-        if is_import_dominated:
-            stress_chip = html.Span(
-                "imports",
-                className="gp-region-card__stress gp-region-card__stress--imports",
-                title=(
-                    f"{name} is an import-dominated balancing authority — "
-                    f"its served demand routinely exceeds in-territory generation "
-                    f"and is supplied via inter-BA transfers. The utilization % "
-                    f"is calculated against an estimated capacity pool, not a "
-                    f"measured plate."
-                ),
-            )
-        else:
-            # Cap displayed stress at 100% so a tight-day reading of
-            # 110% renders as "100%". Matches the choropleth and map.
-            stress_pct = min(stress_ratio, 1.0) * 100
-            if stress_pct >= 85:
-                tone = "high"
-            elif stress_pct >= 70:
-                tone = "mid"
-            else:
-                tone = "low"
-            stress_chip = html.Span(
-                f"{stress_pct:.0f}%",
-                className=f"gp-region-card__stress gp-region-card__stress--{tone}",
-                title=(f"Demand vs. capacity: {current_mw:,.0f} / {capacity_mw:,.0f} MW"),
-            )
-
-    demand_row_children: list = [
-        html.Span(
-            f"{current_mw / 1000:.1f}",
-            className="gp-region-card__demand-value tabular",
-        ),
-        html.Span("GW", className="gp-region-card__demand-unit"),
-    ]
-    if delta_chip is not None:
-        demand_row_children.append(delta_chip)
-
-    interchange_chip = _build_interchange_chip(data.get("interchange"))
-
-    header_children: list = [html.Span(name, className="gp-region-card__name")]
-    if stress_chip is not None:
-        header_children.append(stress_chip)
-    if interchange_chip is not None:
-        header_children.append(interchange_chip)
-
-    return html.Div(
-        [
-            html.Div(header_children, className="gp-region-card__header"),
-            html.Div(demand_row_children, className="gp-region-card__demand"),
-            _build_us_grid_sparkline(today_mw),
-        ],
-        id=card_id,
-        n_clicks=0,
-        className="gp-region-card",
-    )
-
-
-# ── V1.γ: US GRID MAP HELPERS ────────────────────────────────
 #
-# The ``_MAP_*`` tokens (land / coastline / subunit / border colors +
-# the colorscale) live in ``_callbacks_shared.py`` and are re-exported
-# via the module-level star-import. Plotly figures need the hex values
-# inline because Plotly doesn't read CSS custom properties; the shared
-# module keeps them in sync with ``:root`` in ``assets/custom.css``.
+# Extracted into ``components/_callbacks_us_grid.py`` per issue #87.
+# The explicit re-import block below preserves the public-import surface
+# so existing ``from components.callbacks import <X>`` sites
+# (notably the US Grid test files) continue to resolve unchanged.
 
-
-def _build_us_grid_map(region_data: dict) -> html.Div:
-    """Plotly ``scatter_geo`` of BA centroids — sized by demand, colored by stress.
-
-    Cold or empty regions are dropped from the figure (rather than rendering
-    as zero-size markers). When every region is cold the function returns an
-    empty-state div — the page already has the warming language in the title.
-    """
-    # Drop NaN / non-finite / zero demand regions — they would render as
-    # zero-size markers and (worse) could push NaN into the colorscale
-    # via the stress percentage divide below.
-    populated = {r: d for r, d in region_data.items() if _is_real_positive(d.get("current_mw"))}
-
-    if not populated:
-        return html.Div(
-            html.Div(
-                "All regions warming up — switch to Cards view to see per-region status.",
-                className="gp-region-map__empty-message",
-            ),
-            className="gp-region-map gp-region-map--empty",
-        )
-
-    regions = list(populated.keys())
-    lats = [REGION_COORDINATES[r]["lat"] for r in regions]
-    lons = [REGION_COORDINATES[r]["lon"] for r in regions]
-    names = [REGION_NAMES.get(r, r) for r in regions]
-    demand_gw = [populated[r]["current_mw"] / 1000 for r in regions]
-
-    # Stress = demand / capacity (0..>1). Cap at 100% for the colorscale.
-    stress_pct: list[float] = []
-    for r in regions:
-        cap = REGION_CAPACITY_MW.get(r, 0)
-        if cap > 0:
-            stress_pct.append(min(populated[r]["current_mw"] / cap * 100, 100.0))
-        else:
-            stress_pct.append(0.0)
-
-    # Marker size: 10–40 px, scaled by demand. Linear is fine for 16 points.
-    max_demand = max(demand_gw)
-    sizes = [10 + (d / max_demand) * 30 for d in demand_gw]
-
-    # V3.η: append " · imports" suffix to the BA name for structurally
-    # import-dominated BAs (CPLW, HST, SPA) so users understand what
-    # the utilization % is measured against (a peak × 1.15 estimate,
-    # not a measured plate capacity).
-    hover_text = [
-        f"<b>{name}{' · imports' if r in IS_IMPORT_DOMINATED else ''}</b>"
-        f"<br>Demand: {d:.1f} GW<br>Utilization: {s:.0f}%"
-        for r, name, d, s in zip(regions, names, demand_gw, stress_pct, strict=False)
-    ]
-
-    fig = go.Figure(
-        go.Scattergeo(
-            lat=lats,
-            lon=lons,
-            mode="markers",
-            marker={
-                "size": sizes,
-                "color": stress_pct,
-                "colorscale": _MAP_COLORSCALE,
-                "cmin": 0,
-                "cmax": 100,
-                "colorbar": {
-                    "title": {
-                        "text": "Utilization %",
-                        "font": {"color": _MAP_AXIS_FONT_COLOR, "size": 10},
-                    },
-                    "tickfont": {"color": _MAP_AXIS_FONT_COLOR, "size": 10},
-                    "thickness": 10,
-                    "len": 0.6,
-                    "bgcolor": "rgba(0,0,0,0)",
-                    "bordercolor": _MAP_BORDER_COLOR,
-                    "borderwidth": 1,
-                    "x": 1.0,
-                },
-                "line": {"color": _MAP_BORDER_COLOR, "width": 1},
-            },
-            customdata=regions,
-            hovertext=hover_text,
-            hoverinfo="text",
-        )
-    )
-
-    fig.update_geos(
-        scope="usa",
-        projection_type="albers usa",
-        showland=True,
-        landcolor=_MAP_LAND_COLOR,
-        showcoastlines=True,
-        coastlinecolor=_MAP_COASTLINE_COLOR,
-        showsubunits=True,
-        subunitcolor=_MAP_SUBUNIT_COLOR,
-        showcountries=False,
-        showlakes=False,
-        bgcolor="rgba(0,0,0,0)",
-    )
-
-    fig.update_layout(
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor="rgba(0,0,0,0)",
-        margin={"l": 0, "r": 0, "t": 8, "b": 0},
-        font={"family": "Inter, system-ui, sans-serif", "color": _MAP_AXIS_FONT_COLOR, "size": 11},
-        height=480,
-        showlegend=False,
-        hoverlabel={
-            "bgcolor": _MAP_LAND_COLOR,
-            "bordercolor": _MAP_COASTLINE_COLOR,
-            "font": {"color": "#e4e4e7", "family": "Inter, system-ui, sans-serif", "size": 12},
-        },
-    )
-
-    return html.Div(
-        dcc.Graph(
-            id="us-grid-map",
-            figure=fig,
-            config={"displayModeBar": False, "responsive": True},
-            style={"height": "480px"},
-        ),
-        className="gp-region-map",
-    )
-
-
-# ── V3.β: Choropleth (real BA service-territory polygons) ────
-
-
-# In-memory cache for the polygon GeoJSON. Read once per process.
-# The asset is ~165 KB so the parse is cheap, but we don't want to
-# do it on every render.
-_BA_POLYGONS_CACHE: dict | None = None
-
-
-def _load_ba_polygons() -> dict | None:
-    """Load and cache the BA-polygon GeoJSON from ``assets/``.
-
-    Returns ``None`` if the file is missing or malformed — the
-    choropleth helper falls back to the centroid scatter in that case
-    so a corrupt asset doesn't black out the Map view entirely.
-    """
-    global _BA_POLYGONS_CACHE
-    if _BA_POLYGONS_CACHE is not None:
-        return _BA_POLYGONS_CACHE
-
-    import json as _json
-    from pathlib import Path
-
-    asset_path = Path(__file__).parent.parent / "assets" / "ba_polygons.geojson"
-    try:
-        with open(asset_path) as f:
-            _BA_POLYGONS_CACHE = _json.load(f)
-    except Exception as exc:  # pragma: no cover — defensive
-        log.warning("ba_polygons_load_failed", error=str(exc))
-        _BA_POLYGONS_CACHE = None
-    return _BA_POLYGONS_CACHE
-
-
-def _build_us_grid_choropleth(region_data: dict) -> html.Div:
-    """Plotly ``Choropleth`` of BA service-territory polygons — colored
-    by demand-vs-capacity utilization. Same colorscale + drilldown as
-    the centroid scatter so users can switch between them seamlessly.
-
-    V3.β closes the deferral noted in V1.γ — centroids were "80% of the
-    visual punch for 10% of the cost"; this delivers the remaining 20%.
-    Polygons sourced from electricitymaps-contrib's world.geojson (MIT
-    license), filtered to our 51 BA codes via EIA-930 respondent
-    suffixes, ~165 KB pre-simplified.
-
-    Falls back to the centroid scatter when the GeoJSON asset is
-    missing or unreadable so a corrupt file can't black out the tab.
-    """
-    geojson = _load_ba_polygons()
-    if geojson is None:
-        return _build_us_grid_map(region_data)
-
-    populated = {r: d for r, d in region_data.items() if _is_real_positive(d.get("current_mw"))}
-    if not populated:
-        return html.Div(
-            html.Div(
-                "All regions warming up — switch to Cards view to see per-region status.",
-                className="gp-region-map__empty-message",
-            ),
-            className="gp-region-map gp-region-map--empty",
-        )
-
-    regions = list(populated.keys())
-    stress_pct: list[float] = []
-    for r in regions:
-        cap = REGION_CAPACITY_MW.get(r, 0)
-        if cap > 0:
-            stress_pct.append(min(populated[r]["current_mw"] / cap * 100, 100.0))
-        else:
-            stress_pct.append(0.0)
-
-    names = [REGION_NAMES.get(r, r) for r in regions]
-    demand_gw = [populated[r]["current_mw"] / 1000 for r in regions]
-    # V3.η: customdata[3] = " · imports" suffix for import-dominated
-    # BAs, empty string for everyone else. Plotly hovertemplate renders
-    # the empty string invisibly so we don't need separate templates.
-    import_tag = [" · imports" if r in IS_IMPORT_DOMINATED else "" for r in regions]
-    customdata = list(zip(regions, names, demand_gw, import_tag, strict=False))
-
-    fig = go.Figure(
-        go.Choropleth(
-            geojson=geojson,
-            featureidkey="properties.region",
-            locations=regions,
-            z=stress_pct,
-            colorscale=_MAP_COLORSCALE,
-            zmin=0,
-            zmax=100,
-            marker={"line": {"color": _MAP_BORDER_COLOR, "width": 1.0}},
-            colorbar={
-                "title": {
-                    "text": "Utilization %",
-                    "font": {"color": _MAP_AXIS_FONT_COLOR, "size": 10},
-                },
-                "tickfont": {"color": _MAP_AXIS_FONT_COLOR, "size": 10},
-                "thickness": 10,
-                "len": 0.6,
-                "bgcolor": "rgba(0,0,0,0)",
-                "bordercolor": _MAP_BORDER_COLOR,
-                "borderwidth": 1,
-                "x": 1.0,
-            },
-            # Drilldown reads ``customdata`` (the BA code) — same shape
-            # as the scatter so the existing ``us-grid-map.clickData``
-            # callback handles it without changes.
-            customdata=customdata,
-            hovertemplate=(
-                "<b>%{customdata[1]}</b>%{customdata[3]}<br>"
-                "Demand: %{customdata[2]:.1f} GW<br>"
-                "Utilization: %{z:.0f}%<extra></extra>"
-            ),
-        )
-    )
-    fig.update_geos(
-        scope="usa",
-        projection_type="albers usa",
-        showland=True,
-        landcolor=_MAP_LAND_COLOR,
-        showcoastlines=True,
-        coastlinecolor=_MAP_COASTLINE_COLOR,
-        showsubunits=True,
-        subunitcolor=_MAP_SUBUNIT_COLOR,
-        showcountries=False,
-        showlakes=False,
-        bgcolor="rgba(0,0,0,0)",
-    )
-    fig.update_layout(
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor="rgba(0,0,0,0)",
-        margin={"l": 0, "r": 0, "t": 8, "b": 0},
-        font={"family": "Inter, system-ui, sans-serif", "color": _MAP_AXIS_FONT_COLOR, "size": 11},
-        height=480,
-        showlegend=False,
-        hoverlabel={
-            "bgcolor": _MAP_LAND_COLOR,
-            "bordercolor": _MAP_COASTLINE_COLOR,
-            "font": {"color": "#e4e4e7", "family": "Inter, system-ui, sans-serif", "size": 12},
-        },
-    )
-
-    # Coverage caption — disambiguates the dark-fill gaps in the
-    # Polygons view (Idaho, parts of Montana / Wyoming / the Plains,
-    # AK + HI insets) as intentional unmapped territory, not a
-    # rendering bug. EIA-930 has ~64 BAs in the lower 48; we ship
-    # polygons for ~51 (~80% of demand). Renders only inside the
-    # Polygons view body — Cards / Map don't have coverage gaps to
-    # disclose.
-    n_covered = len(regions)
-    caption = html.Div(
-        f"{n_covered} of ~64 lower-48 balancing authorities mapped · "
-        "dark areas are EIA-930 BAs not yet covered here.",
-        className="gp-region-map__coverage-caption",
-    )
-
-    return html.Div(
-        [
-            dcc.Graph(
-                id="us-grid-map",
-                figure=fig,
-                config={"displayModeBar": False, "responsive": True},
-                style={"height": "480px"},
-            ),
-            caption,
-        ],
-        className="gp-region-map",
-    )
+from components._callbacks_us_grid import (  # noqa: E402
+    _BA_POLYGONS_CACHE,  # noqa: F401 — re-export
+    _build_interchange_chip,  # noqa: F401 — re-export
+    _build_us_grid_choropleth,  # noqa: F401 — re-export
+    _build_us_grid_map,  # noqa: F401 — re-export
+    _build_us_grid_metrics_items,  # noqa: F401 — re-export
+    _build_us_grid_region_card,  # noqa: F401 — re-export
+    _build_us_grid_sparkline,  # noqa: F401 — re-export
+    _build_us_grid_title,  # noqa: F401 — re-export
+    _collect_us_grid_region_data,  # noqa: F401 — re-export
+    _is_real_positive,  # noqa: F401 — re-export
+    _load_ba_polygons,  # noqa: F401 — re-export
+)

--- a/tests/unit/test_tab_us_grid.py
+++ b/tests/unit/test_tab_us_grid.py
@@ -112,7 +112,7 @@ class TestRegionDataCollection:
         from components.callbacks import _collect_us_grid_region_data
         from config import REGION_NAMES
 
-        with patch("components.callbacks.redis_get", return_value=None):
+        with patch("components._callbacks_us_grid.redis_get", return_value=None):
             data = _collect_us_grid_region_data()
 
         assert set(data.keys()) == set(REGION_NAMES.keys())
@@ -123,7 +123,7 @@ class TestRegionDataCollection:
         from components.callbacks import _collect_us_grid_region_data
 
         synthetic = {"demand_mw": list(range(1000, 1050))}  # 50 entries
-        with patch("components.callbacks.redis_get", return_value=synthetic):
+        with patch("components._callbacks_us_grid.redis_get", return_value=synthetic):
             data = _collect_us_grid_region_data()
 
         sample = next(iter(data.values()))

--- a/tests/unit/test_us_grid_choropleth.py
+++ b/tests/unit/test_us_grid_choropleth.py
@@ -184,7 +184,7 @@ class TestChoroplethRender:
         from components import callbacks as cb
 
         # Force the loader to return None (asset corrupt / missing)
-        with patch("components.callbacks._load_ba_polygons", return_value=None):
+        with patch("components._callbacks_us_grid._load_ba_polygons", return_value=None):
             body = cb._build_us_grid_choropleth({"PJM": {"current_mw": 70_000.0}})
         # Scatter helper returns a Div with the same gp-region-map class
         # but a Scattergeo trace.

--- a/tests/unit/test_us_grid_nan_guard.py
+++ b/tests/unit/test_us_grid_nan_guard.py
@@ -140,12 +140,11 @@ class TestCollectUsGridRegionData:
 
     def _patch_redis(self, monkeypatch, redis_state):
         """Helper: patch redis_get to return matching keys from the dict."""
-        from components import callbacks as cb
 
         def _get(key):
             return redis_state.get(key)
 
-        monkeypatch.setattr(cb, "redis_get", _get)
+        monkeypatch.setattr("components._callbacks_us_grid.redis_get", _get)
 
     def test_clean_demand_tail(self, monkeypatch):
         from components.callbacks import _collect_us_grid_region_data
@@ -155,7 +154,7 @@ class TestCollectUsGridRegionData:
             {"wattcast:actuals:PJM": {"demand_mw": [70000.0, 71000.0, 72000.0]}},
         )
         # Limit to one region for clarity
-        with patch("components.callbacks.REGION_NAMES", {"PJM": "Mid-Atlantic (PJM)"}):
+        with patch("components._callbacks_us_grid.REGION_NAMES", {"PJM": "Mid-Atlantic (PJM)"}):
             data = _collect_us_grid_region_data()
         assert data["PJM"]["current_mw"] == 72000.0
         assert data["PJM"]["prev_mw"] == 71000.0
@@ -169,7 +168,7 @@ class TestCollectUsGridRegionData:
             monkeypatch,
             {"wattcast:actuals:PSCO": {"demand_mw": [9000.0, 9100.0, 9200.0, float("nan")]}},
         )
-        with patch("components.callbacks.REGION_NAMES", {"PSCO": "Colorado (Xcel)"}):
+        with patch("components._callbacks_us_grid.REGION_NAMES", {"PSCO": "Colorado (Xcel)"}):
             data = _collect_us_grid_region_data()
         assert data["PSCO"]["current_mw"] == 9200.0
         assert data["PSCO"]["prev_mw"] == 9100.0
@@ -185,7 +184,7 @@ class TestCollectUsGridRegionData:
             monkeypatch,
             {"wattcast:actuals:HECO": {"demand_mw": [nan, nan, nan, nan]}},
         )
-        with patch("components.callbacks.REGION_NAMES", {"HECO": "Hawaii (HECO)"}):
+        with patch("components._callbacks_us_grid.REGION_NAMES", {"HECO": "Hawaii (HECO)"}):
             data = _collect_us_grid_region_data()
         assert data["HECO"]["current_mw"] is None
         assert data["HECO"]["prev_mw"] is None
@@ -254,7 +253,7 @@ class TestUsGridRegionCardNaNGuard:
         from components.callbacks import _build_us_grid_region_card
 
         # Card path mocks REGION_NAMES indirectly via REGION_NAMES.get
-        with patch("components.callbacks.REGION_NAMES", {"PSCO": "Colorado (Xcel)"}):
+        with patch("components._callbacks_us_grid.REGION_NAMES", {"PSCO": "Colorado (Xcel)"}):
             card = _build_us_grid_region_card("PSCO", {"current_mw": float("nan")})
         # Walk the card looking for "nan" in any string content
 
@@ -278,7 +277,7 @@ class TestUsGridRegionCardNaNGuard:
     def test_none_current_renders_placeholder(self):
         from components.callbacks import _build_us_grid_region_card
 
-        with patch("components.callbacks.REGION_NAMES", {"PSCO": "Colorado (Xcel)"}):
+        with patch("components._callbacks_us_grid.REGION_NAMES", {"PSCO": "Colorado (Xcel)"}):
             card = _build_us_grid_region_card("PSCO", {"current_mw": None})
         # Should pick the empty-card class, not the populated one
         assert "gp-region-card--empty" in (card.className or "")
@@ -289,7 +288,7 @@ class TestUsGridTitleNaNGuard:
         """Title bar's 'X.X GW total demand' must not say 'nan GW'."""
         from components.callbacks import _build_us_grid_title
 
-        with patch("components.callbacks.REGION_NAMES", {"PJM": "PJM", "PSCO": "PSCO"}):
+        with patch("components._callbacks_us_grid.REGION_NAMES", {"PJM": "PJM", "PSCO": "PSCO"}):
             title = _build_us_grid_title(
                 {
                     "PJM": {"current_mw": 70000.0},
@@ -320,7 +319,7 @@ class TestUsGridTitleNaNGuard:
     def test_all_nan_renders_warming(self):
         from components.callbacks import _build_us_grid_title
 
-        with patch("components.callbacks.REGION_NAMES", {"PJM": "PJM", "PSCO": "PSCO"}):
+        with patch("components._callbacks_us_grid.REGION_NAMES", {"PJM": "PJM", "PSCO": "PSCO"}):
             title = _build_us_grid_title(
                 {
                     "PJM": {"current_mw": float("nan")},

--- a/tests/unit/test_us_grid_stress_cap.py
+++ b/tests/unit/test_us_grid_stress_cap.py
@@ -94,7 +94,7 @@ class TestMetricsBarStressCap:
 
         # Inject a region with stress between 100% and ceiling
         with patch.dict(
-            "components.callbacks.REGION_CAPACITY_MW",
+            "components._callbacks_us_grid.REGION_CAPACITY_MW",
             {"PJM": 50000},  # 70000/50000 = 140% (reliable but over 100%)
             clear=False,
         ):
@@ -149,7 +149,7 @@ class TestRegionCardStressChip:
         from components.callbacks import _build_us_grid_region_card
 
         # CPLW with realistic served demand vs in-territory capacity
-        with patch("components.callbacks.REGION_NAMES", {"CPLW": "DEP-W (NC mtn)"}):
+        with patch("components._callbacks_us_grid.REGION_NAMES", {"CPLW": "DEP-W (NC mtn)"}):
             card = _build_us_grid_region_card(
                 "CPLW",
                 {"current_mw": 449.0, "prev_mw": 445.0, "today_mw": [449.0] * 24},
@@ -164,7 +164,7 @@ class TestRegionCardStressChip:
         regular percentage."""
         from components.callbacks import _build_us_grid_region_card
 
-        with patch("components.callbacks.REGION_NAMES", {"PJM": "Mid-Atlantic (PJM)"}):
+        with patch("components._callbacks_us_grid.REGION_NAMES", {"PJM": "Mid-Atlantic (PJM)"}):
             card = _build_us_grid_region_card(
                 "PJM",
                 {"current_mw": 70000.0, "prev_mw": 69000.0, "today_mw": [70000.0] * 24},
@@ -184,11 +184,11 @@ class TestRegionCardStressChip:
 
         with (
             patch.dict(
-                "components.callbacks.REGION_CAPACITY_MW",
+                "components._callbacks_us_grid.REGION_CAPACITY_MW",
                 {"PJM": 50000},  # 140%
                 clear=False,
             ),
-            patch("components.callbacks.REGION_NAMES", {"PJM": "PJM"}),
+            patch("components._callbacks_us_grid.REGION_NAMES", {"PJM": "PJM"}),
         ):
             card = _build_us_grid_region_card(
                 "PJM",
@@ -214,7 +214,7 @@ class TestStressCeilingThreshold:
         from components.callbacks import _build_us_grid_metrics_items
 
         with patch.dict(
-            "components.callbacks.REGION_CAPACITY_MW", {"PJM": 35176}, clear=False
+            "components._callbacks_us_grid.REGION_CAPACITY_MW", {"PJM": 35176}, clear=False
         ):  # 70000/35176 ≈ 199%
             region_data = {"PJM": {"current_mw": 70000.0, "today_mw": [70000.0] * 24}}
             items = _build_us_grid_metrics_items(region_data)
@@ -226,7 +226,7 @@ class TestStressCeilingThreshold:
         from components.callbacks import _build_us_grid_metrics_items
 
         with patch.dict(
-            "components.callbacks.REGION_CAPACITY_MW", {"PJM": 34825}, clear=False
+            "components._callbacks_us_grid.REGION_CAPACITY_MW", {"PJM": 34825}, clear=False
         ):  # 70000/34825 ≈ 201%
             region_data = {
                 "PJM": {"current_mw": 70000.0, "today_mw": [70000.0] * 24},


### PR DESCRIPTION
Step 2 of #87. Pulls the US Grid tab's data-collection + render helpers (cards / map / polygons) out of callbacks.py into `components/_callbacks_us_grid.py`. Also promotes `_latest_real_demand` to shared since it's cross-tab.

**callbacks.py: 7,051 → 6,389 lines** (-662 from this PR, -778 cumulative since #98)

## Moved (720 lines)

- `_collect_us_grid_region_data` — Redis fan-out for the 51-BA card grid
- `_build_us_grid_title` — page title + V3.ζ hidden-region annotation
- `_is_real_positive` — NaN guard used across US Grid arithmetic
- `_build_us_grid_metrics_items` — 4-up MetricsBar with stress cap
- `_build_us_grid_sparkline` — per-card 24h sparkline SVG
- `_build_interchange_chip` — V3.α net interchange chip
- `_build_us_grid_region_card` — single region card (with V3.η imports chip)
- `_build_us_grid_map` — Plotly `scatter_geo` centroid view
- `_load_ba_polygons` + `_BA_POLYGONS_CACHE` — geojson loader + cache
- `_build_us_grid_choropleth` — Plotly `Choropleth` polygon view

## Test-path updates

Module-relocation refactors need `patch()` / `monkeypatch` targets updated — the function reads its imports from its OWN module namespace, so patches must target that namespace. 4 test files affected, mechanical sed replacement, no behavior changes:
- `components.callbacks.redis_get` → `components._callbacks_us_grid.redis_get`
- `components.callbacks.REGION_NAMES` → `components._callbacks_us_grid.REGION_NAMES`
- `components.callbacks.REGION_CAPACITY_MW` → `components._callbacks_us_grid.REGION_CAPACITY_MW`
- `components.callbacks._load_ba_polygons` → `components._callbacks_us_grid._load_ba_polygons`

## Public-import surface preserved

callbacks.py re-imports every moved symbol via explicit named imports. `app.py` and the test `from components.callbacks import <X>` sites resolve unchanged.

## Verification

- All 1,688 tests pass
- `ruff check` + `ruff format --check` clean
- Polygon visibility regression tests pass

🤖 Generated with Claude Code