### PR TITLE
chore(infra): add REDIS_DUAL_WRITE_PREFIX + redis_publish() helper (#91 Phase 2)

### DIFF
--- a/config.py
+++ b/config.py
@@ -108,10 +108,21 @@ REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
 # Key prefix for every Redis namespace this app touches. Issue #91 tracks
 # the multi-phase migration from the old ``wattcast:`` prefix (a project
 # name that predates GridPulse) to ``gridpulse:``. Default stays
-# ``wattcast`` until Phase 3 — Phase 1 (this commit) only introduces the
-# indirection so callsites no longer hardcode the literal. Override via
-# the ``REDIS_KEY_PREFIX`` env var without code changes.
+# ``wattcast`` until Phase 3 — Phase 1 introduced the indirection so
+# callsites no longer hardcode the literal. Override via the
+# ``REDIS_KEY_PREFIX`` env var without code changes.
 REDIS_KEY_PREFIX = os.getenv("REDIS_KEY_PREFIX", "wattcast")
+
+# Secondary prefix that producer jobs (scoring / training) mirror writes
+# to. When set, every ``redis_publish(suffix, ...)`` call writes the
+# payload to BOTH ``{REDIS_KEY_PREFIX}:{suffix}`` and
+# ``{REDIS_DUAL_WRITE_PREFIX}:{suffix}``. Phase 2 (#91) uses this to
+# warm the ``gridpulse:`` namespace while the web still reads
+# ``wattcast:`` — so Phase 3 (flipping ``REDIS_KEY_PREFIX``) finds a
+# fully-populated bucket on the new prefix. After Phase 3 stabilises,
+# Phase 4 unsets this var (and the dual-write code path removes itself).
+# Empty string = disabled (single-write to primary).
+REDIS_DUAL_WRITE_PREFIX = os.getenv("REDIS_DUAL_WRITE_PREFIX", "")
 
 # When True the web callbacks (load_data, _run_forecast_outlook,
 # _run_backtest_for_horizon) must NOT fall back to synchronous API fetches

--- a/data/redis_client.py
+++ b/data/redis_client.py
@@ -104,6 +104,53 @@ def redis_set(key: str, value: dict | list, ttl: int = 86400) -> bool:
         return False
 
 
+def redis_publish(suffix: str, value: dict | list, ttl: int = 86400) -> bool:
+    """Write a JSON value to the primary prefix and (optionally) a dual-write prefix.
+
+    Phase 2 of the ``wattcast:`` → ``gridpulse:`` migration (issue #91).
+    Producer jobs (``jobs/phases.py``) call this with a suffix like
+    ``"actuals:{region}"``; the helper composes the full key from
+    ``REDIS_KEY_PREFIX`` and writes there. When
+    ``REDIS_DUAL_WRITE_PREFIX`` is also set (Phase 2 ops), the same
+    payload is written to ``{dual_prefix}:{suffix}`` so the new
+    namespace is populated before the Phase 3 read-cutover happens.
+
+    Both writes are attempted independently. Return value is ``True`` only
+    when the **primary** write succeeds — the dual write is best-effort
+    (it's a migration safety net, not the source of truth). Dual-write
+    failures log a warning but don't fail the primary path; the next
+    scoring/training cycle will retry.
+
+    Args:
+        suffix: Key suffix after the prefix, e.g. ``"actuals:FPL"``.
+        value: JSON-serializable payload.
+        ttl: TTL in seconds (default 24h, matching scoring/training cadence).
+
+    Returns:
+        ``True`` if the primary write succeeded, ``False`` otherwise.
+    """
+    # Imported lazily for the same reason as ``redis_key`` — avoid forcing
+    # config to load before test fixtures monkeypatch the env.
+    from config import REDIS_DUAL_WRITE_PREFIX, REDIS_KEY_PREFIX
+
+    primary_key = f"{REDIS_KEY_PREFIX}:{suffix}"
+    primary_ok = redis_set(primary_key, value, ttl=ttl)
+
+    if REDIS_DUAL_WRITE_PREFIX and REDIS_DUAL_WRITE_PREFIX != REDIS_KEY_PREFIX:
+        dual_key = f"{REDIS_DUAL_WRITE_PREFIX}:{suffix}"
+        # redis_set already swallows + logs exceptions, so this just
+        # produces a structured warning on failure without raising.
+        dual_ok = redis_set(dual_key, value, ttl=ttl)
+        if not dual_ok:
+            logger.warning(
+                "redis_dual_write_failed primary=%s dual=%s — dual is best-effort",
+                primary_key,
+                dual_key,
+            )
+
+    return primary_ok
+
+
 def redis_available() -> bool:
     """Check if Redis is connected and responsive."""
     return _get_redis() is not None

--- a/jobs/phases.py
+++ b/jobs/phases.py
@@ -191,7 +191,7 @@ def _ts_list(series: Any) -> list[str]:
 
 def write_actuals_and_weather(data: RegionData) -> PhaseResult:
     """Write actuals + weather JSON payloads to Redis."""
-    from data.redis_client import redis_key, redis_set
+    from data.redis_client import redis_publish
 
     region = data.region
     try:
@@ -203,7 +203,7 @@ def write_actuals_and_weather(data: RegionData) -> PhaseResult:
             "timestamps": _ts_list(demand_df["timestamp"]),
             "demand_mw": demand_df["demand_mw"].tolist(),
         }
