### PR TITLE
chore(infra): flip Redis namespace wattcast: → gridpulse: (closes #91)

### DIFF
--- a/components/_callbacks_alerts.py
+++ b/components/_callbacks_alerts.py
@@ -11,7 +11,7 @@ Continues the per-tab split established by:
 
 Currently a single function: ``_alerts_tab_from_redis``. The Alerts tab
 is structurally a "Redis-only" tab — every view it renders comes from
-the ``wattcast:alerts:{region}`` payload that the scoring job writes
+the ``gridpulse:alerts:{region}`` payload that the scoring job writes
 each hour. There's no fallback compute path because alert detection
 itself runs in the scoring job, not on the web. That makes this module
 small (~200 lines) and self-contained.

--- a/components/_callbacks_backtest.py
+++ b/components/_callbacks_backtest.py
@@ -28,7 +28,7 @@ Seven helpers covering the Backtest surface:
   for a backtest fold, with Redis snapshot + climatology fallback.
 * ``_backtest_tab_from_redis`` — Redis fast path that builds the
   entire Backtest tab from the scoring job's hourly
-  ``wattcast:backtest:{exog_mode}:{region}:{horizon_hours}`` payload.
+  ``gridpulse:backtest:{exog_mode}:{region}:{horizon_hours}`` payload.
 * ``_predict_single_fold`` — train+predict for one fold of one model.
 * ``_ensemble_fold`` — equal-weight ensemble across all models for
   one fold. Uses uniform averaging (not 1/MAPE) to avoid data leakage

--- a/components/_callbacks_forecast.py
+++ b/components/_callbacks_forecast.py
@@ -33,7 +33,7 @@ Six helpers that compose the demand-forecast surface:
   see realistic daily/weekly patterns instead of frozen values.
 * ``_outlook_tab_from_redis`` — Redis fast path that builds the entire
   Demand Forecast tab (figure + 7 KPI strings + insight card) from the
-  scoring job's hourly ``wattcast:forecast:{region}:1h`` payload.
+  scoring job's hourly ``gridpulse:forecast:{region}:1h`` payload.
 
 ## Cross-tab dependency factoring
 

--- a/components/_callbacks_generation.py
+++ b/components/_callbacks_generation.py
@@ -12,7 +12,7 @@ Continues the per-tab split established by:
 
 ``_generation_tab_from_redis`` — the Redis fast path that builds the
 entire Generation & Net Load tab from the scoring job's hourly
-``wattcast:generation:{region}`` payload.
+``gridpulse:generation:{region}`` payload.
 
 The function shapes the parallel-array EIA payload into a fuel-pivot
 DataFrame, joins with demand for net-load arithmetic, computes the four

--- a/components/_callbacks_models.py
+++ b/components/_callbacks_models.py
@@ -16,7 +16,7 @@ module owns the Models / Diagnostics tab's data-shaping helpers:
 
 All three are exclusively Models-tab data path. ``_models_tab_from_redis``
 is the producer/consumer split between the scoring job (writes
-``wattcast:diagnostics:{region}``) and the web request path. The
+``gridpulse:diagnostics:{region}``) and the web request path. The
 metric formatter is its only caller plus ``register_callbacks``'s v1
 fallback branch (which mirrors the same table layout when Redis is
 cold). ``_get_feature_importance`` is the Models-tab v1 fallback's

--- a/components/_callbacks_us_grid.py
+++ b/components/_callbacks_us_grid.py
@@ -64,7 +64,7 @@ def _collect_us_grid_region_data() -> dict[str, dict]:
     most recent hour) — get a dict with ``current_mw=None`` so the
     caller can render an ``"—"`` placeholder card without ever exposing
     a NaN to downstream sums or divisions. ``interchange`` is the V3.α
-    ``wattcast:interchange:{region}:1h`` payload, or ``None`` if absent.
+    ``gridpulse:interchange:{region}:1h`` payload, or ``None`` if absent.
 
     Regions failing the quality gate (XGBoost holdout MAPE in the
     ``rollback`` grade per ``mape_grade()``) are omitted from the

--- a/components/_callbacks_weather.py
+++ b/components/_callbacks_weather.py
@@ -15,7 +15,7 @@ Continues the per-tab split established by:
 Plotly figures (temp/wind/solar scatters, correlation heatmap, feature-
 importance bar chart, seasonal decomposition subplots) for the
 Weather-Energy Correlation tab from the scoring job's hourly
-``wattcast:weather-correlation:{region}`` payload.
+``gridpulse:weather-correlation:{region}`` payload.
 
 ## Orphaned-callback observation
 

--- a/components/tab_demand_outlook.py
+++ b/components/tab_demand_outlook.py
@@ -47,7 +47,7 @@ def _model_segmented() -> html.Div:
 
     Production data path only carries XGBoost predictions: the scheduled
     scoring job at ``jobs/phases.py:364`` writes only XGBoost output to
-    ``wattcast:forecast:{region}:1h``, and the v1 inline-compute fallback
+    ``gridpulse:forecast:{region}:1h``, and the v1 inline-compute fallback
     in ``_run_forecast_outlook`` is gated by ``REQUIRE_REDIS`` (returns a
     warming state instead of training Prophet / ARIMA on the request
     thread). Surface only the option the data path can actually fulfill —

