### PR TITLE
refactor(callbacks): extract Weather tab fast path to _callbacks_weather.py

### DIFF
--- a/components/_callbacks_weather.py
+++ b/components/_callbacks_weather.py
@@ -1,0 +1,191 @@
+"""Weather-Energy Correlation tab helpers extracted from ``components/callbacks.py``.
+
+Step 6 of the ``callbacks.py`` decomposition tracked in issue #87.
+Continues the per-tab split established by:
+
+* #98 — shared infrastructure (``_callbacks_shared.py``)
+* #99 — US Grid tab (``_callbacks_us_grid.py``)
+* #100 — Models tab (``_callbacks_models.py``)
+* #101 — Alerts tab (``_callbacks_alerts.py``)
+* #102 — Generation tab (``_callbacks_generation.py``)
+
+## What lives here
+
+``_weather_tab_from_redis`` — the Redis fast path that builds the six
+Plotly figures (temp/wind/solar scatters, correlation heatmap, feature-
+importance bar chart, seasonal decomposition subplots) for the
+Weather-Energy Correlation tab from the scoring job's hourly
+``wattcast:weather-correlation:{region}`` payload.
+
+## Orphaned-callback observation
+
+Like ``_generation_tab_from_redis`` before it (#102), this fast path is
+no longer wired into ``register_callbacks``. Tests still exercise it,
+so the re-export stays — but a follow-up should decide whether to fully
+delete or re-wire.
+
+## Public-import surface
+
+``components/callbacks.py`` re-imports ``_weather_tab_from_redis`` by
+name with an explicit ``# noqa: F401 — re-export`` marker (tests import
+via ``from components.callbacks import``).
+
+When patching for tests, target the function's *new* namespace:
+
+    @patch("components._callbacks_weather.redis_get")  # ✓
+    @patch("components.callbacks.redis_get")           # ✗ (no effect)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import plotly.graph_objects as go
+import structlog
+from plotly.subplots import make_subplots
+
+from components._callbacks_shared import COLORS, _layout
+from data.redis_client import redis_get
+
+log = structlog.get_logger()
+
+
+def _weather_tab_from_redis(region):
+    """Redis fast path for update_weather_tab callback.
+
+    Returns a 6-tuple of Plotly figures or None if cache miss.
+    """
+    cached = redis_get(f"wattcast:weather-correlation:{region}")
+    if cached is None:
+        return None
+
+    log.info("weather_redis_hit", region=region)
+    corr_data = cached.get("correlation_matrix", {})
+    imp_data = cached.get("importance", {})
+    seasonal = cached.get("seasonal", {})
+
+    # Scatter: Temperature vs Demand
+    fig_temp = go.Figure(
+        go.Scatter(
+            x=cached.get("temperature_2m", []),
+            y=cached.get("demand_mw", []),
+            mode="markers",
+            marker=dict(size=3, color=COLORS["actual"], opacity=0.4),
+        )
+    )
+    fig_temp.update_layout(
+        **_layout(uirevision=region, xaxis_title="Temperature (°F)", yaxis_title="Demand (MW)")
+    )
+
+    # Scatter: Wind
+    fig_wind = go.Figure(
+        go.Scatter(
+            x=cached.get("wind_speed_80m", []),
+            y=cached.get("wind_power", []),
+            mode="markers",
+            marker=dict(size=3, color=COLORS["wind"], opacity=0.5),
+        )
+    )
+    fig_wind.update_layout(
+        **_layout(
+            uirevision=region,
+            xaxis_title="Wind Speed (mph)",
+            yaxis_title="Wind Power Estimate",
+        )
+    )
+
+    # Scatter: Solar
+    fig_solar = go.Figure(
+        go.Scatter(
+            x=cached.get("shortwave_radiation", []),
+            y=cached.get("solar_cf", []),
+            mode="markers",
+            marker=dict(size=3, color=COLORS["solar"], opacity=0.5),
+        )
+    )
+    fig_solar.update_layout(
+        **_layout(
+            uirevision=region,
+            xaxis_title="GHI (W/m²)",
+            yaxis_title="Solar Capacity Factor",
+        )
+    )
+
+    # Heatmap
+    corr_cols = corr_data.get("cols", [])
+    corr_vals = corr_data.get("values", [])
+    fig_heatmap = go.Figure(
+        go.Heatmap(
+            z=corr_vals,
+            x=corr_cols,
+            y=corr_cols,
+            colorscale="RdBu",
+            zmid=0,
+            text=np.round(np.array(corr_vals), 2) if corr_vals else [],
+            texttemplate="%{text}",
+        )
+    )
+    fig_heatmap.update_layout(**_layout(uirevision=region))
+
+    # Feature importance
+    imp_names = imp_data.get("names", [])
+    imp_vals = imp_data.get("values", [])
+    fig_importance = go.Figure(
+        go.Bar(
+            x=imp_vals,
+            y=imp_names,
+            orientation="h",
+            marker_color=COLORS["ensemble"],
+        )
+    )
+    fig_importance.update_layout(**_layout(uirevision=region, xaxis_title="Correlation Strength"))
+
+    # Seasonal decomposition
+    s_ts = pd.to_datetime(seasonal.get("timestamps", []))
+    s_orig = seasonal.get("original", [])
+    s_trend = seasonal.get("trend", [])
+    s_resid = seasonal.get("residual", [])
+    fig_seasonal = make_subplots(
+        rows=3,
+        cols=1,
+        shared_xaxes=True,
+        subplot_titles=["Original", "Trend (7-day)", "Residual"],
+    )
+    fig_seasonal.add_trace(
+        go.Scatter(
+            x=s_ts,
+            y=s_orig,
+            line=dict(color=COLORS["actual"], width=1),
+            showlegend=False,
+        ),
+        row=1,
+        col=1,
+    )
+    fig_seasonal.add_trace(
+        go.Scatter(
+            x=s_ts,
+            y=s_trend,
+            line=dict(color=COLORS["ensemble"], width=2),
+            showlegend=False,
+        ),
+        row=2,
+        col=1,
+    )
+    fig_seasonal.add_trace(
+        go.Scatter(
+            x=s_ts,
+            y=s_resid,
+            line=dict(color=COLORS["arima"], width=1),
+            showlegend=False,
+        ),
+        row=3,
+        col=1,
+    )
+    fig_seasonal.update_layout(**_layout(uirevision=region, height=350))
+
+    return fig_temp, fig_wind, fig_solar, fig_heatmap, fig_importance, fig_seasonal
+
+
+__all__ = [
+    "_weather_tab_from_redis",
+]

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -26,7 +26,6 @@ import pandas as pd
 import plotly.graph_objects as go
 import structlog
 from dash import ALL, Input, Output, State, ctx, dcc, html, no_update
-from plotly.subplots import make_subplots
 
 # Shared infrastructure — caches, layout helpers, color tokens, basemap
 # constants — lives in ``_callbacks_shared.py``. The explicit re-import
@@ -69,6 +68,9 @@ from components._callbacks_shared import (
     _empty_figure,
     _latest_real_demand,
     _layout,
+)
+from components._callbacks_weather import (
+    _weather_tab_from_redis,  # noqa: F401 — re-export (tests/unit/test_redis_fast_paths.py); fast path is currently orphaned in register_callbacks
 )
 from components.accessibility import CB_PALETTE, LINE_STYLES
 from components.cards import (
@@ -998,142 +1000,6 @@ def _load_data_from_redis(region):
         audit_record.to_json(),
         json.dumps(pipeline_summary, default=str),
     )
-
-
-def _weather_tab_from_redis(region):
-    """Redis fast path for update_weather_tab callback.
-
-    Returns a 6-tuple of Plotly figures or None if cache miss.
-    """
-    cached = redis_get(f"wattcast:weather-correlation:{region}")
-    if cached is None:
-        return None
-
-    log.info("weather_redis_hit", region=region)
-    corr_data = cached.get("correlation_matrix", {})
-    imp_data = cached.get("importance", {})
-    seasonal = cached.get("seasonal", {})
-
-    # Scatter: Temperature vs Demand
-    fig_temp = go.Figure(
-        go.Scatter(
-            x=cached.get("temperature_2m", []),
-            y=cached.get("demand_mw", []),
-            mode="markers",
-            marker=dict(size=3, color=COLORS["actual"], opacity=0.4),
-        )
-    )
-    fig_temp.update_layout(
-        **_layout(uirevision=region, xaxis_title="Temperature (°F)", yaxis_title="Demand (MW)")
-    )
-
-    # Scatter: Wind
-    fig_wind = go.Figure(
-        go.Scatter(
-            x=cached.get("wind_speed_80m", []),
-            y=cached.get("wind_power", []),
-            mode="markers",
-            marker=dict(size=3, color=COLORS["wind"], opacity=0.5),
-        )
-    )
-    fig_wind.update_layout(
-        **_layout(
-            uirevision=region,
-            xaxis_title="Wind Speed (mph)",
-            yaxis_title="Wind Power Estimate",
-        )
-    )
-
-    # Scatter: Solar
-    fig_solar = go.Figure(
-        go.Scatter(
-            x=cached.get("shortwave_radiation", []),
-            y=cached.get("solar_cf", []),
-            mode="markers",
-            marker=dict(size=3, color=COLORS["solar"], opacity=0.5),
-        )
-    )
-    fig_solar.update_layout(
-        **_layout(
-            uirevision=region,
-            xaxis_title="GHI (W/m²)",
-            yaxis_title="Solar Capacity Factor",
-        )
-    )
-
-    # Heatmap
-    corr_cols = corr_data.get("cols", [])
-    corr_vals = corr_data.get("values", [])
-    fig_heatmap = go.Figure(
-        go.Heatmap(
-            z=corr_vals,
-            x=corr_cols,
-            y=corr_cols,
-            colorscale="RdBu",
-            zmid=0,
-            text=np.round(np.array(corr_vals), 2) if corr_vals else [],
-            texttemplate="%{text}",
-        )
-    )
-    fig_heatmap.update_layout(**_layout(uirevision=region))
-
-    # Feature importance
-    imp_names = imp_data.get("names", [])
-    imp_vals = imp_data.get("values", [])
-    fig_importance = go.Figure(
-        go.Bar(
-            x=imp_vals,
-            y=imp_names,
-            orientation="h",
-            marker_color=COLORS["ensemble"],
-        )
-    )
-    fig_importance.update_layout(**_layout(uirevision=region, xaxis_title="Correlation Strength"))
-
-    # Seasonal decomposition
-    s_ts = pd.to_datetime(seasonal.get("timestamps", []))
-    s_orig = seasonal.get("original", [])
-    s_trend = seasonal.get("trend", [])
-    s_resid = seasonal.get("residual", [])
-    fig_seasonal = make_subplots(
-        rows=3,
-        cols=1,
-        shared_xaxes=True,
-        subplot_titles=["Original", "Trend (7-day)", "Residual"],
-    )
-    fig_seasonal.add_trace(
-        go.Scatter(
-            x=s_ts,
-            y=s_orig,
-            line=dict(color=COLORS["actual"], width=1),
-            showlegend=False,
-        ),
-        row=1,
-        col=1,
-    )
-    fig_seasonal.add_trace(
-        go.Scatter(
-            x=s_ts,
-            y=s_trend,
-            line=dict(color=COLORS["ensemble"], width=2),
-            showlegend=False,
-        ),
-        row=2,
-        col=1,
-    )
-    fig_seasonal.add_trace(
-        go.Scatter(
-            x=s_ts,
-            y=s_resid,
-            line=dict(color=COLORS["arima"], width=1),
-            showlegend=False,
-        ),
-        row=3,
-        col=1,
-    )
-    fig_seasonal.update_layout(**_layout(uirevision=region, height=350))
-
-    return fig_temp, fig_wind, fig_solar, fig_heatmap, fig_importance, fig_seasonal
 
 
 def _outlook_tab_from_redis(

--- a/tests/unit/test_redis_fast_paths.py
+++ b/tests/unit/test_redis_fast_paths.py
@@ -304,7 +304,7 @@ class TestLoadDataFromRedis:
 class TestWeatherTabFromRedis:
     """Tests for _weather_tab_from_redis(region)."""
 
-    @patch("components.callbacks.redis_get")
+    @patch("components._callbacks_weather.redis_get")
     def test_full_data_returns_6_figures(self, mock_rg):
         """Full cached weather correlation data → returns 6 go.Figures."""
         mock_rg.return_value = _weather_correlation_payload()
@@ -317,7 +317,7 @@ class TestWeatherTabFromRedis:
         for fig in result:
             assert isinstance(fig, go.Figure)
 
-    @patch("components.callbacks.redis_get")
+    @patch("components._callbacks_weather.redis_get")
     def test_cache_miss_returns_none(self, mock_rg):
         """Cache miss → returns None."""
         mock_rg.return_value = None
@@ -326,7 +326,7 @@ class TestWeatherTabFromRedis:
 
         assert _weather_tab_from_redis("FPL") is None
 
-    @patch("components.callbacks.redis_get")
+    @patch("components._callbacks_weather.redis_get")
     def test_empty_correlation_matrix_still_creates_figures(self, mock_rg):
         """Empty correlation matrix → figures still created (no crash)."""
         payload = _weather_correlation_payload()
@@ -339,7 +339,7 @@ class TestWeatherTabFromRedis:
         assert result is not None
         assert len(result) == 6
 
-    @patch("components.callbacks.redis_get")
+    @patch("components._callbacks_weather.redis_get")
     def test_scatter_plots_have_traces(self, mock_rg):
         """Temperature, wind, solar scatter plots have marker traces."""
         mock_rg.return_value = _weather_correlation_payload()
@@ -356,7 +356,7 @@ class TestWeatherTabFromRedis:
         assert len(fig_solar.data) == 1
         assert fig_solar.data[0].mode == "markers"
 
-    @patch("components.callbacks.redis_get")
+    @patch("components._callbacks_weather.redis_get")
     def test_heatmap_uses_rdbu_colorscale(self, mock_rg):
         """Heatmap figure uses RdBu colorscale."""
         mock_rg.return_value = _weather_correlation_payload()


### PR DESCRIPTION
## Summary

Step 6 of the ``callbacks.py`` decomposition (issue #87). First PR after the previous stack of 5 (#98–#102) all landed in `main`, so this one is based directly on a clean main.

- ``_weather_tab_from_redis`` (~134 lines) moves out of callbacks.py into ``components/_callbacks_weather.py``.
- 5 ``@patch("components.callbacks.redis_get")`` decorators inside ``TestWeatherTabFromRedis`` rewired to ``components._callbacks_weather`` — standard "patch where it's used, not where it's defined."
- Same orphaned-callback story as #102: Weather fast path is tested but no longer wired in ``register_callbacks``. Kept the re-export, flagged with ``# noqa``. Likely a deferred cleanup from an earlier refactor.

## Size impact

| File | Before | After | Δ |
|---|---|---|---|
| `components/callbacks.py` | 5,802 | 5,668 | **–134** |
| `components/_callbacks_weather.py` | — | 191 | new |

## Cumulative progress

| PR | Tab | callbacks.py | Δ |
|---|---|---|---|
| #98 | Shared | 7,167 → 7,051 | –116 |
| #99 | US Grid | 7,051 → 6,389 | –662 |
| #100 | Models | 6,389 → 6,183 | –206 |
| #101 | Alerts | 6,183 → 5,978 | –205 |
| #102 | Generation | 5,978 → 5,802 | –176 |
| **this** | **Weather** | **5,802 → 5,668** | **–134** |

**Total: −1,499 lines from the monolith across 6 PRs (−20.9%).**

## What's next

Remaining work in the decomposition plan:
- **Forecast tab** — needs deliberate cross-dep design with Backtest helpers (`_empirical_interval_from_backtests`). Multi-hour PR with shared-module factoring decisions. Will likely move that into shared first.
- **Backtest tab** — ~500 lines once Forecast cross-deps are clean.
- **Overview helpers** — ~1,900 lines (re-scoped up from the original ~600 estimate after closer inspection). Will need to split into 3 sub-PRs.
- **Final**: split `register_callbacks` into per-tab `register_X_callbacks(app)`.

## Test plan

- [x] All 1,568 unit tests pass locally
- [x] `ruff check components/` clean
- [x] `TestWeatherTabFromRedis` (5 tests) green with updated patches
- [ ] CI: lint + test + docker + security

🤖 Generated with [Claude Code](https://claude.com/claude-code)