-        redis_set(redis_key(f"actuals:{region}"), actuals_payload, ttl=REDIS_TTL)
+        redis_publish(f"actuals:{region}", actuals_payload, ttl=REDIS_TTL)
 
         weather_payload: dict[str, Any] = {
             "region": region,
@@ -213,7 +213,7 @@ def write_actuals_and_weather(data: RegionData) -> PhaseResult:
             if col == "timestamp":
                 continue
             weather_payload[col] = weather_df[col].tolist()
-        redis_set(redis_key(f"weather:{region}"), weather_payload, ttl=REDIS_TTL)
+        redis_publish(f"weather:{region}", weather_payload, ttl=REDIS_TTL)
 
         return PhaseResult(
             region=region,
@@ -231,7 +231,7 @@ def write_actuals_and_weather(data: RegionData) -> PhaseResult:
 def write_generation(region: str) -> PhaseResult:
     """Fetch generation-by-fuel for a region and write a pivoted payload to Redis."""
     from data.eia_client import fetch_generation_by_fuel
-    from data.redis_client import redis_key, redis_set
+    from data.redis_client import redis_publish
 
     if not _has_eia_key():
         return PhaseResult(region=region, ok=False, error="no_eia_api_key")
@@ -269,7 +269,7 @@ def write_generation(region: str) -> PhaseResult:
             ren_pct = [0.0] * len(pivot)
         payload["renewable_pct"] = ren_pct
 
-        redis_set(redis_key(f"generation:{region}"), payload, ttl=REDIS_TTL)
+        redis_publish(f"generation:{region}", payload, ttl=REDIS_TTL)
         avg_ren = float(np.mean(ren_pct)) if ren_pct else 0.0
         log.info(
             "job_generation_written",
@@ -313,7 +313,7 @@ def write_interchange(region: str) -> PhaseResult:
     instead of guessing.
     """
     from data.eia_client import fetch_interchange
-    from data.redis_client import redis_key, redis_set
+    from data.redis_client import redis_publish
 
     if not _has_eia_key():
         return PhaseResult(region=region, ok=False, error="no_eia_api_key")
@@ -334,12 +334,12 @@ def write_interchange(region: str) -> PhaseResult:
 
     if flow_df is None or flow_df.empty:
         log.info("job_interchange_empty", region=region)
-        redis_set(redis_key(f"interchange:{region}:1h"), payload, ttl=REDIS_TTL)
+        redis_publish(f"interchange:{region}:1h", payload, ttl=REDIS_TTL)
         return PhaseResult(region=region, ok=True, details={"net_mw": None, "rows": 0})
 
     flow_df = flow_df.dropna(subset=["interchange_mw"])
     if flow_df.empty:
-        redis_set(redis_key(f"interchange:{region}:1h"), payload, ttl=REDIS_TTL)
+        redis_publish(f"interchange:{region}:1h", payload, ttl=REDIS_TTL)
         return PhaseResult(region=region, ok=True, details={"net_mw": None, "rows": 0})
 
     latest_ts = flow_df["timestamp"].max()
@@ -360,7 +360,7 @@ def write_interchange(region: str) -> PhaseResult:
             "counterparties": counterparties,
         }
     )
-    redis_set(redis_key(f"interchange:{region}:1h"), payload, ttl=REDIS_TTL)
+    redis_publish(f"interchange:{region}:1h", payload, ttl=REDIS_TTL)
     log.info(
         "job_interchange_written",
         region=region,
@@ -504,7 +504,7 @@ def predict_and_write_forecast(
         model_mapes: Optional mapping of model name → recent MAPE (%). Drives
             ensemble weighting when present.
     """
-    from data.redis_client import redis_key, redis_set
+    from data.redis_client import redis_publish
     from models.ensemble import compute_ensemble_weights, ensemble_combine
 
     region = data.region
@@ -601,8 +601,8 @@ def predict_and_write_forecast(
                 k: round(v, 4) for k, v in ensemble_weights.items()
             }
 
-        redis_set(
-            redis_key(f"forecast:{region}:1h"),
+        redis_publish(
+            f"forecast:{region}:1h",
             redis_payload,
             ttl=REDIS_TTL,
         )
@@ -633,7 +633,7 @@ def write_backtests(data: RegionData) -> PhaseResult:
     isn't pulled into the job container unless this phase runs.
     """
     from components.callbacks import _run_backtest_for_horizon
-    from data.redis_client import redis_key, redis_set
+    from data.redis_client import redis_publish
 
     region = data.region
     written: list[int] = []
@@ -662,8 +662,8 @@ def write_backtests(data: RegionData) -> PhaseResult:
             preds = np.asarray(bt["predictions"]).tolist()
             timestamps = [pd.Timestamp(t).isoformat() for t in bt["timestamps"]]
             residuals = (np.asarray(bt["actual"]) - np.asarray(bt["predictions"])).tolist()
-            redis_set(
-                redis_key(f"backtest:{DEFAULT_BACKTEST_EXOG_MODE}:{region}:{horizon}"),
+            redis_publish(
+                f"backtest:{DEFAULT_BACKTEST_EXOG_MODE}:{region}:{horizon}",
                 {
                     "horizon": horizon,
                     "exog_mode": DEFAULT_BACKTEST_EXOG_MODE,
@@ -705,7 +705,7 @@ def write_backtests(data: RegionData) -> PhaseResult:
 def write_weather_correlation(data: RegionData) -> PhaseResult:
     """Write the weather-correlation payload consumed by the Weather tab."""
     from data.feature_engineering import compute_solar_capacity_factor, compute_wind_power
-    from data.redis_client import redis_key, redis_set
+    from data.redis_client import redis_publish
 
     region = data.region
     try:
@@ -775,7 +775,7 @@ def write_weather_correlation(data: RegionData) -> PhaseResult:
         ):
             payload[col] = wc_merged[col].tolist() if col in wc_merged.columns else []
 
-        redis_set(redis_key(f"weather-correlation:{region}"), payload, ttl=REDIS_TTL)
+        redis_publish(f"weather-correlation:{region}", payload, ttl=REDIS_TTL)
         return PhaseResult(region=region, ok=True, details={"rows": len(wc_merged)})
     except Exception as e:
         log.warning("job_weather_correlation_failed", region=region, error=str(e))
@@ -784,7 +784,7 @@ def write_weather_correlation(data: RegionData) -> PhaseResult:
 
 def write_diagnostics(data: RegionData, xgb_model: dict | None) -> PhaseResult:
     """Write the model-diagnostics payload (actuals vs ensemble, residuals, importance)."""
-    from data.redis_client import redis_key, redis_set
+    from data.redis_client import redis_publish
     from models.model_service import get_forecasts
 
     region = data.region
@@ -827,8 +827,8 @@ def write_diagnostics(data: RegionData, xgb_model: dict | None) -> PhaseResult:
             fi_names = [f[0] for f in sorted_feats]
             fi_vals = [f[1] for f in sorted_feats]
 
-        redis_set(
-            redis_key(f"diagnostics:{region}"),
+        redis_publish(
+            f"diagnostics:{region}",
             {
                 "region": region,
                 "timestamps": _ts_list(diag_ts),
@@ -857,7 +857,7 @@ def write_diagnostics(data: RegionData, xgb_model: dict | None) -> PhaseResult:
 def write_alerts(data: RegionData) -> PhaseResult:
     """Write the alerts / stress / anomaly payload for the Risk tab."""
     from data.demo_data import generate_demo_alerts
-    from data.redis_client import redis_key, redis_set
+    from data.redis_client import redis_publish
 
     region = data.region
     try:
@@ -904,7 +904,7 @@ def write_alerts(data: RegionData) -> PhaseResult:
                 "values": recent_w["temperature_2m"].tolist(),
             }
 
-        redis_set(redis_key(f"alerts:{region}"), payload, ttl=REDIS_TTL)
+        redis_publish(f"alerts:{region}", payload, ttl=REDIS_TTL)
         return PhaseResult(
             region=region,
             ok=True,
@@ -925,14 +925,14 @@ def write_alerts(data: RegionData) -> PhaseResult:
 
 def write_meta(key: str, extra: dict[str, Any] | None = None) -> None:
     """Write a ``wattcast:meta:{key}`` marker with current UTC timestamp."""
-    from data.redis_client import redis_key, redis_set
+    from data.redis_client import redis_publish
 
     payload = {
         "updated_at": datetime.now(UTC).isoformat(),
     }
     if extra:
         payload.update(extra)
-    redis_set(redis_key(f"meta:{key}"), payload, ttl=REDIS_TTL)
+    redis_publish(f"meta:{key}", payload, ttl=REDIS_TTL)
 
 
 # ── Orchestration helpers ────────────────────────────────────

--- a/tests/unit/test_redis_client.py
+++ b/tests/unit/test_redis_client.py
@@ -197,3 +197,125 @@ class TestRedisKeyPrefix:
         assert rc.redis_key("") == "wattcast:"
         # Colons in the suffix pass through (this is how multi-part keys work)
         assert rc.redis_key("a:b:c") == "wattcast:a:b:c"
+
+
+class TestRedisPublishDualWrite:
+    """Verify ``redis_publish()`` writes to primary and (optionally) dual-write prefix.
+
+    Phase 2 of the ``wattcast:`` → ``gridpulse:`` migration tracked in
+    issue #91. The helper composes the primary key from
+    ``REDIS_KEY_PREFIX`` and, when ``REDIS_DUAL_WRITE_PREFIX`` is set,
+    mirrors the same payload to the secondary namespace.
+    """
+
+    def _reload_modules(self):
+        """Reload config + redis_client so the env vars set in the test propagate."""
+        import importlib
+
+        import config
+        import data.redis_client as rc
+
+        importlib.reload(config)
+        importlib.reload(rc)
+        return rc
+
+    def test_single_write_when_dual_prefix_unset(self):
+        """Default mode (no dual-write env) writes once to the primary prefix."""
+        with patch.dict(
+            "os.environ",
+            {"REDIS_KEY_PREFIX": "wattcast"},
+            clear=False,
+        ) as env:
+            env.pop("REDIS_DUAL_WRITE_PREFIX", None)
+            rc = self._reload_modules()
+
+            with patch("data.redis_client.redis_set", return_value=True) as mock_set:
+                ok = rc.redis_publish("actuals:FPL", {"x": 1}, ttl=60)
+
+            assert ok is True
+            assert mock_set.call_count == 1
+            args, kwargs = mock_set.call_args
+            assert args[0] == "wattcast:actuals:FPL"
+            assert args[1] == {"x": 1}
+            assert kwargs == {"ttl": 60}
+
+    def test_dual_write_when_prefix_set(self):
+        """When ``REDIS_DUAL_WRITE_PREFIX`` is set, writes to both prefixes."""
+        with patch.dict(
+            "os.environ",
+            {"REDIS_KEY_PREFIX": "wattcast", "REDIS_DUAL_WRITE_PREFIX": "gridpulse"},
+            clear=False,
+        ):
+            rc = self._reload_modules()
+
+            with patch("data.redis_client.redis_set", return_value=True) as mock_set:
+                ok = rc.redis_publish("forecast:ERCOT:1h", {"y": 2}, ttl=120)
+
+            assert ok is True
+            assert mock_set.call_count == 2
+            primary_call, dual_call = mock_set.call_args_list
+            assert primary_call.args[0] == "wattcast:forecast:ERCOT:1h"
+            assert dual_call.args[0] == "gridpulse:forecast:ERCOT:1h"
+            # Same payload + TTL on both writes
+            assert primary_call.args[1] == dual_call.args[1] == {"y": 2}
+            assert primary_call.kwargs == dual_call.kwargs == {"ttl": 120}
+
+    def test_dual_write_failure_doesnt_break_primary(self):
+        """A failed dual-write logs a warning but still reports primary success.
+
+        Justifies the "best-effort" claim in the docstring: during Phase 2
+        rollout, a transient failure on the new prefix shouldn't degrade
+        the production write path. The next scoring cycle overwrites both
+        keys within an hour, so missed dual-writes self-heal.
+        """
+        with patch.dict(
+            "os.environ",
+            {"REDIS_KEY_PREFIX": "wattcast", "REDIS_DUAL_WRITE_PREFIX": "gridpulse"},
+            clear=False,
+        ):
+            rc = self._reload_modules()
+
+            # First call (primary) succeeds, second (dual) fails.
+            with patch("data.redis_client.redis_set", side_effect=[True, False]):
+                ok = rc.redis_publish("diagnostics:PJM", {"z": 3})
+
+            # Primary success → caller sees True even though dual failed.
+            assert ok is True
+
+    def test_primary_failure_reports_false(self):
+        """When the primary write fails, return False regardless of dual outcome."""
+        with patch.dict(
+            "os.environ",
+            {"REDIS_KEY_PREFIX": "wattcast", "REDIS_DUAL_WRITE_PREFIX": "gridpulse"},
+            clear=False,
+        ):
+            rc = self._reload_modules()
+
+            # Primary fails, dual succeeds. Still report failure — the
+            # source of truth (current prefix) didn't write.
+            with patch("data.redis_client.redis_set", side_effect=[False, True]):
+                ok = rc.redis_publish("alerts:CAISO", {"w": 4})
+
+            assert ok is False
+
+    def test_same_prefix_for_both_skips_dual_write(self):
+        """If ops accidentally set DUAL == PRIMARY, write once not twice.
+
+        Defensive: avoids a redundant Redis round-trip and a confusing
+        log line if someone configures the same prefix for both env vars.
+        """
+        with patch.dict(
+            "os.environ",
+            {"REDIS_KEY_PREFIX": "gridpulse", "REDIS_DUAL_WRITE_PREFIX": "gridpulse"},
+            clear=False,
+        ):
+            rc = self._reload_modules()
+
+            with patch("data.redis_client.redis_set", return_value=True) as mock_set:
+                rc.redis_publish("meta:last_scored", {"t": "now"})
+
+            assert mock_set.call_count == 1
+            assert mock_set.call_args.args[0] == "gridpulse:meta:last_scored"
+
+        # Restore default for sibling tests.
+        self._reload_modules()


### PR DESCRIPTION
## Summary

Phase 2 of the 4-phase ``wattcast:`` → ``gridpulse:`` Redis namespace migration tracked in issue #91. Builds on PR #112 (Phase 1). Adds producer-side dual-write so the new namespace can be warmed while the web still reads the old one.

**Still zero behavior change by default**: with ``REDIS_DUAL_WRITE_PREFIX`` unset, ``redis_publish()`` writes once to the primary prefix — exactly what ``redis_set(redis_key(...), ...)`` did before. Setting the env var to ``gridpulse`` (Phase 2 ops) starts mirroring every job write to the new namespace.

## What changes

| Surface | Change |
|---|---|
| `config.py` | New `REDIS_DUAL_WRITE_PREFIX = os.getenv(...)` (default empty) |
| `data/redis_client.py` | New `redis_publish(suffix, value, ttl)` helper |
| `jobs/phases.py` | All 12 `redis_set(redis_key(...), ...)` write sites converted to `redis_publish(...)`. Lazy imports updated. |

## Design: best-effort dual-write

A dual failure logs a warning but doesn't break the primary path. Reasoning: dual writes are a migration safety net, not the source of truth. The next scoring cycle overwrites both keys within an hour, so transient failures self-heal. The public return value (``True``/``False``) tracks only the primary write.

## Safety: same-prefix detection

If ops accidentally sets `REDIS_DUAL_WRITE_PREFIX=wattcast` while `REDIS_KEY_PREFIX=wattcast`, the helper detects the equal-prefix case and falls back to single-write. Tested explicitly.

## Tests

5 new `TestRedisPublishDualWrite` tests covering:
- Default single-write mode
- Dual-write when prefix set
- Dual failure → primary still True
- Primary failure → False regardless of dual
- Same-prefix short-circuit

All 1,571 existing tests still pass.

## Phase 3/4 ops plan

1. **Phase 2a ops** (after merge): set `REDIS_DUAL_WRITE_PREFIX=gridpulse` on **scoring + training Jobs only** (web has no writer path). One scoring + one training run populates the new namespace.
2. **Phase 3 ops**: flip `REDIS_KEY_PREFIX=gridpulse` on web + jobs. Web reads cut over. Jobs keep dual-writing with `wattcast` as the secondary.
3. **Phase 4 ops** (after ~1 week of stability): unset `REDIS_DUAL_WRITE_PREFIX`. Old keys TTL out within 24h.
4. **Phase 4 code PR**: remove the dual-write code path once unused.

## Risk

Near-zero. Default behavior bit-for-bit unchanged. Phase 2 ops change targets the **producer side only** — a misconfigured dual prefix can't break the web read path; at worst it writes extra (ignored) keys.

## Test plan

- [x] 5 new dual-write tests pass
- [x] 1,571 existing unit tests pass
- [x] 145 integration tests pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI: lint + test + docker + security

Part of issue #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)