--- a/config.py
+++ b/config.py
@@ -105,13 +105,16 @@ ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY", "")
 REDIS_HOST = os.getenv("REDIS_HOST", "")
 REDIS_PORT = int(os.getenv("REDIS_PORT", "6379"))
 
-# Key prefix for every Redis namespace this app touches. Issue #91 tracks
-# the multi-phase migration from the old ``wattcast:`` prefix (a project
-# name that predates GridPulse) to ``gridpulse:``. Default stays
-# ``wattcast`` until Phase 3 — Phase 1 (this commit) only introduces the
-# indirection so callsites no longer hardcode the literal. Override via
-# the ``REDIS_KEY_PREFIX`` env var without code changes.
-REDIS_KEY_PREFIX = os.getenv("REDIS_KEY_PREFIX", "wattcast")
+# Key prefix for every Redis namespace this app touches. Renamed from
+# ``wattcast`` (an older project name) to ``gridpulse`` to match the
+# product (issue #91). Override via the ``REDIS_KEY_PREFIX`` env var if
+# you need to point at a different namespace — e.g. when running an
+# experimental scoring job that shouldn't clobber production keys.
+#
+# On the deploy that flipped this default, the web service returned
+# "Data warming up" until the next hourly scoring run populated the
+# ``gridpulse:*`` keys. Old ``wattcast:*`` keys TTL out within 24h.
+REDIS_KEY_PREFIX = os.getenv("REDIS_KEY_PREFIX", "gridpulse")
 
 # When True the web callbacks (load_data, _run_forecast_outlook,
 # _run_backtest_for_horizon) must NOT fall back to synchronous API fetches

--- a/data/redis_client.py
+++ b/data/redis_client.py
@@ -54,18 +54,20 @@ def _get_redis():
 def redis_key(suffix: str) -> str:
     """Compose a fully-qualified Redis key from the configured prefix and a suffix.
 
-    Phase 1 of the ``wattcast:`` → ``gridpulse:`` migration (issue #91).
     Callers pass the part of the key *after* the prefix, e.g.
-    ``redis_key("actuals:FPL")`` returns ``"wattcast:actuals:FPL"``
-    (default) or ``"gridpulse:actuals:FPL"`` when ``REDIS_KEY_PREFIX``
-    is set. Putting the indirection in this module — rather than at
-    every callsite — means future migrations are a single-line change.
+    ``redis_key("actuals:FPL")`` returns ``"gridpulse:actuals:FPL"``
+    (default). Putting the indirection in this module — rather than at
+    every callsite — means future renames are a single-line change.
 
-    The prefix is read once per process at import time of ``config``,
-    so an env-var flip requires a process restart. That matches the
-    Cloud Run deploy boundary: changing ``REDIS_KEY_PREFIX`` in the
-    service/job env definition triggers a new revision, which gets a
-    new prefix on its first ``redis_key`` call.
+    The prefix is read every call from ``config.REDIS_KEY_PREFIX``, so
+    tests can override it via ``importlib.reload(config)`` after
+    monkeypatching the env. In production it's effectively constant per
+    process — Cloud Run revisions get their prefix from the env on first
+    request and don't see env changes until the next deploy.
+
+    Issue #91 tracked the original ``wattcast`` → ``gridpulse`` rename;
+    this helper was introduced as part of that work and stays useful as
+    a hedge against the next rename.
     """
     # Imported lazily to avoid a circular: config -> nothing, this module
     # -> config is fine, but importing at module top would force config

--- a/jobs/phases.py
+++ b/jobs/phases.py
@@ -10,11 +10,11 @@ Both the hourly scoring job and the daily training job need to:
 
 The scoring job additionally predicts forward-looking demand, writes
 forecast / alerts / diagnostics / weather-correlation Redis entries, and
-refreshes ``wattcast:meta:last_scored``.
+refreshes ``gridpulse:meta:last_scored``.
 
 The training job additionally trains new model artifacts, persists them to
 GCS via :mod:`models.persistence`, recomputes backtests, and refreshes
-``wattcast:meta:last_trained``.
+``gridpulse:meta:last_trained``.
 
 Design:
 - Every phase returns a structured result (``PhaseResult``) rather than
