### PR TITLE
fix(charts): close two remaining update_layout xaxis/yaxis collisions

### DIFF
--- a/components/_callbacks_overview.py
+++ b/components/_callbacks_overview.py
@@ -254,19 +254,22 @@ def _build_overview_hero_chart(
         log.warning("overview_hero_forecast_failed", region=region, error=str(exc))
 
     fig.update_layout(
-        **_layout(uirevision=region, showlegend=False),
-        xaxis=dict(
-            showgrid=False,
-            linecolor="rgba(255,255,255,0.04)",
-            tickfont=dict(color="#71717a", size=10),
-        ),
-        yaxis=dict(
-            showgrid=True,
-            gridcolor="rgba(255,255,255,0.04)",
-            zeroline=False,
-            tickformat=",.0f",
-            tickfont=dict(color="#71717a", size=10),
-            title=None,
+        **_layout(
+            uirevision=region,
+            showlegend=False,
+            xaxis=dict(
+                showgrid=False,
+                linecolor="rgba(255,255,255,0.04)",
+                tickfont=dict(color="#71717a", size=10),
+            ),
+            yaxis=dict(
+                showgrid=True,
+                gridcolor="rgba(255,255,255,0.04)",
+                zeroline=False,
+                tickformat=",.0f",
+                tickfont=dict(color="#71717a", size=10),
+                title=None,
+            ),
         ),
     )
     return fig
@@ -1069,10 +1072,12 @@ def _driver_sparkline(df: pd.DataFrame, column: str, color: str, fillcolor: str)
         )
     )
     fig.update_layout(
-        **_layout(uirevision=column),
-        xaxis=dict(visible=False),
-        yaxis=dict(visible=False),
-        margin=dict(l=0, r=0, t=4, b=4),
+        **_layout(
+            uirevision=column,
+            xaxis=dict(visible=False),
+            yaxis=dict(visible=False),
+            margin=dict(l=0, r=0, t=4, b=4),
+        )
     )
     return fig
 

--- a/tests/unit/test_callbacks_helpers.py
+++ b/tests/unit/test_callbacks_helpers.py
@@ -2146,3 +2146,91 @@ class TestModuleConstants:
         removed = PLOT_CONFIG["modeBarButtonsToRemove"]
         for button in ("select2d", "lasso2d", "autoScale2d", "toggleSpikelines"):
             assert button in removed
