### PR TITLE
feat(charts): cross-cutting hover + axis polish, PLOT_CONFIG token (#26)

### DIFF
--- a/components/_callbacks_overview.py
+++ b/components/_callbacks_overview.py
@@ -1109,9 +1109,6 @@ def _build_overview_sparkline(demand_df: pd.DataFrame | None, region: str) -> go
         uirevision=region,
         showlegend=False,
         margin=dict(l=40, r=10, t=10, b=30),
-    )
-    fig.update_layout(
-        **sparkline_layout,
         xaxis=dict(
             showgrid=False,
             tickformat="%H:%M",
@@ -1123,6 +1120,7 @@ def _build_overview_sparkline(demand_df: pd.DataFrame | None, region: str) -> go
             title="MW",
         ),
     )
+    fig.update_layout(**sparkline_layout)
     return fig
 
 
@@ -1499,11 +1497,11 @@ def _spotlight_renewables(weather_df: pd.DataFrame | None, region: str) -> go.Fi
         uirevision=region,
         margin=dict(l=45, r=45, t=35, b=40),
         legend=dict(orientation="h", y=-0.15, font=dict(size=10)),
-    )
-    fig.update_layout(
-        **renew_layout,
-        title=dict(text="Renewable Potential (48h)", font=dict(size=13, color="#DDE6F2")),
-        showlegend=True,
+        # Axis overrides flow through ``_layout()`` so the shared
+        # gridcolor / linecolor defaults in ``PLOT_LAYOUT`` deep-merge
+        # with per-chart options. Passing these as kwargs to
+        # ``update_layout()`` separately would conflict with the
+        # ``xaxis`` / ``yaxis`` keys already in ``PLOT_LAYOUT``.
         yaxis=dict(
             title="Wind (mph)",
             showgrid=True,
@@ -1516,6 +1514,11 @@ def _spotlight_renewables(weather_df: pd.DataFrame | None, region: str) -> go.Fi
             showgrid=False,
         ),
         xaxis=dict(showgrid=False, tickformat="%b %d %H:%M"),
+    )
+    fig.update_layout(
+        **renew_layout,
+        title=dict(text="Renewable Potential (48h)", font=dict(size=13, color="#DDE6F2")),
+        showlegend=True,
     )
     return fig
 
@@ -1573,11 +1576,9 @@ def _spotlight_trader(demand_df: pd.DataFrame | None, region: str) -> go.Figure:
             annotation_font_color=color,
         )
 
-    trader_layout = _layout(uirevision=region, margin=dict(l=50, r=10, t=35, b=30))
-    fig.update_layout(
-        **trader_layout,
-        title=dict(text="Demand vs Capacity", font=dict(size=13, color="#DDE6F2")),
-        showlegend=False,
+    trader_layout = _layout(
+        uirevision=region,
+        margin=dict(l=50, r=10, t=35, b=30),
         xaxis=dict(showgrid=False, tickformat="%b %d %H:%M"),
         yaxis=dict(
             showgrid=True,
@@ -1585,6 +1586,11 @@ def _spotlight_trader(demand_df: pd.DataFrame | None, region: str) -> go.Figure:
             tickformat=",.0f",
             title="MW",
         ),
+    )
+    fig.update_layout(
+        **trader_layout,
+        title=dict(text="Demand vs Capacity", font=dict(size=13, color="#DDE6F2")),
+        showlegend=False,
     )
     return fig
 
@@ -1625,17 +1631,20 @@ def _spotlight_model_accuracy(region: str) -> go.Figure:
         )
     )
 