@@ -293,7 +293,7 @@ def write_generation(region: str) -> PhaseResult:
 def write_interchange(region: str) -> PhaseResult:
     """Fetch BA-to-BA hourly interchange and write a per-region snapshot to Redis.
 
-    Output Redis key: ``wattcast:interchange:{region}:1h``. Schema::
+    Output Redis key: ``gridpulse:interchange:{region}:1h``. Schema::
 
         {
             "region": "PJM",
@@ -484,7 +484,7 @@ def predict_and_write_forecast(
     models: dict[str, Any] | None,
     model_mapes: dict[str, float | None] | None = None,
 ) -> PhaseResult:
-    """Run all loaded forward forecasters and write ``wattcast:forecast:{region}:1h``.
+    """Run all loaded forward forecasters and write ``gridpulse:forecast:{region}:1h``.
 
     Each model in ``models`` (e.g. ``{"xgboost": <m>, "prophet": <m>,
     "arima": <m>}``) is dispatched through ``_predict_one``. The per-row
@@ -924,7 +924,7 @@ def write_alerts(data: RegionData) -> PhaseResult:
 
 
 def write_meta(key: str, extra: dict[str, Any] | None = None) -> None:
-    """Write a ``wattcast:meta:{key}`` marker with current UTC timestamp."""
+    """Write a ``gridpulse:meta:{key}`` marker with current UTC timestamp."""
     from data.redis_client import redis_key, redis_set
 
     payload = {

--- a/jobs/scoring_job.py
+++ b/jobs/scoring_job.py
@@ -3,14 +3,14 @@ GridPulse scoring job — hourly.
 
 Refreshes Redis with the data the Dash web service reads:
 
-- actuals (``wattcast:actuals:{region}``)
-- weather (``wattcast:weather:{region}``)
-- generation by fuel (``wattcast:generation:{region}``)
-- 720h forward forecast (``wattcast:forecast:{region}:1h``)
-- weather-correlation payload (``wattcast:weather-correlation:{region}``)
-- model diagnostics (``wattcast:diagnostics:{region}``)
-- alerts / stress / anomalies (``wattcast:alerts:{region}``)
-- ``wattcast:meta:last_scored`` marker
+- actuals (``gridpulse:actuals:{region}``)
+- weather (``gridpulse:weather:{region}``)
+- generation by fuel (``gridpulse:generation:{region}``)
+- 720h forward forecast (``gridpulse:forecast:{region}:1h``)
+- weather-correlation payload (``gridpulse:weather-correlation:{region}``)
+- model diagnostics (``gridpulse:diagnostics:{region}``)
+- alerts / stress / anomalies (``gridpulse:alerts:{region}``)
+- ``gridpulse:meta:last_scored`` marker
 
 Per-region failures are isolated — one region going sideways must not
 abort the whole run. The job returns a non-zero exit code only when

--- a/jobs/training_job.py
+++ b/jobs/training_job.py
@@ -8,7 +8,7 @@ For each region:
 3. Train XGBoost (primary), Prophet, and SARIMAX (best-effort).
 4. Persist each model to GCS via :mod:`models.persistence`.
 5. Recompute backtests and write them to Redis.
-6. Mark ``wattcast:meta:last_trained``.
+6. Mark ``gridpulse:meta:last_trained``.
 
 Does not trigger scoring — the next hourly scoring run picks up the new
 models via :func:`models.persistence.load_model`.
@@ -578,7 +578,7 @@ def run() -> int:
     files, which are written with optimistic-concurrency
     (see :func:`models.persistence._write_latest`).
 
-    Only task 0 writes the ``wattcast:meta:last_trained`` Redis pointer
+    Only task 0 writes the ``gridpulse:meta:last_trained`` Redis pointer
     at the end — the other tasks log their per-task completion but
     don't race the meta write. That key is consumed by the UI's
     data-freshness chip; partial-meta from one task would mislead.

--- a/models/model_service.py
+++ b/models/model_service.py
@@ -85,7 +85,7 @@ def get_model_metrics(region: str) -> dict[str, dict[str, float]]:
        are still supplemented from Redis below).
     3. Ensemble metrics from xgboost's meta extra
        (``ensemble_holdout_metrics``).
-    4. Redis diagnostics ``wattcast:diagnostics:{region}`` —
+    4. Redis diagnostics ``gridpulse:diagnostics:{region}`` —
        fallback ONLY for fields not provided by the meta path.
        In production this content is currently
        ``_simulate_forecasts``-derived; the meta-first ordering means

--- a/tests/integration/test_scoring_job.py
+++ b/tests/integration/test_scoring_job.py
@@ -5,7 +5,7 @@ All external I/O is faked:
 - ``data.redis_client.redis_set`` is replaced with an in-memory dict writer.
 - ``models.persistence.load_model`` is monkeypatched to return a tiny fake model.
 
-The tests assert the scoring job writes the expected wattcast:* keys and
+The tests assert the scoring job writes the expected gridpulse:* keys and
 returns a success exit code.
 """
 
@@ -182,20 +182,20 @@ class TestScoringJob:
 
         # Must have refreshed the core Redis keys for ERCOT.
         expected_keys = {
-            "wattcast:actuals:ERCOT",
-            "wattcast:weather:ERCOT",
-            "wattcast:generation:ERCOT",
-            "wattcast:forecast:ERCOT:1h",
-            "wattcast:weather-correlation:ERCOT",
-            "wattcast:diagnostics:ERCOT",
-            "wattcast:alerts:ERCOT",
-            "wattcast:meta:last_scored",
+            "gridpulse:actuals:ERCOT",
+            "gridpulse:weather:ERCOT",
+            "gridpulse:generation:ERCOT",
+            "gridpulse:forecast:ERCOT:1h",
+            "gridpulse:weather-correlation:ERCOT",
+            "gridpulse:diagnostics:ERCOT",
+            "gridpulse:alerts:ERCOT",
+            "gridpulse:meta:last_scored",
         }
         missing = expected_keys - set(fake_redis.keys())
         assert not missing, f"Missing Redis keys: {missing}"
 
         # last_scored must record the successful region count.
-        meta = fake_redis["wattcast:meta:last_scored"]
+        meta = fake_redis["gridpulse:meta:last_scored"]
         assert meta["regions_scored"] == 1
         assert meta["mode"] == "scoring-job"
 