+
+
+class TestChartHelpersDoNotCollideOnAxisKwargs:
+    """Regression guard for the ``update_layout() got multiple values for
+    keyword argument 'xaxis'`` family of bugs.
+
+    After PR #115 added ``xaxis``/``yaxis`` defaults to ``PLOT_LAYOUT``,
+    any callsite still doing ``update_layout(**_layout(...), xaxis=...)``
+    fails at call time. The unit tests caught the spotlight + sparkline
+    sites but missed the Overview hero chart and the Forecast drivers
+    sparkline. Production caught them. This test class exercises every
+    chart-building helper to ensure none of them collide.
+
+    Failure mode: the helper raises ``TypeError: ... got multiple values
+    for keyword argument 'xaxis'`` when its ``update_layout()`` is
+    called. Passing this test means the helper successfully built a
+    figure end-to-end.
+    """
+
+    def _demand_df(self, periods: int = 200):
+        return pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2024-01-01", periods=periods, freq="h", tz="UTC"),
+                "demand_mw": [40000.0] * periods,
+            }
+        )
+
+    def _weather_df(self, periods: int = 48):
+        ts = pd.date_range("2024-01-01", periods=periods, freq="h", tz="UTC")
+        return pd.DataFrame(
+            {
+                "timestamp": ts,
+                "temperature_2m": [70.0] * periods,
+                "wind_speed_80m": [10.0] * periods,
+                "shortwave_radiation": [200.0] * periods,
+            }
+        )
+
+    def test_overview_hero_chart_builds(self):
+        """``_build_overview_hero_chart`` builds without xaxis/yaxis collision."""
+        from components.callbacks import _build_overview_hero_chart
+
+        fig = _build_overview_hero_chart("FPL", self._demand_df())
+        # If we got here without TypeError, the fix is intact. Also check the
+        # PLOT_LAYOUT axis tone landed — that confirms the merge worked.
+        assert fig.layout.xaxis.gridcolor == "rgba(255,255,255,0.04)"
+
+    def test_overview_sparkline_builds(self):
+        """``_build_overview_sparkline`` — 24h demand sparkline."""
+        from components.callbacks import _build_overview_sparkline
+
+        fig = _build_overview_sparkline(self._demand_df(periods=48), "FPL")
+        assert fig.layout.xaxis is not None
+
+    def test_driver_sparkline_builds(self):
+        """``_driver_sparkline`` — the Forecast tab's per-driver mini chart.
+
+        This one bit twice: in the spotlight-fix wave (PR #115) and
+        again here. The xaxis/yaxis kwargs were outside ``_layout()``.
+        Not re-exported via the callbacks shim (internal Overview
+        helper) — import from the per-tab module directly.
+        """
+        from components._callbacks_overview import _driver_sparkline
+
+        wdf = self._weather_df(periods=24)
+        fig = _driver_sparkline(wdf, "temperature_2m", "#3b82f6", "rgba(0,0,0,0.1)")
+        # ``visible=False`` is from the helper's own override (hiding axes
+        # on the sparkline); proves the override reached the figure.
+        assert fig.layout.xaxis.visible is False
+        assert fig.layout.yaxis.visible is False
+
+    def test_spotlight_renewables_builds(self):
+        from components.callbacks import _spotlight_renewables
+
+        fig = _spotlight_renewables(self._weather_df(), "FPL")
+        assert fig.layout.title.text == "Renewable Potential (48h)"
+
+    def test_spotlight_trader_builds(self):
+        from components.callbacks import _spotlight_trader
+
+        fig = _spotlight_trader(self._demand_df(periods=48), "FPL")
+        assert fig.layout.title.text == "Demand vs Capacity"
+
+    def test_spotlight_model_accuracy_builds(self):
+        from components.callbacks import _spotlight_model_accuracy
+
+        fig = _spotlight_model_accuracy("FPL")
+        assert fig.layout.title.text == "Model MAPE Comparison"


### PR DESCRIPTION
## Summary

Production caught two charts I missed in PR #115's spotlight/sparkline fixup wave. Same root cause: PR #115 added \`xaxis\` and \`yaxis\` defaults to \`PLOT_LAYOUT\`, but two callsites were still passing their own \`xaxis=\` / \`yaxis=\` as separate kwargs to \`update_layout()\` after unpacking \`**_layout(...)\`. Python rejects the duplicate-keyword shape with \`TypeError: ... got multiple values for keyword argument 'xaxis'\`.

## What was broken

| Chart | File / line | When it fires |
|---|---|---|
| Overview hero chart | \`_callbacks_overview.py:256\` | Every Overview tab load (loudest failure) |
| Driver sparkline | \`_callbacks_overview.py:1074\` | When the Forecast tab's Drivers panel opens |

Both fixed the same way the spotlights were in #115: move \`xaxis\` / \`yaxis\` overrides INTO the \`_layout()\` call so the shallow merge resolves them before the unpack.

## Why the unit tests didn't catch this

The existing chart-builder tests focus on **output shape** (figures return, traces have expected counts, NaN guards trip). They never called \`update_layout()\` on the built figure — which is where the duplicate-kwarg error fires.

## Regression guard

New \`TestChartHelpersDoNotCollideOnAxisKwargs\` test class. One test per chart-building helper that calls \`update_layout()\`. A passing test means the helper built end-to-end without the TypeError.

Covered helpers (6 tests):
- \`_build_overview_hero_chart\`
- \`_build_overview_sparkline\`
- \`_driver_sparkline\`
- \`_spotlight_renewables\`
- \`_spotlight_trader\`
- \`_spotlight_model_accuracy\`

## Lessons

1. **Mechanical extractions need mechanical tests.** PR #115's spotlight fixes were correct; what was missing was a test class exercising every chart helper, not just the ones whose bugs I'd already noticed.
2. **Production is the second line of defense.** If this regression class had existed before #115, both bugs would have surfaced at PR time.

## Test plan

- [x] 6 new regression tests pass
- [x] All 1,724 existing unit + integration tests pass
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] CI: lint + test + docker + security

🤖 Generated with [Claude Code](https://claude.com/claude-code)