### PR TITLE
chore(pm): introduce STATUS.md + pre-session ritual as canonical state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,51 @@
 # CLAUDE.md — Project Conventions for GridPulse
 
+## Before recommending what's next
+
+Don't rely on memory, the system prompt, or `docs/internal/NEXT_UP.md`.
+Always run a state check at session start before suggesting work:
+
+```bash
+cat STATUS.md                # active focus + recent decisions + open question
+gh pr list --state open      # in-flight work
+gh issue list --state open   # committed queue
+```
+
+If `STATUS.md` contradicts what `gh` reports, **GitHub wins** — patch
+STATUS.md in the same session. `docs/internal/NEXT_UP.md` is the
+historical roadmap with acceptance criteria, **not** the operational
+queue.
+
+## End-of-PR explanatory-doc check
+
+For any non-trivial PR, before reporting "done":
+
+1. **Architecture changed** (new service, swapped tech, removed component)?
+   → update `docs/HOW_IT_WORKS.md` + relevant Mermaid diagrams in same PR
+2. **`CANONICAL_FACTS.md` value moved**? → update it in same PR
+3. **STAR-story trigger hit** (trade-off, debugging arc, surprising
+   decision, recovery, scope-cut)?
+   → draft the story in `docs/INTERVIEW_PREP.md` in same PR
+4. **`STATUS.md` active focus or next-3 changed**? → update STATUS.md
+   in the same PR
+
+Otherwise report: "no explanatory-doc impact."
+
+*(Note: `docs/HOW_IT_WORKS.md`, `CANONICAL_FACTS.md`, and
+`docs/INTERVIEW_PREP.md` will exist after the explanatory-docs Phase 1
+PR ships. Skip the relevant check until then.)*
+
 ## Start here
 
 This repo already has multiple context layers. Read them in this order:
 