@@ -217,16 +217,16 @@ class TestScoringJob:
 
         # Actuals/weather/generation/alerts must still be present.
         for key in (
-            "wattcast:actuals:ERCOT",
-            "wattcast:weather:ERCOT",
-            "wattcast:generation:ERCOT",
-            "wattcast:alerts:ERCOT",
-            "wattcast:meta:last_scored",
+            "gridpulse:actuals:ERCOT",
+            "gridpulse:weather:ERCOT",
+            "gridpulse:generation:ERCOT",
+            "gridpulse:alerts:ERCOT",
+            "gridpulse:meta:last_scored",
         ):
             assert key in fake_redis
 
         # Forecast key must NOT be present when the model is missing.
-        assert "wattcast:forecast:ERCOT:1h" not in fake_redis
+        assert "gridpulse:forecast:ERCOT:1h" not in fake_redis
 
     def test_scoring_job_no_data_returns_failure(
         self,
@@ -244,5 +244,5 @@ class TestScoringJob:
         exit_code = scoring_job.run()
         assert exit_code == 1
         # last_scored still gets written with the failure summary.
-        assert fake_redis["wattcast:meta:last_scored"]["regions_scored"] == 0
-        assert "ERCOT" in fake_redis["wattcast:meta:last_scored"]["regions_failed"]
+        assert fake_redis["gridpulse:meta:last_scored"]["regions_scored"] == 0
+        assert "ERCOT" in fake_redis["gridpulse:meta:last_scored"]["regions_failed"]

--- a/tests/integration/test_training_job.py
+++ b/tests/integration/test_training_job.py
@@ -154,8 +154,8 @@ class TestTrainingJob:
         assert ("ERCOT", "arima") in saved_versions
 
         # last_trained meta is present and reflects the successful region.
-        assert "wattcast:meta:last_trained" in fake_redis
-        meta = fake_redis["wattcast:meta:last_trained"]
+        assert "gridpulse:meta:last_trained" in fake_redis
+        meta = fake_redis["gridpulse:meta:last_trained"]
         assert meta["regions_trained"] == 1
         assert meta["mode"] == "training-job"
 
@@ -201,7 +201,7 @@ class TestTrainingJob:
         exit_code = training_job.run()
         assert exit_code == 1
         # Region must show up in failed list when xgboost couldn't be saved.
-        assert "ERCOT" in fake_redis["wattcast:meta:last_trained"]["regions_failed"]
+        assert "ERCOT" in fake_redis["gridpulse:meta:last_trained"]["regions_failed"]
 
     def test_training_job_no_data_records_failure(
         self,
@@ -218,4 +218,4 @@ class TestTrainingJob:
 
         exit_code = training_job.run()
         assert exit_code == 1
-        assert "ERCOT" in fake_redis["wattcast:meta:last_trained"]["regions_failed"]
+        assert "ERCOT" in fake_redis["gridpulse:meta:last_trained"]["regions_failed"]

--- a/tests/unit/test_callbacks_module_helpers.py
+++ b/tests/unit/test_callbacks_module_helpers.py
@@ -705,14 +705,14 @@ class TestBuildPersonaKpis:
 
             result = _build_persona_kpis("grid_ops", "ERCOT")
             # Should have called redis_get for actuals
-            mock_redis.assert_any_call("wattcast:actuals:ERCOT")
+            mock_redis.assert_any_call("gridpulse:actuals:ERCOT")
             assert isinstance(result, dbc.Row)
 
     @patch("components._callbacks_overview._BACKTEST_CACHE", {})
     def test_redis_demand_fallback(self):
         """Redis provides demand stats when demand_df is None."""
         redis_data = {
-            "wattcast:actuals:ERCOT": {
+            "gridpulse:actuals:ERCOT": {
                 "demand_mw": [25000, 30000, 35000, 40000],
             },
         }

--- a/tests/unit/test_phases_forecast.py
+++ b/tests/unit/test_phases_forecast.py
@@ -94,7 +94,7 @@ class TestPredictAndWriteForecast:
         )
 
         assert result.ok
-        payload = fake_redis["wattcast:forecast:ERCOT:1h"]
+        payload = fake_redis["gridpulse:forecast:ERCOT:1h"]
         weights = payload["ensemble_weights"]
         # 1/1 : 1/2 : 1/4 = 0.5714 : 0.2857 : 0.1429 (rounded to 4dp)
         assert weights["xgboost"] == pytest.approx(0.5714, abs=1e-3)
@@ -134,7 +134,7 @@ class TestPredictAndWriteForecast:
         )
 
         assert result.ok
-        payload = fake_redis["wattcast:forecast:ERCOT:1h"]
+        payload = fake_redis["gridpulse:forecast:ERCOT:1h"]
         weights = payload["ensemble_weights"]
         assert weights == {"xgboost": 1 / 3, "prophet": 1 / 3, "arima": 1 / 3} or (
             weights["xgboost"] == pytest.approx(1 / 3, abs=1e-3)
@@ -167,7 +167,7 @@ class TestPredictAndWriteForecast:
         )
 
         assert result.ok
-        payload = fake_redis["wattcast:forecast:ERCOT:1h"]
+        payload = fake_redis["gridpulse:forecast:ERCOT:1h"]
         weights = payload["ensemble_weights"]
         assert weights["xgboost"] == pytest.approx(0.5, abs=1e-6)
         assert weights["prophet"] == pytest.approx(0.5, abs=1e-6)
@@ -186,7 +186,7 @@ class TestPredictAndWriteForecast:
         )
 
         assert result.ok