-    model_layout = _layout(uirevision=region, margin=dict(l=40, r=10, t=35, b=30))
-    fig.update_layout(
-        **model_layout,
-        title=dict(text="Model MAPE Comparison", font=dict(size=13, color="#DDE6F2")),
-        showlegend=False,
+    model_layout = _layout(
+        uirevision=region,
+        margin=dict(l=40, r=10, t=35, b=30),
         yaxis=dict(
             title="MAPE (%)",
             showgrid=True,
             gridcolor="rgba(255,255,255,0.05)",
         ),
         xaxis=dict(showgrid=False),
+    )
+    fig.update_layout(
+        **model_layout,
+        title=dict(text="Model MAPE Comparison", font=dict(size=13, color="#DDE6F2")),
+        showlegend=False,
     )
     return fig
 

--- a/components/_callbacks_shared.py
+++ b/components/_callbacks_shared.py
@@ -86,8 +86,40 @@ _EIA_FUEL_MAP: dict[str, str] = {
 
 
 # ── Plotly layout tokens ─────────────────────────────────────────────
+#
+# Issue #26: cross-cutting Plotly polish — hover label theming, axis
+# tone, modebar trim. Defaults set here so every chart that flows
+# through ``_layout()`` picks them up; per-chart overrides still win
+# because ``_layout()`` does a shallow merge over ``PLOT_LAYOUT``.
 
 PLOT_TEMPLATE = "plotly_dark"
+
+# Modebar config for any chart that *wants* a visible modebar. The
+# current GridPulse design hides the modebar entirely on every tab
+# (each ``tab_*.py`` defines a local ``_GRAPH_CONFIG`` with
+# ``displayModeBar: False`` — portfolio-dashboard context where no
+# user is doing analytic exploration). This constant lives here as
+# the cross-cutting alternative: when a future chart needs a
+# user-facing zoom/pan/download bar, opt in with
+# ``dcc.Graph(config=PLOT_CONFIG, ...)`` instead of inventing yet
+# another local config dict.
+#
+# ``displaylogo=False`` strips the Plotly attribution.
+# ``modeBarButtonsToRemove`` trims the lasso / select / autoscale /
+# spike-line buttons (not useful for time-series demand data) so
+# the only remaining buttons are zoom / pan / reset / download.
+# ``responsive=True`` keeps charts legible on container resize.
+PLOT_CONFIG: dict[str, object] = {
+    "displaylogo": False,
+    "modeBarButtonsToRemove": [
+        "select2d",
+        "lasso2d",
+        "autoScale2d",
+        "toggleSpikelines",
+    ],
+    "responsive": True,
+}
+
 PLOT_LAYOUT = dict(
     template=PLOT_TEMPLATE,
     paper_bgcolor="rgba(0,0,0,0)",
@@ -104,6 +136,40 @@ PLOT_LAYOUT = dict(
         font=dict(size=11),
         bgcolor="rgba(0,0,0,0)",
     ),
+    # Hover label — dark surface, Inter, left-aligned. Matches the
+    # rest of the v2 chrome and reads as "part of the same surface"
+    # rather than a Plotly-default light pill.
+    hoverlabel=dict(
+        bgcolor="#11141c",
+        bordercolor="rgba(255,255,255,0.10)",
+        font=dict(
+            family="Inter, 'Segoe UI', system-ui, sans-serif",
+            size=12,
+            color="#F5F7FA",
+        ),
+        align="left",
+    ),
+    # Unified hover groups every trace's value at the same x — much
+    # cleaner for time-series with multiple model overlays. Charts
+    # that want trace-individual hovers (heatmaps, scatters) override
+    # this in their own ``_layout()`` call.
+    hovermode="x unified",
+    # Subtle axis tone. Plotly's default dark-template grid is too
+    # heavy — these are barely-visible against ``--bg-raised``,
+    # which is exactly the cue we want (gridlines guide the eye
+    # without competing with the data).
+    xaxis=dict(
+        gridcolor="rgba(255,255,255,0.04)",
+        zerolinecolor="rgba(255,255,255,0.08)",
+        linecolor="rgba(255,255,255,0.10)",
+        tickfont=dict(color="#8892A5", size=11),
+    ),
+    yaxis=dict(
+        gridcolor="rgba(255,255,255,0.04)",
+        zerolinecolor="rgba(255,255,255,0.08)",
+        linecolor="rgba(255,255,255,0.10)",
+        tickfont=dict(color="#8892A5", size=11),
+    ),
 )
 
 
@@ -117,8 +183,31 @@ def _layout(*, uirevision: str | None = None, **overrides) -> dict:
     the same revision string and the chart's interaction state survives.
     Changing the string forces Plotly to re-initialize the view, which
     is the desired behavior when the user picks a new region/horizon.
+
+    Axis dicts merge instead of replace: ``PLOT_LAYOUT`` carries the
+    shared axis tone (gridcolor / linecolor / tickfont) and callsites
+    layer per-chart options (titles, tick format, showgrid toggles) on
+    top. Without this merge, a callsite that passes ``xaxis=dict(...)``
+    would silently lose the shared styling.
     """
     layout = {**PLOT_LAYOUT, **overrides}
+    # Deep-merge xaxis / yaxis (and any yaxis2/yaxis3 etc. for dual-axis
+    # plots): combine the PLOT_LAYOUT defaults with the per-call override,
+    # with the override winning on conflicting keys.
+    for axis_key, default_value in PLOT_LAYOUT.items():
+        if not (axis_key.startswith("xaxis") or axis_key.startswith("yaxis")):
+            continue
+        override_value = overrides.get(axis_key)
+        if override_value is None:
+            continue  # only the default applies — leave PLOT_LAYOUT entry alone
+        if isinstance(default_value, dict) and isinstance(override_value, dict):
+            layout[axis_key] = {**default_value, **override_value}
+        # else: scalar override (rare) — already handled by the outer
+        # ``{**PLOT_LAYOUT, **overrides}`` above.
+    # Plotly also accepts dual-axis configs the callsite didn't have a
+    # default for (e.g. ``yaxis2``). Those pass through unchanged from
+    # the override dict — they're already in ``layout`` from the
+    # outer merge above.
     if uirevision is not None:
         layout["uirevision"] = uirevision
     return layout
@@ -462,6 +551,7 @@ __all__ = [
     # Plotly layout
     "PLOT_TEMPLATE",
     "PLOT_LAYOUT",
+    "PLOT_CONFIG",
     "_layout",
     "_empty_figure",
     # Color palette

--- a/components/callbacks.py
+++ b/components/callbacks.py
@@ -104,6 +104,7 @@ from components._callbacks_shared import (
     BACKTEST_EXOG_MODES,  # noqa: F401 — re-export
     COLORS,  # noqa: F401 — re-export (tests/unit/test_callbacks_helpers.py::TestModuleConstants)
     DEFAULT_BACKTEST_EXOG_MODE,  # noqa: F401 — re-export (tests + Backtest module imports it elsewhere)
+    PLOT_CONFIG,  # noqa: F401 — re-export
     PLOT_LAYOUT,  # noqa: F401 — re-export
     PLOT_TEMPLATE,  # noqa: F401 — re-export
     _cache_lock,  # noqa: F401 — re-export (app.py uses for cache stats)

--- a/tests/unit/test_callbacks_helpers.py
+++ b/tests/unit/test_callbacks_helpers.py
@@ -2112,3 +2112,37 @@ class TestModuleConstants:
         from components.callbacks import PLOT_LAYOUT
 
         assert "template" in PLOT_LAYOUT
+
+    def test_plot_layout_has_hover_and_axis_polish(self):
+        """Issue #26 — cross-cutting hover/axis tokens live in PLOT_LAYOUT."""
+        from components.callbacks import PLOT_LAYOUT
+
+        # Hover label theming
+        assert PLOT_LAYOUT["hovermode"] == "x unified"
+        hoverlabel = PLOT_LAYOUT["hoverlabel"]
+        assert hoverlabel["bgcolor"] == "#11141c"
+        assert hoverlabel["align"] == "left"
+
+        # Subtle axis tone on both axes (one rgba alpha — same value)
+        for axis in ("xaxis", "yaxis"):
+            ax = PLOT_LAYOUT[axis]
+            assert ax["gridcolor"] == "rgba(255,255,255,0.04)"
+            assert ax["zerolinecolor"] == "rgba(255,255,255,0.08)"
+            assert ax["linecolor"] == "rgba(255,255,255,0.10)"
+
+    def test_plot_config_constant(self):
+        """PLOT_CONFIG is exported for charts that opt into a visible modebar.
+
+        Current GridPulse design hides the modebar everywhere — each tab
+        has its own ``_GRAPH_CONFIG = {"displayModeBar": False, ...}``.
+        PLOT_CONFIG is the cross-cutting alternative for future charts
+        that need user-facing zoom/pan/download.
+        """
+        from components.callbacks import PLOT_CONFIG
+
+        assert PLOT_CONFIG["displaylogo"] is False
+        assert PLOT_CONFIG["responsive"] is True
+        # Lasso / select buttons don't belong on a time-series modebar
+        removed = PLOT_CONFIG["modeBarButtonsToRemove"]
+        for button in ("select2d", "lasso2d", "autoScale2d", "toggleSpikelines"):
+            assert button in removed


### PR DESCRIPTION
## Summary

Scoped slice of issue #26 — ships the **no-regression-risk** chart-polish pieces. Defers per-chart-audit items (drop Plotly titles, legend reposition, line widths) to a follow-up PR where each chart can be visually reviewed.

## What changes

### `_callbacks_shared.py` — `PLOT_LAYOUT` extensions

Two additive blocks every chart flows through via `_layout()`:

1. **Hover label theming + `hovermode="x unified"`** — dark surface, Inter font, left-aligned. Unified hover groups all traces at the cursor x (cleaner for time-series with multi-model overlays).
2. **Subtle axis tone** — gridcolor / zerolinecolor / linecolor / tickfont on both axes. Replaces plotly-dark's prominent default grid (4% white instead of ~15%).

### `_callbacks_shared.py` — `PLOT_CONFIG` token

New exported constant for charts opting into a visible modebar. Current GridPulse design hides the modebar everywhere (each `tab_*.py` has its own `_GRAPH_CONFIG = {"displayModeBar": False, ...}`); PLOT_CONFIG is the cross-cutting alternative if a future chart needs zoom/pan/download. Drops displaylogo + lasso/select/autoscale/spike-line buttons.

### `_callbacks_shared.py` — `_layout()` axis deep-merge

`_layout()` now deep-merges `xaxis` / `yaxis` (and dual-axis like `yaxis2`) instead of shallow replace. Without this, a callsite passing `xaxis=dict(...)` would silently lose the shared styling.

### `_callbacks_overview.py` — spotlight + sparkline fixups

Three spotlight builders + sparkline were calling `fig.update_layout(**_layout(...), xaxis=..., yaxis=...)` — the new `PLOT_LAYOUT.xaxis`/`yaxis` defaults collide with those kwargs (`TypeError: got multiple values for keyword argument 'xaxis'`). Fix: move axis overrides INTO each `_layout()` call so the deep-merge resolves them.

## What's NOT in this PR (deferred from #26)

- **Drop Plotly titles** — would orphan spotlight chart labels (Renewable Potential, Demand vs Capacity, Model MAPE Comparison) which have no external chart-title div to carry the label
- **Legend reposition** (top-right inside plot) — overlap risk on dense charts, needs visual review
- **Line widths** (forecast 1.75 / actual 2.25) — per-trace change across many callsites, better as a focused visual-review PR

## Visual change

On the next deploy, every chart that flows through `_layout()` will:
- Dark, Inter-font, left-aligned hover tooltip
- Unified hover (one tooltip listing all traces at cursor x)
- Barely-visible grid lines (4% white) instead of the heavier plotly-dark default

No chart breaks; no layout shifts.

## Test plan

- [x] 2 new `TestModuleConstants` tests pin the hover/axis/PLOT_CONFIG values
- [x] All 1,718 existing tests pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI: lint + test + docker + security

Part of issue #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)