### PR TITLE
fix(scenarios): couple wind & solar deltas to demand in heuristic

### DIFF
--- a/components/_callbacks_overview.py
+++ b/components/_callbacks_overview.py
@@ -876,6 +876,33 @@ def _build_risk_insight(
     return build_insight_card("Risk summary", body)
 
 
+def _scenario_demand_factor(
+    temp_delta: float, wind_delta: float, solar_delta: float
+) -> float:
+    """Linear demand-sensitivity factor for the scenario simulator heuristic.
+
+    Returns a multiplicative factor to apply to a baseline 24h forecast.
+    Coefficients are order-of-magnitude-defensible against load-research
+    norms (not physically rigorous — full-fidelity physics lives in
+    ``simulation/scenario_engine.py``):
+
+      * temp_delta: ±2.5 % per 5 °F (existing — dominant driver)
+      * solar_delta: +1.5 % per 100 W/m² (sun load → AC demand;
+        meaningful for summer-peaking BAs like FPL/ERCOT/PJM)
+      * wind_delta: +0.5 % per 10 mph (wind chill → heating demand;
+        meaningful for winter-peaking BAs)
+
+    All three combine linearly. Pulled out as a pure function so the
+    heuristic is unit-testable without spinning up the Plotly render.
+    """
+    return (
+        1.0
+        + (temp_delta / 5.0) * 0.025
+        + solar_delta * 0.00015
+        + wind_delta * 0.0005
+    )
+
+
 def _build_scenarios_panel(
     temp_delta: int | float | None,
     wind_delta: int | float | None,
@@ -891,12 +918,14 @@ def _build_scenarios_panel(
     Scenarios tab and the simulation/scenario_engine module — exposing
     full-fidelity here would need model loading on every slider drag.
 
-    Sensitivities (calibrated against typical residential cooling/heating
-    response in U.S. balancing authorities):
-      * temp_delta: ±2.5 % demand per +5 °F above 65 °F (cooling) and per
-        −5 °F below 65 °F (heating). Symmetric for simplicity.
-      * wind_delta: ±0.6 % renewable share per +1 mph (caps at 30 % share).
-      * solar_delta: ±0.05 % renewable share per +1 W/m² (caps similarly).
+    Demand sensitivities — see ``_scenario_demand_factor`` for coefficients.
+
+    Renewable-share sensitivities (independent of demand):
+      * wind_delta: ±0.6 pp per mph (caps at 30 pp)
+      * solar_delta: ±0.05 pp per W/m² (caps at 30 pp)
+
+    Confidence sensitivity: −1 pp per 5 °F of |temp_delta|, capped at −10 pp
+    (forecast residuals grow with abs(temp_delta) outside ±10 °F).
     """
     region = region or "FPL"
     temp_delta = float(temp_delta or 0)
@@ -936,9 +965,10 @@ def _build_scenarios_panel(
         return (kpi_empty, _empty_figure("Awaiting baseline forecast"))
 
     # ── Heuristic scenario forecast ────────────────────────────
-    # Demand response is dominated by temperature; wind/solar shift the
-    # renewable share (which we surface separately) but barely move demand.
-    demand_factor = 1.0 + (temp_delta / 5.0) * 0.025  # ±2.5% per 5°F
+    # Demand response is dominated by temperature, plus smaller terms
+    # for solar (AC load) and wind (wind chill). See
+    # ``_scenario_demand_factor`` for the coefficient rationale.
+    demand_factor = _scenario_demand_factor(temp_delta, wind_delta, solar_delta)
     scenario_y = base_y * demand_factor
 
     base_peak = float(np.max(base_y))

--- a/components/_callbacks_overview.py
+++ b/components/_callbacks_overview.py
@@ -876,9 +876,7 @@ def _build_risk_insight(
     return build_insight_card("Risk summary", body)
 
 
-def _scenario_demand_factor(
-    temp_delta: float, wind_delta: float, solar_delta: float
-) -> float:
+def _scenario_demand_factor(temp_delta: float, wind_delta: float, solar_delta: float) -> float:
     """Linear demand-sensitivity factor for the scenario simulator heuristic.
 
     Returns a multiplicative factor to apply to a baseline 24h forecast.
@@ -895,12 +893,7 @@ def _scenario_demand_factor(
     All three combine linearly. Pulled out as a pure function so the
     heuristic is unit-testable without spinning up the Plotly render.
     """
-    return (
-        1.0
-        + (temp_delta / 5.0) * 0.025
-        + solar_delta * 0.00015
-        + wind_delta * 0.0005
-    )
+    return 1.0 + (temp_delta / 5.0) * 0.025 + solar_delta * 0.00015 + wind_delta * 0.0005
 
 
 def _build_scenarios_panel(

--- a/tests/unit/test_scenarios_heuristic.py
+++ b/tests/unit/test_scenarios_heuristic.py
@@ -15,9 +15,6 @@ demand-side terms. Full-fidelity physics lives in
 
 from __future__ import annotations
 
-import io
-import json
-
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/unit/test_scenarios_heuristic.py
+++ b/tests/unit/test_scenarios_heuristic.py
@@ -1,0 +1,158 @@
+"""Regression tests for the Forecast-tab scenario simulator heuristic.
+
+A latent gap shipped where the ``_build_scenarios_panel`` heuristic
+coupled ΔPeak to temperature only — wind and solar deltas moved the
+renewable-share KPI but produced literally zero ΔPeak. That made the
+"Stress-test demand against weather shifts" subhead misleading (the
+Solar Eclipse and Calm Overcast scenario presets produced no demand
+delta at all).
+
+These tests lock the post-fix behavior: temperature is still the
+dominant driver, but wind and solar now contribute small, defensible
+demand-side terms. Full-fidelity physics lives in
+``simulation/scenario_engine.py`` — these are heuristic-tier checks.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from components._callbacks_overview import (
+    _build_scenarios_panel,
+    _scenario_demand_factor,
+)
+
+
+class TestScenarioDemandFactor:
+    """Pure-function checks on the heuristic itself."""
+
+    def test_zero_deltas_return_unit_factor(self):
+        assert _scenario_demand_factor(0.0, 0.0, 0.0) == pytest.approx(1.0)
+
+    def test_temp_delta_dominates(self):
+        # ±2.5 % per 5 °F — existing coefficient, must stay stable.
+        assert _scenario_demand_factor(5.0, 0.0, 0.0) == pytest.approx(1.025)
+        assert _scenario_demand_factor(-5.0, 0.0, 0.0) == pytest.approx(0.975)
+        assert _scenario_demand_factor(10.0, 0.0, 0.0) == pytest.approx(1.05)
+
+    def test_solar_delta_moves_demand(self):
+        # +200 W/m² → +3 % demand (sun load / AC). This is the headline
+        # regression: pre-fix this was 1.000 (zero coupling).
+        assert _scenario_demand_factor(0.0, 0.0, 200.0) == pytest.approx(1.03)
+        assert _scenario_demand_factor(0.0, 0.0, -200.0) == pytest.approx(0.97)
+
+    def test_wind_delta_moves_demand(self):
+        # +10 mph → +0.5 % demand (wind chill → heating). Pre-fix was 1.000.
+        assert _scenario_demand_factor(0.0, 10.0, 0.0) == pytest.approx(1.005)
+        assert _scenario_demand_factor(0.0, -10.0, 0.0) == pytest.approx(0.995)
+
+    def test_solar_effect_exceeds_wind_effect(self):
+        # At slider maxima, solar (±200 → ±3 %) should swamp wind
+        # (±10 → ±0.5 %). Captures the order-of-magnitude claim in
+        # the docstring.
+        solar_max = abs(_scenario_demand_factor(0.0, 0.0, 200.0) - 1.0)
+        wind_max = abs(_scenario_demand_factor(0.0, 10.0, 0.0) - 1.0)
+        assert solar_max > wind_max * 5  # solar effect ≥ 5× wind at slider maxima
+
+    def test_temp_effect_dominates_at_realistic_combos(self):
+        # +14 °F (Heat Dome) + max solar + max wind: temp should still
+        # drive most of the delta. Locks the "temperature is dominant"
+        # narrative.
+        combined = _scenario_demand_factor(14.0, 10.0, 200.0)
+        temp_only = _scenario_demand_factor(14.0, 0.0, 0.0)
+        temp_share = (temp_only - 1.0) / (combined - 1.0)
+        assert temp_share > 0.6  # temp explains >60 % of the combined delta
+
+    def test_terms_combine_linearly(self):
+        # f(a+b) = f(a) + f(b) - 1.0 (since baseline is 1.0). Locks the
+        # linearity property the heuristic claims.
+        t = _scenario_demand_factor(5.0, 0.0, 0.0) - 1.0
+        w = _scenario_demand_factor(0.0, 5.0, 0.0) - 1.0
+        s = _scenario_demand_factor(0.0, 0.0, 100.0) - 1.0
+        combined = _scenario_demand_factor(5.0, 5.0, 100.0) - 1.0
+        assert combined == pytest.approx(t + w + s)
+
+
+class TestScenariosPanelEndToEnd:
+    """End-to-end checks against ``_build_scenarios_panel``: assert the
+    scenario forecast trace actually diverges from baseline when wind or
+    solar move.
+    """
+
+    @staticmethod
+    def _demand_json() -> str:
+        # Synthetic 14-day hourly demand series; enough lookback for
+        # the panel's ``get_forecasts`` call to produce a non-empty
+        # ensemble (the panel needs 24+ hours of forecast).
+        ts = pd.date_range("2026-05-01", periods=24 * 14, freq="h")
+        # Sinusoidal daily cycle around 100k MW — mimics PJM scale.
+        hours = np.arange(len(ts))
+        demand = 100_000 + 15_000 * np.sin(2 * np.pi * hours / 24)
+        df = pd.DataFrame({"timestamp": ts, "demand_mw": demand})
+        return df.to_json(orient="records", date_format="iso")
+
+    @staticmethod
+    def _scenario_trace_y(figure) -> np.ndarray | None:
+        """Extract the scenario forecast y-series from the panel figure."""
+        for trace in figure.data:
+            name = (trace.name or "").lower()
+            if "scenario" in name:
+                return np.asarray(trace.y, dtype=float)
+        return None
+
+    def test_solar_delta_diverges_from_baseline(self):
+        demand_json = self._demand_json()
+        _, fig_baseline = _build_scenarios_panel(0, 0, 0, "PJM", demand_json)
+        _, fig_solar = _build_scenarios_panel(0, 0, 200, "PJM", demand_json)
+
+        base_y = self._scenario_trace_y(fig_baseline)
+        solar_y = self._scenario_trace_y(fig_solar)
+
+        if base_y is None or solar_y is None:
+            pytest.skip("ensemble forecast unavailable in this environment")
+
+        # Solar +200 W/m² should lift the entire 24h trace by ~3 %.
+        ratio = float(np.mean(solar_y / base_y))
+        assert ratio == pytest.approx(1.03, rel=1e-3)
+
+    def test_wind_delta_diverges_from_baseline(self):
+        demand_json = self._demand_json()
+        _, fig_baseline = _build_scenarios_panel(0, 0, 0, "PJM", demand_json)
+        _, fig_wind = _build_scenarios_panel(0, 10, 0, "PJM", demand_json)
+
+        base_y = self._scenario_trace_y(fig_baseline)
+        wind_y = self._scenario_trace_y(fig_wind)
+
+        if base_y is None or wind_y is None:
+            pytest.skip("ensemble forecast unavailable in this environment")
+
+        ratio = float(np.mean(wind_y / base_y))
+        assert ratio == pytest.approx(1.005, rel=1e-3)
+
+    def test_zero_deltas_produce_identical_traces(self):
+        # Sanity check: baseline-vs-scenario should overlap perfectly
+        # when all sliders are at 0. The user's screenshots showed
+        # this happening for the wind/solar-only cases pre-fix —
+        # post-fix that should ONLY happen at (0, 0, 0).
+        demand_json = self._demand_json()
+        _, fig = _build_scenarios_panel(0, 0, 0, "PJM", demand_json)
+
+        base_y = self._scenario_trace_y(fig)
+        if base_y is None:
+            pytest.skip("ensemble forecast unavailable in this environment")
+
+        # Find the "baseline" trace and confirm it matches scenario.
+        baseline_trace = None
+        for trace in fig.data:
+            if "baseline" in (trace.name or "").lower():
+                baseline_trace = np.asarray(trace.y, dtype=float)
+                break
+        if baseline_trace is None:
+            pytest.skip("baseline trace not present in this layout")
+
+        np.testing.assert_allclose(base_y, baseline_trace, rtol=1e-9)


### PR DESCRIPTION
## Summary

The Forecast-tab scenario simulator was silently understating wind and solar's role in demand. Sliding **Wind Δ** or **Solar Δ** only moved the **Δ Renewable** KPI — **Δ Peak stayed at literally 0 MW** because the heuristic coupled demand to temperature alone.

This made the "Stress-test demand against weather shifts" subhead misleading, particularly for the **Solar Eclipse** and **Calm Overcast** presets (both lean on solar/wind to drive their differentiation; both produced zero demand impact).

## Before vs after

| Slider move | ΔPeak before | ΔPeak after |
|---|---|---|
| Solar +200 W/m² | **+0 MW (+0.0%)** | **+3.0 %** (~+3,100 MW on a 100 GW base) |
| Solar -200 W/m² | **+0 MW (+0.0%)** | **-3.0 %** |
| Wind +10 mph | **+0 MW (+0.0%)** | **+0.5 %** |
| Temp +14 °F | +7.0 % (unchanged) | +7.0 % (unchanged) |

## What changed

Extracted ``_scenario_demand_factor`` as a pure function and added two small terms alongside the existing temperature coupling:

```python
factor = 1.0
       + (temp_delta / 5.0) * 0.025   # existing: ±2.5 % per 5 °F
       + solar_delta * 0.00015        # NEW: +1.5 % per 100 W/m² (AC load)
       + wind_delta * 0.0005          # NEW: +0.5 % per 10 mph (wind chill)
```

Coefficients are deliberately small so **temperature stays dominant** (a regression test pins this: temp explains >60 % of any combined delta at slider maxima), but **non-zero** so the simulator stops misrepresenting solar's material role in summer-peaking BAs.

## Why a heuristic and not the full engine

Full-fidelity physics already lives in [``simulation/scenario_engine.py``](../blob/main/simulation/scenario_engine.py) — it copies the feature matrix, applies overrides, recomputes derived features, and re-runs the ensemble. The Forecast-tab simulator deliberately *doesn't* call it because that would require model loading on every slider drag.

Wiring the full engine to the Forecast tab (via a server-side debounced callback) is **parked as a follow-up** — would close the heuristic-vs-physics gap entirely but lands on the latency-vs-fidelity trade-off discussion.

## Tests

New file: ``tests/unit/test_scenarios_heuristic.py`` with **10 tests** in two classes:

- ``TestScenarioDemandFactor`` (7) — pure-function checks: baseline, per-coefficient effects, linearity, "temp stays dominant" property
- ``TestScenariosPanelEndToEnd`` (3) — build the actual Plotly figure and assert the scenario trace's per-hour ratio against baseline matches the expected coefficient when only wind or only solar moves. Locks the bug closed at the integration layer.

**Full unit suite: 1589 passed, 0 failures.**

## Test plan

- [x] Unit tests for the heuristic
- [x] End-to-end tests against the figure render
- [x] Full unit suite green (1589 / 1589)
- [ ] Spot-check in production: slide Solar to ±200 W/m² and confirm Δ Peak is no longer +0 MW

🤖 Generated with [Claude Code](https://claude.com/claude-code)