-        payload = fake_redis["wattcast:forecast:ERCOT:1h"]
+        payload = fake_redis["gridpulse:forecast:ERCOT:1h"]
         assert "ensemble_weights" not in payload
         row0 = payload["forecasts"][0]
         assert "ensemble" not in row0

--- a/tests/unit/test_phases_interchange.py
+++ b/tests/unit/test_phases_interchange.py
@@ -58,7 +58,7 @@ class TestWriteInterchange:
         result = phases.write_interchange("PJM")
 
         assert result.ok is True
-        payload = fake_redis["wattcast:interchange:PJM:1h"]
+        payload = fake_redis["gridpulse:interchange:PJM:1h"]
         assert payload["region"] == "PJM"
         assert payload["net_mw"] is None
         assert payload["counterparties"] == []
@@ -86,7 +86,7 @@ class TestWriteInterchange:
         result = phases.write_interchange("PJM")
 
         assert result.ok is True
-        payload = fake_redis["wattcast:interchange:PJM:1h"]
+        payload = fake_redis["gridpulse:interchange:PJM:1h"]
         assert payload["latest_hour"] == latest.isoformat()
         # Net = sum of all four = -1625.5
         assert payload["net_mw"] == pytest.approx(-1625.5, abs=0.01)
@@ -118,7 +118,7 @@ class TestWriteInterchange:
         )
 
         phases.write_interchange("PJM")
-        payload = fake_redis["wattcast:interchange:PJM:1h"]
+        payload = fake_redis["gridpulse:interchange:PJM:1h"]
         assert payload["latest_hour"] == latest.isoformat()
         assert payload["net_mw"] == pytest.approx(-750.0, abs=0.01)
         assert payload["counterparties"][0]["mw"] == pytest.approx(-500.0)
@@ -140,7 +140,7 @@ class TestWriteInterchange:
         )
 
         phases.write_interchange("PJM")
-        payload = fake_redis["wattcast:interchange:PJM:1h"]
+        payload = fake_redis["gridpulse:interchange:PJM:1h"]
         assert payload["net_mw"] == pytest.approx(-1000.0)
         assert len(payload["counterparties"]) == 1
         assert payload["counterparties"][0]["to_ba"] == "MISO"
@@ -161,7 +161,7 @@ class TestWriteInterchange:
 
         assert result.ok is False
         assert "synthetic EIA outage" in (result.error or "")
-        assert "wattcast:interchange:PJM:1h" not in fake_redis
+        assert "gridpulse:interchange:PJM:1h" not in fake_redis
 
     def test_no_eia_api_key_returns_failure(self, fake_redis, monkeypatch):
         """No API key → bail before fetch attempt."""
@@ -173,7 +173,7 @@ class TestWriteInterchange:
 
         assert result.ok is False
         assert result.error == "no_eia_api_key"
-        assert "wattcast:interchange:PJM:1h" not in fake_redis
+        assert "gridpulse:interchange:PJM:1h" not in fake_redis
 
 
 class TestInterchangeChipRender:

--- a/tests/unit/test_redis_client.py
+++ b/tests/unit/test_redis_client.py
@@ -15,7 +15,7 @@ class TestRedisClientGracefulFallback:
         rc._redis_init_attempted = False
 
         with patch.dict("os.environ", {"REDIS_HOST": ""}, clear=False):
-            result = rc.redis_get("wattcast:actuals:FPL")
+            result = rc.redis_get("gridpulse:actuals:FPL")
             assert result is None
 
     def test_redis_unavailable_returns_none(self):
@@ -36,7 +36,7 @@ class TestRedisClientGracefulFallback:
             mock_redis_mod.Redis.return_value = mock_client
             # Need to reimport to pick up the mock
             rc._redis_init_attempted = False
-            result = rc.redis_get("wattcast:actuals:FPL")
+            result = rc.redis_get("gridpulse:actuals:FPL")
             assert result is None
 
     def test_redis_available_returns_true(self):
@@ -69,9 +69,9 @@ class TestRedisClientReads:
         rc._redis_client = mock_client
         rc._redis_init_attempted = True
 
-        result = rc.redis_get("wattcast:actuals:FPL")
+        result = rc.redis_get("gridpulse:actuals:FPL")
         assert result == payload
-        mock_client.get.assert_called_once_with("wattcast:actuals:FPL")
+        mock_client.get.assert_called_once_with("gridpulse:actuals:FPL")
 
     def test_redis_get_returns_none_for_missing_key(self):
         """redis_get returns None when key doesn't exist."""
@@ -82,7 +82,7 @@ class TestRedisClientReads:
         rc._redis_client = mock_client
         rc._redis_init_attempted = True
 
-        result = rc.redis_get("wattcast:actuals:MISSING")
+        result = rc.redis_get("gridpulse:actuals:MISSING")
         assert result is None
 
     def test_redis_get_handles_corrupt_json(self):