-1. `CLAUDE.md` — architecture, conventions, code standards, execution guardrails
-2. `docs/internal/EXECUTION_BRIEF.md` — prioritization, redesign direction, product-shell changes, execution order
-3. `README.md` — current public framing and deployment overview
-4. `PRD.md` — product requirements, personas, ADRs, descoping rationale
-5. `TECHNICAL_SPEC.md` — data/model/system details
+1. `STATUS.md` — current focus, next 3, recent decisions (canonical state)
+2. `CLAUDE.md` — architecture, conventions, code standards, execution guardrails
+3. `docs/internal/EXECUTION_BRIEF.md` — prioritization, redesign direction, product-shell changes, execution order
+4. `README.md` — current public framing and deployment overview
+5. `PRD.md` — product requirements, personas, ADRs, descoping rationale
+6. `TECHNICAL_SPEC.md` — data/model/system details
+7. `docs/internal/NEXT_UP.md` — historical roadmap with acceptance criteria (reference, not queue)
 
 ### Agent objective
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,68 @@
+# Status — updated 2026-05-19
+
+> Canonical pointer for "where am I, what's next." This file + GitHub
+> Projects + the issue tracker are the single source of truth for
+> project state. See [`docs/internal/NEXT_UP.md`](docs/internal/NEXT_UP.md)
+> for the full historical roadmap with acceptance criteria; see
+> [`CLAUDE.md`](CLAUDE.md) for the pre-session sanity-check ritual
+> that keeps this file from drifting.
+
+## Active investment
+
+**None active.** Path A (portfolio-grade complete) was declared done
+2026-05-19 with the close of #115 / #117 / #118 / #119 / #120. The
+roadmap is awaiting a strategic decision: invest in Path B #1
+(Model drift monitoring) now, or pause.
+
+The Path B #1 case is strengthened by a real observation —
+see §"Open question" below.
+
+## Next 3 (priority order)
+
+1. **[#121](https://github.com/kristenmartino/gridpulse/issues/121) — V4 Path B #1: Model drift monitoring** (~1 week, `path-b`, `effort-week`). Recommended next investment. Concrete evidence: 2026-05-19 PJM walkthrough surfaced a 47 GW spread between XGBoost / Ensemble / Prophet / ARIMA on the same horizon — exactly the symptom drift monitoring is designed to catch.
+2. **[#122](https://github.com/kristenmartino/gridpulse/issues/122) — V3.γ: Hawaii coverage** (3–5 days, `v3-open`, `effort-week`). Blocked on HECO data-quality assessment.
+3. **V4 Path B #2: Observability infrastructure** (3–5 days). Not yet promoted to an issue — sketch lives in [`docs/internal/NEXT_UP.md` §V4 Path B](docs/internal/NEXT_UP.md). Promote to issue when committing to start.
+
+The remaining 6 V4 Path B items (auth, API surface, alerting, DR,
+data-quality monitoring, cost monitoring) are sketches in NEXT_UP.md.
+They become issues when committed to, not before.
+
+## Recent decisions (last 7 days)
+
+- **Path A declared complete** (2026-05-19) — #21 / #25 / #26 / #87 / #91 all closed + the 2026-05-19 sweep (#116 / #118 / #119) merged. There is no remaining Path A backlog. [PR #120](https://github.com/kristenmartino/gridpulse/pull/120).
+- **Scenario simulator: heuristic over full-fidelity engine** (#119) — adding wind/solar→demand coupling to the existing analytical approximation rather than wiring the real `simulation/scenario_engine.py` to a server-side debounced callback. Full physics is parked as a follow-up if there's ever a real user.
+- **Big-bang Redis namespace flip over phased migration** (#114) — closed #91 by accepting ~1 hour of "warming" downtime instead of building a 4-phase zero-downtime cutover for a single-tenant portfolio app.
+- **Project-state lives in GitHub, not Markdown** (this PR) — STATUS.md + GitHub Projects + Issues are canonical. `docs/internal/NEXT_UP.md` keeps the historical roadmap with acceptance criteria but is no longer the operational queue.
+
+## Open question
+
+**Path B #1 (Model drift monitoring) now, or pause?**
+
+Arguments **for now**: the 2026-05-19 PJM spread is real evidence that
+the inverse-MAPE ensemble weights drift between trainings. Today's
+portfolio-grade product silently misrepresents forecast confidence in
+that condition. Building drift monitoring closes that gap.
+
+Arguments **for pause**: Path B is ~6–8 weeks of focused work end to
+end. The marginal portfolio-recruiter value of "I built drift
+monitoring" over the current shipped state is modest. The real return
+is when there's a paying user / interviewer who probes the ML
+operationalization story.
+
+Recommend: **decide before next session.** The cron-triggered doc
+audit will create an issue every month regardless — don't let the
+audit be the only thing in the queue.
+
+## How this file gets updated
+
+- Per-PR: updated **in the same commit** as material work that
+  changes active investment, next-3, or recent decisions
+- End-of-session: agent re-reads STATUS.md and verifies it matches
+  reality (PRs merged, issues closed, decisions made) — opens a
+  small touch-up commit if drift
+- Pre-external-use ritual (interview, networking event, portfolio
+  share): user re-reads top-to-bottom; ~1 minute
+
+If this file disagrees with `gh issue list` / `gh pr list` /
+`config.py` / merged PR bodies, **the live sources win** — fix
+STATUS.md in a follow-up commit.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,11 +1,12 @@
 # Status — updated 2026-05-19
 
-> Canonical pointer for "where am I, what's next." This file + GitHub
-> Projects + the issue tracker are the single source of truth for
-> project state. See [`docs/internal/NEXT_UP.md`](docs/internal/NEXT_UP.md)
-> for the full historical roadmap with acceptance criteria; see
-> [`CLAUDE.md`](CLAUDE.md) for the pre-session sanity-check ritual
-> that keeps this file from drifting.
+> Canonical pointer for "where am I, what's next." This file +
+> [GitHub Projects board](https://github.com/users/kristenmartino/projects/1)
+> + the issue tracker are the single source of truth for project state.
+> See [`docs/internal/NEXT_UP.md`](docs/internal/NEXT_UP.md) for the full
+> historical roadmap with acceptance criteria; see [`CLAUDE.md`](CLAUDE.md)
+> for the pre-session sanity-check ritual that keeps this file from
+> drifting.
 
 ## Active investment
 


### PR DESCRIPTION
## Why

Project state has been scattered across 6 sources — memory, Claude Code logs, PR descriptions, portfolio docs, GitHub issues, and `docs/internal/NEXT_UP.md`. NEXT_UP.md tried to be the single roadmap and silently drifted 18 days, costing real time today (see [#120](https://github.com/kristenmartino/gridpulse/pull/120) where it was re-aligned and the rationale was documented).

This PR establishes a sustainable replacement: **GitHub is the source of truth** (issues + PRs + Project), and a small `STATUS.md` at the repo root holds the narrative anchor (active focus, next 3, recent decisions, open question).

## What changed in this PR

**`STATUS.md`** (new, ~70 lines)

Current state, populated from real GitHub data:
- Active investment: none — Path A complete, awaiting decision on Path B #1
- Next 3 priorities with real issue links ([#121](https://github.com/kristenmartino/gridpulse/issues/121), [#122](https://github.com/kristenmartino/gridpulse/issues/122))
- Recent decisions (last 7 days, with PR links)
- Open question: Path B #1 now or pause?
- Documented update rules — per-PR + end-of-session + pre-external-use

**`CLAUDE.md`** (two new sections + reading-order tweak)

1. *"Before recommending what's next"* — at the top. Three-command state check (`cat STATUS.md`, `gh pr list`, `gh issue list`) the agent runs at session start. If STATUS.md disagrees with `gh`, GitHub wins. This is the rule that would have prevented today's session-opening confusion.
2. *"End-of-PR explanatory-doc check"* — agent self-imposed doc-impact check before declaring a PR done. References explanatory docs that will exist after the next PR (HOW_IT_WORKS, INTERVIEW_PREP, CANONICAL_FACTS) with a "skip until they exist" note.
3. *"Start here" reading order* — added `STATUS.md` as item #1; moved `docs/internal/NEXT_UP.md` to last with a clarifying note that it's reference, not queue.

## Companion GitHub state created in the same session

**Labels** (6, via `gh label create`):
- `path-b` — V4 Path B: production-real system items
- `v3-open` — V3 backlog item still open
- `effort-day` / `effort-week` / `effort-weeks`
- `doc-audit` — for the future cron-triggered audit workflow

**Issues** (2, the actually-committed open work — speculative Path B items #2-#8 stay as sketches in NEXT_UP.md until someone commits to them):
- [#121 V4 Path B #1 — Model drift monitoring](https://github.com/kristenmartino/gridpulse/issues/121) — labels: `path-b`, `effort-week`. Body cites the 2026-05-19 PJM 47 GW model-spread observation as concrete justification.
- [#122 V3.γ — Hawaii / Alaska coverage](https://github.com/kristenmartino/gridpulse/issues/122) — labels: `v3-open`, `effort-week`. Body covers data-path constraints, files, acceptance criteria.

## Deferred to you — `gh` Project setup (~2 min once auth scope refreshed)

The `gh` token doesn't have the `project` scope, so I can't programmatically set up the Project. Once you run:

```bash
gh auth refresh -s project
```

…you (or I, on next invocation) can run these 5 commands to finish the setup:

```bash
# 1. Create the Project (user-level so it can pull cross-repo issues later)
gh project create --owner kristenmartino --title "GridPulse Roadmap"

# Note the project number from the output, e.g. 1, then:

# 2-3. Add the 2 open issues
gh project item-add <project-number> --owner kristenmartino \
  --url https://github.com/kristenmartino/gridpulse/issues/121
gh project item-add <project-number> --owner kristenmartino \
  --url https://github.com/kristenmartino/gridpulse/issues/122

# 4. (Optional) Link the repo so future issues surface as Project candidates
# Use the GitHub UI: Project → ⋯ → Settings → Manage access → link gridpulse repo
# (gh project link is not in the stable CLI yet)
```

Built-in `Status` field (Backlog / In Progress / Done) is the default; the labels handle tier and effort, so no custom fields needed at this scale.

## Net effect

Your "where am I?" ritual becomes:

```bash
cat STATUS.md      # 30s — current focus + decisions
gh pr list         # in flight
gh issue list      # queued
```

No tabs. No memory. No asking the agent to reconstruct state from PR archaeology.

## Test plan

Documentation + GitHub state change. No code impact.

- [x] `STATUS.md` renders cleanly in GitHub preview
- [x] `CLAUDE.md` modifications don't break existing instruction sections (verified via diff scope: 2 inserts + 1 list extension)
- [x] Issues [#121](https://github.com/kristenmartino/gridpulse/issues/121) and [#122](https://github.com/kristenmartino/gridpulse/issues/122) created with correct labels (`gh issue view 121 --json labels`)
- [ ] Verify GitHub Project creation once auth scope refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)