@@ -94,7 +94,7 @@ class TestRedisClientReads:
         rc._redis_client = mock_client
         rc._redis_init_attempted = True
 
-        result = rc.redis_get("wattcast:actuals:FPL")
+        result = rc.redis_get("gridpulse:actuals:FPL")
         assert result is None
 
     def test_redis_get_handles_read_exception(self):
@@ -106,7 +106,7 @@ class TestRedisClientReads:
         rc._redis_client = mock_client
         rc._redis_init_attempted = True
 
-        result = rc.redis_get("wattcast:actuals:FPL")
+        result = rc.redis_get("gridpulse:actuals:FPL")
         assert result is None
 
 
@@ -134,7 +134,7 @@ class TestRedisBacktestFormat:
         rc._redis_client = mock_client
         rc._redis_init_attempted = True
 
-        result = rc.redis_get("wattcast:backtest:FPL:24")
+        result = rc.redis_get("gridpulse:backtest:FPL:24")
         assert result is not None
         assert "metrics" in result
         assert "actual" in result
@@ -146,15 +146,14 @@ class TestRedisBacktestFormat:
 class TestRedisKeyPrefix:
     """Verify the ``redis_key()`` helper composes the prefix correctly.
 
-    Phase 1 of the ``wattcast:`` → ``gridpulse:`` migration tracked in
-    issue #91. The helper lives in ``data/redis_client.py`` and reads
-    ``REDIS_KEY_PREFIX`` from ``config`` at call time, so an env-var
-    flip after process start does not propagate (matches the Cloud Run
-    deploy boundary — each new revision picks up the new prefix).
+    The helper lives in ``data/redis_client.py`` and reads
+    ``REDIS_KEY_PREFIX`` from ``config`` at every call. Tests that want
+    to exercise an override re-import config after monkeypatching the
+    env so the new value propagates.
     """
 
-    def test_default_prefix_is_wattcast(self):
-        """Until Phase 3 ops flip, the default prefix matches the legacy literal."""
+    def test_default_prefix_is_gridpulse(self):
+        """The default prefix matches the product name."""
         import importlib
 
         import config
@@ -167,22 +166,29 @@ class TestRedisKeyPrefix:
             env.pop("REDIS_KEY_PREFIX", None)
             importlib.reload(config)
             importlib.reload(rc)
-            assert rc.redis_key("actuals:FPL") == "wattcast:actuals:FPL"
-            assert rc.redis_key("forecast:ERCOT:1h") == "wattcast:forecast:ERCOT:1h"
+            assert rc.redis_key("actuals:FPL") == "gridpulse:actuals:FPL"
+            assert rc.redis_key("forecast:ERCOT:1h") == "gridpulse:forecast:ERCOT:1h"
 
     def test_env_var_override_changes_prefix(self):
-        """Setting ``REDIS_KEY_PREFIX`` flips the prefix on next import."""
+        """Setting ``REDIS_KEY_PREFIX`` flips the prefix on next import.
+
+        Uses the historical ``wattcast`` value (issue #91) to verify the
+        override path — pointing at any non-default namespace exercises
+        the same code path. In production this is what you'd reach for
+        when running an experimental scoring job that shouldn't clobber
+        live keys.
+        """
         import importlib
 
         import config
         import data.redis_client as rc
 
-        with patch.dict("os.environ", {"REDIS_KEY_PREFIX": "gridpulse"}, clear=False):
+        with patch.dict("os.environ", {"REDIS_KEY_PREFIX": "wattcast"}, clear=False):
             importlib.reload(config)
             importlib.reload(rc)
-            assert rc.redis_key("actuals:FPL") == "gridpulse:actuals:FPL"
+            assert rc.redis_key("actuals:FPL") == "wattcast:actuals:FPL"
             assert rc.redis_key("backtest:forecast_exog:PJM:24") == (
-                "gridpulse:backtest:forecast_exog:PJM:24"
+                "wattcast:backtest:forecast_exog:PJM:24"
             )
 
         # Restore default so subsequent tests aren't tainted by the reload above.
@@ -194,6 +200,6 @@ class TestRedisKeyPrefix:
         import data.redis_client as rc
 
         # Empty suffix (edge case)
-        assert rc.redis_key("") == "wattcast:"
+        assert rc.redis_key("") == "gridpulse:"
         # Colons in the suffix pass through (this is how multi-part keys work)
-        assert rc.redis_key("a:b:c") == "wattcast:a:b:c"
+        assert rc.redis_key("a:b:c") == "gridpulse:a:b:c"

--- a/tests/unit/test_redis_fast_paths.py
+++ b/tests/unit/test_redis_fast_paths.py
@@ -26,7 +26,7 @@ def _ts(n=48):
 
 
 def _demand_payload(n=48, base=30_000):
-    """Minimal ``wattcast:actuals:{region}`` Redis payload."""
+    """Minimal ``gridpulse:actuals:{region}`` Redis payload."""
     return {
         "timestamps": _ts(n),
         "demand_mw": [base + i * 10 for i in range(n)],
@@ -34,7 +34,7 @@ def _demand_payload(n=48, base=30_000):
 
 
 def _weather_payload(n=48):
-    """Minimal ``wattcast:weather:{region}`` Redis payload."""
+    """Minimal ``gridpulse:weather:{region}`` Redis payload."""
     return {
         "timestamps": _ts(n),
         "temperature_2m": [70 + i * 0.1 for i in range(n)],
@@ -44,7 +44,7 @@ def _weather_payload(n=48):
 
 
 def _weather_correlation_payload():
-    """Minimal ``wattcast:weather-correlation:{region}`` Redis payload."""
+    """Minimal ``gridpulse:weather-correlation:{region}`` Redis payload."""
     return {
         "temperature_2m": [70, 72, 74],
         "demand_mw": [30000, 31000, 32000],
@@ -70,7 +70,7 @@ def _weather_correlation_payload():
 
 
 def _diagnostics_payload():
-    """Minimal ``wattcast:diagnostics:{region}`` Redis payload."""
+    """Minimal ``gridpulse:diagnostics:{region}`` Redis payload."""
     n = 48
     return {
         "metrics": {
@@ -94,7 +94,7 @@ def _diagnostics_payload():
 
 
 def _generation_payload(n=72):
-    """Minimal ``wattcast:generation:{region}`` Redis payload."""
+    """Minimal ``gridpulse:generation:{region}`` Redis payload."""
     ts = pd.date_range(pd.Timestamp.now(tz="UTC") - pd.Timedelta(hours=n), periods=n, freq="h")
     return {
         "timestamps": ts.strftime("%Y-%m-%dT%H:%M:%S%z").tolist(),
@@ -107,7 +107,7 @@ def _generation_payload(n=72):
 
 
 def _alerts_payload(with_alerts=True):
-    """Minimal ``wattcast:alerts:{region}`` Redis payload."""
+    """Minimal ``gridpulse:alerts:{region}`` Redis payload."""
     alerts = []
     if with_alerts:
         alerts = [
@@ -139,7 +139,7 @@ def _alerts_payload(with_alerts=True):
 
 
 def _forecast_payload(n=72, model="xgboost"):
-    """Minimal ``wattcast:forecast:{region}:1h`` Redis payload."""
+    """Minimal ``gridpulse:forecast:{region}:1h`` Redis payload."""
     return {
         "scored_at": "2024-06-01T12:00:00Z",
         "forecasts": [
@@ -154,7 +154,7 @@ def _forecast_payload(n=72, model="xgboost"):
 
 
 def _backtest_payload(horizon=24):
-    """Minimal ``wattcast:backtest:{region}:{horizon}`` Redis payload."""
+    """Minimal ``gridpulse:backtest:{region}:{horizon}`` Redis payload."""
     n = 48
     actual = [30000 + i * 10 for i in range(n)]
     return {
@@ -183,8 +183,8 @@ class TestLoadDataFromRedis:
     def test_both_keys_hit_returns_5_tuple(self, mock_rg):
         """Both actuals and weather cached → returns 5-tuple of JSON strings."""
         mock_rg.side_effect = lambda k: {
-            "wattcast:actuals:FPL": _demand_payload(),
-            "wattcast:weather:FPL": _weather_payload(),
+            "gridpulse:actuals:FPL": _demand_payload(),
+            "gridpulse:weather:FPL": _weather_payload(),
         }.get(k)
 
         from components.callbacks import _load_data_from_redis
@@ -205,7 +205,7 @@ class TestLoadDataFromRedis:
     def test_actuals_miss_returns_none(self, mock_rg):
         """Actuals cache miss → returns None."""
         mock_rg.side_effect = lambda k: {
-            "wattcast:weather:FPL": _weather_payload(),
+            "gridpulse:weather:FPL": _weather_payload(),
         }.get(k)
 
         from components.callbacks import _load_data_from_redis
@@ -216,7 +216,7 @@ class TestLoadDataFromRedis:
     def test_weather_miss_returns_none(self, mock_rg):
         """Weather cache miss → returns None."""
         mock_rg.side_effect = lambda k: {
-            "wattcast:actuals:FPL": _demand_payload(),
+            "gridpulse:actuals:FPL": _demand_payload(),
         }.get(k)
 
         from components.callbacks import _load_data_from_redis
@@ -237,8 +237,8 @@ class TestLoadDataFromRedis:
         """Empty demand_mw list → freshness dict has no latest_data key."""
         payload = {"timestamps": [], "demand_mw": []}
         mock_rg.side_effect = lambda k: {
-            "wattcast:actuals:FPL": payload,
-            "wattcast:weather:FPL": _weather_payload(),
+            "gridpulse:actuals:FPL": payload,
+            "gridpulse:weather:FPL": _weather_payload(),
         }.get(k)
 
         from components.callbacks import _load_data_from_redis
@@ -252,8 +252,8 @@ class TestLoadDataFromRedis:
     def test_audit_trail_uses_redis_source(self, mock_rg):
         """Audit record records source='redis'."""
         mock_rg.side_effect = lambda k: {
-            "wattcast:actuals:FPL": _demand_payload(),
-            "wattcast:weather:FPL": _weather_payload(),
+            "gridpulse:actuals:FPL": _demand_payload(),
+            "gridpulse:weather:FPL": _weather_payload(),
         }.get(k)
 
         from components.callbacks import _load_data_from_redis
@@ -274,8 +274,8 @@ class TestLoadDataFromRedis:
             "demand_mw": [28000, 0, -5, 29000, 30000],
         }
         mock_rg.side_effect = lambda k: {
-            "wattcast:actuals:NYIS": payload,
-            "wattcast:weather:NYIS": _weather_payload(5),
+            "gridpulse:actuals:NYIS": payload,
+            "gridpulse:weather:NYIS": _weather_payload(5),
         }.get(k)
 
         from components.callbacks import _load_data_from_redis

--- a/tests/unit/test_us_grid_nan_guard.py
+++ b/tests/unit/test_us_grid_nan_guard.py
@@ -151,7 +151,7 @@ class TestCollectUsGridRegionData:
 
         self._patch_redis(
             monkeypatch,
-            {"wattcast:actuals:PJM": {"demand_mw": [70000.0, 71000.0, 72000.0]}},
+            {"gridpulse:actuals:PJM": {"demand_mw": [70000.0, 71000.0, 72000.0]}},
         )
         # Limit to one region for clarity
         with patch("components._callbacks_us_grid.REGION_NAMES", {"PJM": "Mid-Atlantic (PJM)"}):
@@ -166,7 +166,7 @@ class TestCollectUsGridRegionData:
 
         self._patch_redis(
             monkeypatch,
-            {"wattcast:actuals:PSCO": {"demand_mw": [9000.0, 9100.0, 9200.0, float("nan")]}},
+            {"gridpulse:actuals:PSCO": {"demand_mw": [9000.0, 9100.0, 9200.0, float("nan")]}},
         )
         with patch("components._callbacks_us_grid.REGION_NAMES", {"PSCO": "Colorado (Xcel)"}):
             data = _collect_us_grid_region_data()
@@ -182,7 +182,7 @@ class TestCollectUsGridRegionData:
         nan = float("nan")
         self._patch_redis(
             monkeypatch,
-            {"wattcast:actuals:HECO": {"demand_mw": [nan, nan, nan, nan]}},
+            {"gridpulse:actuals:HECO": {"demand_mw": [nan, nan, nan, nan]}},
         )
         with patch("components._callbacks_us_grid.REGION_NAMES", {"HECO": "Hawaii (HECO)"}):
             data = _collect_us_grid_region_data()


### PR DESCRIPTION
## Summary

Big-bang flip of the Redis key prefix from the old project name (``wattcast``) to the product name (``gridpulse``). **Replaces the 4-phase zero-downtime migration** originally scoped in issue #91 — that plan was over-engineered for a single-tenant portfolio app where the actual cost of a cutover is ~1 hour of "Data warming up" state on the next deploy.

## What changes

| Surface | Change |
|---|---|
| `config.py` | `REDIS_KEY_PREFIX` default flips `wattcast` → `gridpulse`. Override via env var still works. |
| 11 production files | Docstring / module-doc references to `wattcast:*` keys updated to `gridpulse:*`. Live code already routes through `redis_key()` (PR #112), so this is pure documentation hygiene. |
| 8 test files | Hardcoded `"wattcast:..."` fixture strings updated to `"gridpulse:..."`. Same wire-format test intent, new namespace. |
| `data/redis_client.py` | `redis_key()` docstring cleaned up — removed multi-phase migration framing, kept a one-line note for code archaeology. |
| `tests/unit/test_redis_client.py` | Renamed `test_default_prefix_is_wattcast` → `test_default_prefix_is_gridpulse`. `test_env_var_override_changes_prefix` now uses `wattcast` as the override target (the historical name self-documents the intent). |

## Deploy effect

1. Web service starts. `REDIS_KEY_PREFIX` reads `gridpulse` from the new default.
2. Web tries to read `gridpulse:*` keys → cache miss.
3. `REQUIRE_REDIS=true` → UI shows "Data warming up".
4. Next hourly scoring job runs (max 1 hour later) → keys populated → cache hit on next page load.
5. Daily training job runs next 04:00 UTC → backtest/diagnostics keys populated.
6. Old `wattcast:*` keys TTL out within 24h (every write key has 24h TTL set by `REDIS_TTL` in `jobs/phases.py`).

## What didn't ship

- **Dual-write infrastructure** (closed PR #113 — `REDIS_DUAL_WRITE_PREFIX` + `redis_publish()` helper) — unnecessary for a single-tenant app. Each scoring/training cycle is the source of truth; one hour of warming on cutover is acceptable.
- **Producer-side migration phases** — collapsed into this single commit. The 4-phase plan in issue #91 was designed for a multi-tenant system; the actual GridPulse deploy topology (one web service + two scheduled jobs, one user) makes phased rollout overhead.

## Risk

Low. The only failure mode is the ~1-hour warming window after deploy — already part of the design (the `REQUIRE_REDIS` warming state was built for exactly this kind of transition). If something goes wrong, set `REDIS_KEY_PREFIX=wattcast` as an env var on Cloud Run to roll back to the old namespace; `wattcast:*` keys persist for 24h post-cutover.

## Test plan

- [x] All 1,571 unit + 145 integration tests pass locally
- [x] `ruff check` + `ruff format --check` clean
- [x] `TestRedisKeyPrefix` suite (3 tests) verifies new default and override path
- [ ] CI: lint + test + docker + security
- [ ] Post-merge: monitor scoring job logs for first `gridpulse:*` writes; confirm web reads cut over within one scoring cycle

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)