### PR TITLE
feat(drift): #121 part 1 — continuous 1-hour-ahead drift measurement

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -30,16 +30,18 @@ items beyond #121 stay deferred — see [`docs/internal/NEXT_UP.md`](docs/intern
 2 of these must be true, or the PM infrastructure built this week is
 theatrical and should be partially reverted:
 
-- [x] (a) `docs/HOW_IT_WORKS.md` has real content (PR-C1, this PR)
-- [ ] (b) `docs/HOW_IT_WORKS.md` and `docs/INTERVIEW_PREP.md` have been used at least once for actual practice (PR-C1 ships real HOW_IT_WORKS + interview story list; full STAR drafts in PR-C2)
-- [ ] (c) [#121](https://github.com/kristenmartino/gridpulse/issues/121) has a draft PR or partial implementation
+- [x] (a) `docs/HOW_IT_WORKS.md` has real content (PR #125)
+- [ ] (b) `docs/HOW_IT_WORKS.md` and `docs/INTERVIEW_PREP.md` have been used at least once for actual practice (read aloud + timed)
+- [x] (c) [#121](https://github.com/kristenmartino/gridpulse/issues/121) has a draft PR or partial implementation (PR-D1, this PR — backend drift measurement)
 - [ ] (d) The handoff quickstart has been run on sift-news or another repo
+
+**2 of 4 criteria now satisfied — the ≥2 threshold is cleared. The PM infrastructure built this week is not theatrical.** Criterion (b) takes ~10 min of reading aloud; (d) takes ~60 min running the quickstart on sift-news.
 
 ## Next 3 (priority order)
 
-1. **PR-C2 — Communication artifacts** (`docs/PITCH.md` 3 lengths + expand `docs/INTERVIEW_PREP.md` STAR stories from the 5 seed entries to full 90-second narratives, ~90 min). Next session.
-2. **[#121](https://github.com/kristenmartino/gridpulse/issues/121) — Model drift monitoring** (~1 week, `path-b`, `effort-week`). After PR-C2 lands. The 2026-05-19 PJM walkthrough surfaced a 47 GW model spread; closing this gap is real product work AND generates the strongest STAR story this project will produce.
-3. **[#122](https://github.com/kristenmartino/gridpulse/issues/122) — V3.γ Hawaii** (~3–5 days, `v3-open`, `effort-week`). Lower priority — blocked on HECO data-quality assessment, lower portfolio leverage than #121.
+1. **[#121](https://github.com/kristenmartino/gridpulse/issues/121) part 2 — UI surfacing** (~1–2 days, `path-b`). Models tab gets a drift indicator panel + confidence badge degrades when live MAPE exceeds holdout MAPE by threshold. Reads from `gridpulse:drift:{region}` (this PR shipped the writer).
+2. **[#121](https://github.com/kristenmartino/gridpulse/issues/121) part 3 — Ensemble weight integration** (~2–3 days, `path-b`). Decision: incorporate live MAPE into ensemble weights, OR surface a stale-weights warning when holdout-vs-live diverges past threshold. Decide based on what part 2 surfaces during use.
+3. **Run handoff quickstart on sift-news** (~60 min, satisfies (d) above + unblocks [#124](https://github.com/kristenmartino/gridpulse/issues/124) cross-linking). PR-C2 (`PITCH.md` + expanded STAR stories) is parked unless interview cycle demands it — currently no signal.
 
 ## Blocked / waiting on
 
@@ -57,7 +59,8 @@ theatrical and should be partially reverted:
 
 ## Recent decisions (last 7 days)
 
-- **2026-05-20** PR-C1 — Recall artifacts shipped. Real `HOW_IT_WORKS.md` + 5 Mermaid diagrams + populated `CANONICAL_FACTS.md` + `INTERVIEW_PREP.md` STAR-story stubs. STATUS.md restructured per review §5; CLAUDE.md caveat removed. [This PR]
+- **2026-05-20** PR-D1 — [#121](https://github.com/kristenmartino/gridpulse/issues/121) part 1 shipped. `models/drift.py` (continuous 1-hour-ahead drift measurement) + `jobs/phases.write_drift_metrics` (hourly Redis writes to `gridpulse:drift:{region}`) + 36 new unit tests. Full suite: 1,625 pass, 0 failures. [This PR]
+- **2026-05-20** PR-C1 — Recall artifacts shipped. Real `HOW_IT_WORKS.md` + 5 Mermaid diagrams + populated `CANONICAL_FACTS.md` + `INTERVIEW_PREP.md` STAR-story content. [PR #125]
 - **2026-05-20** Wider replan after multi-perspective review: confirmed Position A, deferred Path B beyond #121, reordered PR sequence to C → B (conditional) → D (deferred), and split PR-C into C1 (recall) + C2 (communication). [PR #123]
 - **2026-05-19** Path A declared complete. [#120](https://github.com/kristenmartino/gridpulse/pull/120)
 - **2026-05-19** Scenario simulator: heuristic over full-fidelity engine. [#119](https://github.com/kristenmartino/gridpulse/pull/119)

--- a/STATUS.md
+++ b/STATUS.md
@@ -49,6 +49,13 @@ theatrical and should be partially reverted:
   ([#124](https://github.com/kristenmartino/gridpulse/issues/124)) —
   wait until ≥2 repos have their own STATUS.md before linking makes
   sense.
+- **Scenario simulator: full-fidelity physics**
+  ([#127](https://github.com/kristenmartino/gridpulse/issues/127)) —
+  replace the analytical heuristic shipped in PR #119 with real
+  `scenario_engine` re-runs (Approach B: pre-computed sensitivity grid
+  in the scoring job, preserves Redis-only web tier). Parked until a
+  real user / interviewer signal demands physics correctness — see
+  issue body for trigger conditions.
 - **PR-B (doc-drift CI) decision** — ship only if drift surfaces during
   PR-C2 / #121 work. Otherwise stays deferred.
 - **PR-D (audit workflow)** — deferred indefinitely per [2026-05-20

--- a/jobs/phases.py
+++ b/jobs/phases.py
@@ -623,6 +623,112 @@ def predict_and_write_forecast(
         return PhaseResult(region=region, ok=False, error=str(e))
 
 
+# ── Phase: drift (scoring) — #121 part 1 ─────────────────────
+
+
+def read_existing_forecast(region: str) -> dict[str, Any] | None:
+    """Read the *current* ``gridpulse:forecast:{region}:1h`` payload from Redis.
+
+    Called before ``predict_and_write_forecast`` overwrites the key so the
+    drift phase can compare the about-to-be-stale 1-hour-ahead prediction
+    against the now-known actual. Returns ``None`` for first-time scoring
+    or any Redis-side error — the caller treats absence as a no-op.
+    """
+    from data.redis_client import redis_get, redis_key
+
+    try:
+        payload = redis_get(redis_key(f"forecast:{region}:1h"))
+        if isinstance(payload, dict):
+            return payload
+        return None
+    except Exception as exc:  # pragma: no cover — defensive
+        log.warning("drift_previous_forecast_read_failed", region=region, error=str(exc))
+        return None
+
+
+def write_drift_metrics(
+    region: str,
+    previous_forecast: dict[str, Any] | None,
+    demand_df: pd.DataFrame,
+) -> PhaseResult:
+    """Update the rolling per-model drift window at ``gridpulse:drift:{region}``.
+
+    #121 part 1: continuous 1-hour-ahead drift signal. At each scoring tick
+    the previous tick's forecast for the *current* hour has a knowable
+    actual; we compute the per-model absolute % error and append it to a
+    rolling window (default 30 days). Headline 7-day and 30-day MAPEs are
+    persisted alongside the underlying records so downstream UI / alerting
+    has both the summary and the series.
+
+    The phase is a no-op (``ok=True`` with ``details["skipped"]=...``) when:
+    - First-ever scoring tick for the region (``previous_forecast is None``)
+    - The previous forecast has no row matching any recent actual hour
+    - The actuals dataframe is empty / missing required columns
+
+    Failures here MUST NOT block the broader scoring run — drift is a
+    secondary signal, not a critical path.
+    """
+    from data.redis_client import redis_get, redis_key, redis_set
+    from models.drift import build_records_from_actuals, compute_drift_payload
+
+    if previous_forecast is None:
+        return PhaseResult(region=region, ok=True, details={"skipped": "no_previous_forecast"})
+
+    if demand_df is None or demand_df.empty or "demand_mw" not in demand_df.columns:
+        return PhaseResult(region=region, ok=True, details={"skipped": "no_actuals"})
+
+    try:
+        # Build {timestamp_iso -> actual_mw} from the just-fetched demand
+        # frame. We only care about hours where the actual is finite —
+        # EIA's publishing-lag NaN rows can't anchor a drift record.
+        df = demand_df.copy()
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        df = df.dropna(subset=["demand_mw"])
+        actuals: dict[str, float] = {
+            row["timestamp"].isoformat(): float(row["demand_mw"])
+            for _, row in df.iterrows()
+            if np.isfinite(row["demand_mw"]) and float(row["demand_mw"]) > 0
+        }
+
+        new_records = build_records_from_actuals(previous_forecast, actuals)
+        if not new_records:
+            return PhaseResult(
+                region=region,
+                ok=True,
+                details={"skipped": "no_matchable_actual_hour"},
+            )
+
+        existing = redis_get(redis_key(f"drift:{region}"))
+        existing_payload = existing if isinstance(existing, dict) else None
+        payload = compute_drift_payload(region, existing_payload, new_records)
+
+        redis_set(redis_key(f"drift:{region}"), payload, ttl=REDIS_TTL)
+
+        # Compact summary for the scoring-job log line.
+        models_with_records = sorted(payload["models"].keys())
+        sample_model = models_with_records[0] if models_with_records else None
+        rolling_7d = payload["models"][sample_model]["rolling_mape_7d"] if sample_model else None
+        log.info(
+            "drift_updated",
+            region=region,
+            models=models_with_records,
+            new_record_ts=next(iter(new_records.values())).timestamp,
+            sample_rolling_7d=rolling_7d,
+        )
+        return PhaseResult(
+            region=region,
+            ok=True,
+            details={
+                "models": models_with_records,
+                "new_records": len(new_records),
+                "total_records": sum(m["n_records"] for m in payload["models"].values()),
+            },
+        )
+    except Exception as exc:
+        log.warning("drift_write_failed", region=region, error=str(exc))
+        return PhaseResult(region=region, ok=False, error=str(exc))
+
+
 # ── Phase: backtests (training) ──────────────────────────────
 
 

--- a/jobs/scoring_job.py
+++ b/jobs/scoring_job.py
@@ -49,10 +49,28 @@ def _score_region(region: str) -> dict:
         "weather_rows": len(region_data.weather_df),
     }
 
+    # #121 part 1: snapshot the about-to-be-overwritten forecast key
+    # BEFORE write_actuals_and_weather + predict_and_write_forecast run.
+    # The drift phase later in this function compares this previous
+    # forecast's 1-hour-ahead prediction against the now-known actuals.
+    # Read failure → drift phase becomes a no-op for this tick.
+    previous_forecast = phases.read_existing_forecast(region)
+
     actuals_res = phases.write_actuals_and_weather(region_data)
     summary["phases"]["actuals_weather"] = {
         "ok": actuals_res.ok,
         **(actuals_res.details if actuals_res.ok else {"error": actuals_res.error}),
+    }
+
+    # #121 part 1: continuous drift signal. Runs after actuals are
+    # written + before predict_and_write_forecast overwrites the
+    # forecast key. Failures are isolated — a drift-side error never
+    # blocks the broader scoring run because drift is a secondary
+    # signal, not a critical path.
+    drift_res = phases.write_drift_metrics(region, previous_forecast, region_data.demand_df)
+    summary["phases"]["drift"] = {
+        "ok": drift_res.ok,
+        **(drift_res.details if drift_res.ok else {"error": drift_res.error}),
     }
 
     gen_res = phases.write_generation(region)

--- a/models/drift.py
+++ b/models/drift.py
@@ -1,0 +1,352 @@
+"""Model drift measurement against live actuals.
+
+Holdout MAPE — the basis for the inverse-MAPE ensemble weights — is
+computed once per day during the training job. Between trainings,
+individual models can drift relative to live actuals while the
+ensemble weights silently treat them as if they hadn't. The PJM
+walkthrough on 2026-05-19 surfaced exactly this symptom: four
+forecasts spanning a 47 GW range at the same horizon, indicating
+at least one model was performing materially worse on live actuals
+than its frozen training-time MAPE suggested.
+
+This module computes a continuous **1-hour-ahead** drift signal:
+
+* At each hourly scoring tick the previous tick's forecast for the
+  *current* hour has a knowable actual. We compute the per-model
+  absolute percent error for that single point.
+* Records accumulate in Redis under ``gridpulse:drift:{region}`` as
+  a rolling window per model (default 30 days = 720 hourly points).
+* Rolling 7-day and 30-day MAPE are computed from the records and
+  surfaced alongside them so downstream UI / alerting can read
+  either the headline number or the underlying series.
+
+Longer-horizon drift (e.g. 24h-ahead) would require *snapshotting*
+predictions at scoring time and re-evaluating them N hours later.
+That's part 2 work; this module ships the 1-hour-ahead path first
+because the existing forecast key already contains the prediction
+we need — no extra storage.
+
+The scope deliberately stops short of the ensemble-weight update
+loop. That's a separate decision the next part will resolve:
+incorporate live MAPE into the weights, or surface a stale-weights
+warning when holdout-vs-live diverges past a threshold.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import numpy as np
+
+# Default rolling-window depth. 30 days × 24 hours = 720 hourly records
+# per model. Each record is ~80 bytes of JSON → ~57 KB per model × 4
+# models = ~230 KB per region × 51 regions ≈ 12 MB total in Redis.
+# Well within Memorystore capacity.
+DEFAULT_MAX_RECORDS = 720
+WINDOW_7D_HOURS = 24 * 7
+WINDOW_30D_HOURS = 24 * 30
+
+
+@dataclass(frozen=True)
+class DriftRecord:
+    """One (predicted, actual) observation for a single (model, region, hour).
+
+    Stored under ``gridpulse:drift:{region}.models.{model}.records``. Frozen
+    so accidental mutation can't corrupt the rolling window.
+    """
+
+    timestamp: str  # ISO-8601 UTC, the *target* hour the prediction was for
+    predicted: float
+    actual: float
+    abs_pct_error: float  # |actual - predicted| / |actual| * 100, NaN-safe
+
+
+def absolute_pct_error(predicted: float, actual: float) -> float | None:
+    """MAPE-component for one observation, returns ``None`` when undefined.
+
+    Returns ``None`` when:
+    - actual is zero (division by zero — happens when EIA publishes a
+      sentinel zero for a missing observation; we'd rather drop the
+      record than report a degenerate error)
+    - either value is NaN / non-finite
+    """
+    if not (np.isfinite(predicted) and np.isfinite(actual)):
+        return None
+    if actual == 0:
+        return None
+    return abs(actual - predicted) / abs(actual) * 100.0
+
+
+def mape_over_records(records: list[DriftRecord]) -> float | None:
+    """Mean Absolute Percent Error across a list of drift records.
+
+    Records carry their own pre-computed ``abs_pct_error`` so this is a
+    simple mean. Returns ``None`` on empty input rather than 0.0 so
+    callers can distinguish "no data yet" from "model is perfect".
+    """
+    if not records:
+        return None
+    errors = [r.abs_pct_error for r in records if np.isfinite(r.abs_pct_error)]
+    if not errors:
+        return None
+    return float(np.mean(errors))
+
+
+def rolling_mape(
+    records: list[DriftRecord],
+    window_hours: int,
+    *,
+    now_iso: str | None = None,
+) -> float | None:
+    """MAPE over the most recent ``window_hours`` of records.
+
+    Records older than ``window_hours`` ago (as measured from ``now_iso``,
+    defaulting to ``datetime.now(UTC)``) are excluded. Returns ``None``
+    when no records fall within the window.
+    """
+    if not records:
+        return None
+    now = datetime.fromisoformat(now_iso) if now_iso is not None else datetime.now(UTC)
+    cutoff = now - timedelta(hours=window_hours)
+    in_window = [r for r in records if datetime.fromisoformat(r.timestamp) >= cutoff]
+    return mape_over_records(in_window)
+
+
+def extract_one_hour_ahead_predictions(
+    previous_forecast: dict[str, Any] | None,
+    target_timestamp_iso: str,
+) -> dict[str, float]:
+    """Pull each model's 1-hour-ahead prediction for ``target_timestamp_iso``.
+
+    The previous-tick forecast in Redis has the shape::
+
+        {
+            "region": ...,
+            "scored_at": ...,
+            "forecasts": [
+                {"timestamp": "2026-05-20T15:00:00+00:00",
+                 "predicted_demand_mw": 95234.5,
+                 "xgboost": 95234.5,
+                 "prophet": 96012.0,
+                 "arima": 94800.3,
+                 "ensemble": 95212.0},
+                ...
+            ],
+            ...
+        }
+
+    We locate the row whose ``timestamp`` matches ``target_timestamp_iso``
+    (the hour we now have an actual for) and return a mapping of
+    ``model_name -> predicted_mw`` for every model that produced a
+    finite value. Returns an empty dict when no matching row exists or
+    the payload is missing/malformed.
+    """
+    if not previous_forecast:
+        return {}
+    rows = previous_forecast.get("forecasts") or []
+    target = _normalize_ts(target_timestamp_iso)
+    for row in rows:
+        if _normalize_ts(row.get("timestamp", "")) != target:
+            continue
+        preds: dict[str, float] = {}
+        for key, val in row.items():
+            if key in ("timestamp", "predicted_demand_mw"):
+                continue
+            # Skip non-numeric keys (e.g. a future metadata field). A
+            # row contains exactly the model names + the two shared
+            # keys above.
+            try:
+                f = float(val)
+            except (TypeError, ValueError):
+                continue
+            if np.isfinite(f):
+                preds[key] = f
+        return preds
+    return {}
+
+
+def _normalize_ts(ts: str) -> str:
+    """Normalize ISO-8601 timestamps for comparison.
+
+    Tolerates ``Z`` suffix vs explicit ``+00:00``, and stray whitespace.
+    Returns the input unchanged on parse failure so the comparison
+    upstream just fails to match (rather than crashing).
+    """
+    if not ts:
+        return ts
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).isoformat()
+    except ValueError:
+        return ts.strip()
+
+
+def build_records_from_actuals(
+    previous_forecast: dict[str, Any] | None,
+    actuals: dict[str, float],
+) -> dict[str, DriftRecord]:
+    """Pair the previous tick's predictions with the now-known actuals.
+
+    Args:
+        previous_forecast: The Redis payload at ``gridpulse:forecast:{region}:1h``
+            *before* this tick overwrites it. ``None`` for first-run regions.
+        actuals: Mapping of ``timestamp_iso -> actual_mw`` covering hours
+            the actual for which is now available (typically the just-fetched
+            recent EIA window).
+
+    Returns:
+        Mapping of ``model_name -> DriftRecord`` for the most recent hour
+        we have both a prediction and an actual for. Empty dict when no
+        such hour exists (e.g. first-ever scoring tick, or the previous
+        forecast's earliest hour is already in the future).
+
+    The "most recent matchable hour" choice deliberately avoids creating
+    N records for N matchable hours: at hourly cadence each tick should
+    add exactly one observation per model. Backfilling more would happen
+    on first-deploy and could spike record counts oddly.
+    """
+    if not previous_forecast or not actuals:
+        return {}
+
+    # Pick the most recent target timestamp that's in both the previous
+    # forecast's row set AND the actuals mapping. Iterate actuals in
+    # reverse-chronological order so we get "most recent" cheaply.
+    rows = previous_forecast.get("forecasts") or []
+    fc_ts = {_normalize_ts(r.get("timestamp", "")): r for r in rows}
+    ordered_actuals = sorted(actuals.items(), reverse=True)
+    for ts_iso, actual_mw in ordered_actuals:
+        ts_norm = _normalize_ts(ts_iso)
+        if ts_norm not in fc_ts:
+            continue
+        if not np.isfinite(actual_mw):
+            continue
+        preds = extract_one_hour_ahead_predictions(previous_forecast, ts_norm)
+        out: dict[str, DriftRecord] = {}
+        for model_name, predicted_mw in preds.items():
+            err = absolute_pct_error(predicted_mw, actual_mw)
+            if err is None:
+                continue
+            out[model_name] = DriftRecord(
+                timestamp=ts_norm,
+                predicted=predicted_mw,
+                actual=float(actual_mw),
+                abs_pct_error=err,
+            )
+        return out
+    return {}
+
+
+def merge_and_trim(
+    existing_records: list[DriftRecord],
+    new_record: DriftRecord | None,
+    *,
+    max_records: int = DEFAULT_MAX_RECORDS,
+) -> list[DriftRecord]:
+    """Append ``new_record`` to ``existing_records`` and enforce window size.
+
+    De-duplicates by timestamp — if the same target hour is already in
+    the existing records (which happens when a scoring tick re-runs
+    against the same actuals, e.g. backfill / replay), the new record
+    replaces the old one. Otherwise appended and the oldest record
+    drops out when the window exceeds ``max_records``.
+
+    Returns a chronologically-sorted list, oldest first.
+    """
+    if new_record is None:
+        return sorted(existing_records, key=lambda r: r.timestamp)
+
+    by_ts: dict[str, DriftRecord] = {r.timestamp: r for r in existing_records}
+    by_ts[new_record.timestamp] = new_record
+    ordered = sorted(by_ts.values(), key=lambda r: r.timestamp)
+    if len(ordered) > max_records:
+        ordered = ordered[-max_records:]
+    return ordered
+
+
+def serialize_records(records: list[DriftRecord]) -> list[dict[str, Any]]:
+    """Compact dict form for Redis JSON. Keys deliberately short."""
+    return [
+        {
+            "ts": r.timestamp,
+            "p": round(r.predicted, 2),
+            "a": round(r.actual, 2),
+            "e": round(r.abs_pct_error, 4),
+        }
+        for r in records
+    ]
+
+
+def deserialize_records(rows: list[dict[str, Any]] | None) -> list[DriftRecord]:
+    """Inverse of ``serialize_records``. Tolerant of missing rows."""
+    if not rows:
+        return []
+    out: list[DriftRecord] = []
+    for row in rows:
+        try:
+            out.append(
+                DriftRecord(
+                    timestamp=_normalize_ts(row["ts"]),
+                    predicted=float(row["p"]),
+                    actual=float(row["a"]),
+                    abs_pct_error=float(row["e"]),
+                )
+            )
+        except (KeyError, TypeError, ValueError):
+            # A malformed historical row shouldn't poison the whole
+            # window. Drop it and continue.
+            continue
+    return out
+
+
+def compute_drift_payload(
+    region: str,
+    existing_payload: dict[str, Any] | None,
+    new_records: dict[str, DriftRecord],
+    *,
+    max_records: int = DEFAULT_MAX_RECORDS,
+    now_iso: str | None = None,
+) -> dict[str, Any]:
+    """Build the Redis payload for ``gridpulse:drift:{region}``.
+
+    Merges ``new_records`` (one per model from the just-processed tick)
+    into the existing per-model rolling windows, computes 7d and 30d
+    rolling MAPE per model, and returns the full payload ready for
+    ``redis_set``.
+
+    The ``models`` sub-mapping uses the same model-name vocabulary as
+    the forecast payload (``xgboost`` / ``prophet`` / ``arima`` /
+    ``ensemble``). Models without records yet are omitted; the UI
+    handles "no data yet" by simply not showing a drift indicator
+    for that model.
+    """
+    existing_models = (existing_payload or {}).get("models") or {}
+
+    # Union of models we have history for + models we have a new record for.
+    all_model_names = set(existing_models.keys()) | set(new_records.keys())
+
+    models_out: dict[str, Any] = {}
+    for model_name in sorted(all_model_names):
+        prior = deserialize_records(existing_models.get(model_name, {}).get("records"))
+        new_rec = new_records.get(model_name)
+        merged = merge_and_trim(prior, new_rec, max_records=max_records)
+
+        models_out[model_name] = {
+            "rolling_mape_7d": rolling_mape(merged, WINDOW_7D_HOURS, now_iso=now_iso),
+            "rolling_mape_30d": rolling_mape(merged, WINDOW_30D_HOURS, now_iso=now_iso),
+            "n_records": len(merged),
+            "records": serialize_records(merged),
+        }
+
+    return {
+        "region": region,
+        "last_updated_at": now_iso or datetime.now(UTC).isoformat(),
+        "models": models_out,
+    }
+
+
+# Convenience helper kept here so ``jobs/phases.py`` can stay thin and
+# focused on Redis IO rather than re-importing dataclass machinery.
+def record_to_dict(r: DriftRecord) -> dict[str, Any]:
+    """Public-friendly dict (longer keys than ``serialize_records``)."""
+    return asdict(r)

--- a/tests/unit/test_drift.py
+++ b/tests/unit/test_drift.py
@@ -1,0 +1,413 @@
+"""Unit tests for models/drift.py — #121 part 1.
+
+Coverage targets:
+- Pure-function arithmetic (absolute_pct_error, mape_over_records, rolling_mape)
+- Edge cases (zero actual, NaN inputs, empty windows, malformed records)
+- Payload construction (compute_drift_payload merges + trims + computes rolling)
+- Forecast-row extraction (extract_one_hour_ahead_predictions tolerates
+  Z suffix vs +00:00, missing rows, non-numeric fields)
+- Record building (build_records_from_actuals picks most-recent matchable hour)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from models.drift import (
+    DEFAULT_MAX_RECORDS,
+    WINDOW_7D_HOURS,
+    WINDOW_30D_HOURS,
+    DriftRecord,
+    absolute_pct_error,
+    build_records_from_actuals,
+    compute_drift_payload,
+    deserialize_records,
+    extract_one_hour_ahead_predictions,
+    mape_over_records,
+    merge_and_trim,
+    rolling_mape,
+    serialize_records,
+)
+
+
+def _ts(hours_ago: int, now: datetime | None = None) -> str:
+    """Helper: ISO timestamp ``hours_ago`` before ``now`` (defaults to a fixed instant)."""
+    base = now or datetime(2026, 5, 20, 15, 0, 0, tzinfo=UTC)
+    return (base - timedelta(hours=hours_ago)).isoformat()
+
+
+def _rec(hours_ago: int, error_pct: float, now: datetime | None = None) -> DriftRecord:
+    """Helper: build a DriftRecord at ``hours_ago`` with the given % error."""
+    return DriftRecord(
+        timestamp=_ts(hours_ago, now=now),
+        predicted=100_000.0,
+        actual=100_000.0 / (1 + error_pct / 100.0) if error_pct != 0 else 100_000.0,
+        abs_pct_error=error_pct,
+    )
+
+
+class TestAbsolutePctError:
+    def test_basic(self):
+        assert absolute_pct_error(110.0, 100.0) == pytest.approx(10.0)
+        assert absolute_pct_error(90.0, 100.0) == pytest.approx(10.0)
+
+    def test_zero_actual_returns_none(self):
+        # EIA sentinel: actual=0 is "missing observation," not real demand.
+        # We drop the record rather than report a degenerate error.
+        assert absolute_pct_error(50.0, 0.0) is None
+
+    def test_nan_inputs_return_none(self):
+        assert absolute_pct_error(float("nan"), 100.0) is None
+        assert absolute_pct_error(100.0, float("nan")) is None
+        assert absolute_pct_error(float("inf"), 100.0) is None
+
+    def test_perfect_prediction(self):
+        assert absolute_pct_error(100.0, 100.0) == pytest.approx(0.0)
+
+
+class TestMapeOverRecords:
+    def test_empty_returns_none(self):
+        # "no data yet" is distinguishable from "model is perfect" — both
+        # would silently render as 0% if we returned 0.0 here.
+        assert mape_over_records([]) is None
+
+    def test_single_record(self):
+        assert mape_over_records([_rec(1, 5.0)]) == pytest.approx(5.0)
+
+    def test_mean_of_multiple(self):
+        records = [_rec(1, 4.0), _rec(2, 8.0), _rec(3, 6.0)]
+        assert mape_over_records(records) == pytest.approx(6.0)
+
+    def test_skips_nonfinite_errors(self):
+        # A bad row shouldn't poison the mean — production drift records
+        # CAN end up with NaN if a stored record was corrupted by an old
+        # bug. The aggregator must be tolerant.
+        bad = DriftRecord(
+            timestamp=_ts(1), predicted=100.0, actual=100.0, abs_pct_error=float("nan")
+        )
+        good = _rec(2, 6.0)
+        assert mape_over_records([bad, good]) == pytest.approx(6.0)
+
+
+class TestRollingMape:
+    def test_empty_returns_none(self):
+        assert rolling_mape([], WINDOW_7D_HOURS) is None
+
+    def test_filters_outside_window(self):
+        # now = 2026-05-20 15:00 UTC. Records at 1h, 24h, 200h ago.
+        # 7d window (168h) should exclude only the 200h-ago record.
+        now = datetime(2026, 5, 20, 15, 0, 0, tzinfo=UTC)
+        recs = [_rec(1, 4.0, now=now), _rec(24, 8.0, now=now), _rec(200, 20.0, now=now)]
+        result = rolling_mape(recs, WINDOW_7D_HOURS, now_iso=now.isoformat())
+        # Only the 4% and 8% records should count.
+        assert result == pytest.approx(6.0)
+
+    def test_30d_window_includes_all_recent_data(self):
+        now = datetime(2026, 5, 20, 15, 0, 0, tzinfo=UTC)
+        recs = [_rec(h, 5.0, now=now) for h in range(0, 720, 24)]
+        result = rolling_mape(recs, WINDOW_30D_HOURS, now_iso=now.isoformat())
+        assert result == pytest.approx(5.0)
+
+    def test_returns_none_when_window_excludes_everything(self):
+        now = datetime(2026, 5, 20, 15, 0, 0, tzinfo=UTC)
+        ancient = [_rec(2000, 10.0, now=now)]  # older than any reasonable window
+        assert rolling_mape(ancient, WINDOW_7D_HOURS, now_iso=now.isoformat()) is None
+
+
+class TestExtractOneHourAheadPredictions:
+    def test_finds_matching_row(self):
+        target = "2026-05-20T15:00:00+00:00"
+        payload = {
+            "forecasts": [
+                {
+                    "timestamp": target,
+                    "predicted_demand_mw": 95234.5,
+                    "xgboost": 95234.5,
+                    "prophet": 96012.0,
+                    "arima": 94800.3,
+                    "ensemble": 95212.0,
+                },
+                {"timestamp": "2026-05-20T16:00:00+00:00", "xgboost": 96000},
+            ]
+        }
+        out = extract_one_hour_ahead_predictions(payload, target)
+        assert out == {
+            "xgboost": pytest.approx(95234.5),
+            "prophet": pytest.approx(96012.0),
+            "arima": pytest.approx(94800.3),
+            "ensemble": pytest.approx(95212.0),
+        }
+
+    def test_none_payload(self):
+        assert extract_one_hour_ahead_predictions(None, "2026-05-20T15:00:00+00:00") == {}
+
+    def test_empty_forecasts(self):
+        assert extract_one_hour_ahead_predictions({"forecasts": []}, "x") == {}
+
+    def test_no_matching_timestamp(self):
+        payload = {"forecasts": [{"timestamp": "2026-05-20T16:00:00+00:00", "xgboost": 1}]}
+        out = extract_one_hour_ahead_predictions(payload, "2026-05-20T15:00:00+00:00")
+        assert out == {}
+
+    def test_tolerates_z_suffix_vs_explicit_offset(self):
+        # Production payloads use +00:00; some test fixtures use Z.
+        # The extractor normalizes so they match.
+        payload = {"forecasts": [{"timestamp": "2026-05-20T15:00:00Z", "xgboost": 100.0}]}
+        out = extract_one_hour_ahead_predictions(payload, "2026-05-20T15:00:00+00:00")
+        assert out == {"xgboost": pytest.approx(100.0)}
+
+    def test_skips_non_numeric_and_nan(self):
+        payload = {
+            "forecasts": [
+                {
+                    "timestamp": "2026-05-20T15:00:00+00:00",
+                    "xgboost": 100.0,
+                    "prophet": float("nan"),
+                    "arima": "broken",
+                    "ensemble": 99.0,
+                }
+            ]
+        }
+        out = extract_one_hour_ahead_predictions(payload, "2026-05-20T15:00:00+00:00")
+        assert "xgboost" in out and "ensemble" in out
+        assert "prophet" not in out and "arima" not in out
+
+
+class TestBuildRecordsFromActuals:
+    def _previous_forecast(self) -> dict:
+        return {
+            "region": "PJM",
+            "forecasts": [
+                {
+                    "timestamp": "2026-05-20T13:00:00+00:00",
+                    "xgboost": 100_000.0,
+                    "prophet": 102_000.0,
+                },
+                {
+                    "timestamp": "2026-05-20T14:00:00+00:00",
+                    "xgboost": 101_000.0,
+                    "prophet": 103_000.0,
+                },
+            ],
+        }
+
+    def test_picks_most_recent_matchable_hour(self):
+        # Two forecast hours, both have actuals available — we want the
+        # MOST RECENT one (14:00), not the earlier (13:00). Hourly cadence
+        # → one record per tick.
+        actuals = {
+            "2026-05-20T13:00:00+00:00": 101_500.0,
+            "2026-05-20T14:00:00+00:00": 102_000.0,
+        }
+        recs = build_records_from_actuals(self._previous_forecast(), actuals)
+        for model_name in ("xgboost", "prophet"):
+            assert recs[model_name].timestamp == "2026-05-20T14:00:00+00:00"
+            assert recs[model_name].actual == pytest.approx(102_000.0)
+
+    def test_skips_hour_with_no_actual(self):
+        # Only the older forecast hour has an actual. The newer one
+        # (14:00) is still being awaited from EIA. Use what we have.
+        actuals = {"2026-05-20T13:00:00+00:00": 101_500.0}
+        recs = build_records_from_actuals(self._previous_forecast(), actuals)
+        assert recs["xgboost"].timestamp == "2026-05-20T13:00:00+00:00"
+
+    def test_no_previous_forecast_returns_empty(self):
+        assert build_records_from_actuals(None, {"x": 1.0}) == {}
+
+    def test_no_actuals_returns_empty(self):
+        assert build_records_from_actuals(self._previous_forecast(), {}) == {}
+
+    def test_zero_actual_filtered(self):
+        # actual=0 makes the % error undefined → record skipped.
+        actuals = {"2026-05-20T14:00:00+00:00": 0.0}
+        assert build_records_from_actuals(self._previous_forecast(), actuals) == {}
+
+    def test_computes_correct_pct_error(self):
+        # predicted=101_000, actual=100_000 → 1% over.
+        actuals = {"2026-05-20T14:00:00+00:00": 100_000.0}
+        # Patch the forecast to only have one model + only the matching hour
+        # for a clean numeric check.
+        forecast = {"forecasts": [{"timestamp": "2026-05-20T14:00:00+00:00", "xgboost": 101_000.0}]}
+        recs = build_records_from_actuals(forecast, actuals)
+        assert recs["xgboost"].abs_pct_error == pytest.approx(1.0)
+
+
+class TestMergeAndTrim:
+    def test_appends_new_record(self):
+        existing = [_rec(2, 5.0), _rec(1, 4.0)]
+        new = _rec(0, 3.0)
+        out = merge_and_trim(existing, new)
+        assert len(out) == 3
+        # Sorted oldest → newest
+        assert out[0].timestamp < out[1].timestamp < out[2].timestamp
+
+    def test_deduplicates_same_timestamp(self):
+        # Re-scoring against the same actuals (e.g. backfill) shouldn't
+        # double-count. The new record replaces the old.
+        existing = [_rec(1, 10.0)]
+        new = DriftRecord(
+            timestamp=existing[0].timestamp,
+            predicted=200.0,
+            actual=210.0,
+            abs_pct_error=4.76,
+        )
+        out = merge_and_trim(existing, new)
+        assert len(out) == 1
+        assert out[0].abs_pct_error == pytest.approx(4.76)
+
+    def test_trims_to_max_records(self):
+        # 25 records, max=20 → drop the 5 oldest.
+        existing = [_rec(h, 5.0) for h in range(25, 0, -1)]
+        new = _rec(0, 5.0)
+        out = merge_and_trim(existing, new, max_records=20)
+        assert len(out) == 20
+        # Newest 20 retained.
+        oldest_kept_h = max(h for h in range(25, 0, -1) if h < 20)
+        assert any(_ts(oldest_kept_h) == r.timestamp for r in out)
+
+    def test_none_new_record_returns_existing_sorted(self):
+        existing = [_rec(2, 5.0), _rec(1, 4.0)]
+        out = merge_and_trim(existing, None)
+        assert [r.timestamp for r in out] == sorted(r.timestamp for r in existing)
+
+
+class TestSerializeRoundTrip:
+    def test_round_trip(self):
+        original = [
+            DriftRecord(
+                timestamp="2026-05-20T15:00:00+00:00",
+                predicted=95234.5,
+                actual=98123.2,
+                abs_pct_error=2.94,
+            )
+        ]
+        serialized = serialize_records(original)
+        # Compact short-key form.
+        assert serialized[0]["ts"] == "2026-05-20T15:00:00+00:00"
+        assert serialized[0]["p"] == pytest.approx(95234.5)
+        assert serialized[0]["a"] == pytest.approx(98123.2)
+        assert serialized[0]["e"] == pytest.approx(2.94)
+
+        deserialized = deserialize_records(serialized)
+        assert len(deserialized) == 1
+        assert deserialized[0].abs_pct_error == pytest.approx(2.94)
+
+    def test_deserialize_tolerates_malformed_rows(self):
+        # One good row, one missing required key, one with wrong types.
+        rows = [
+            {
+                "ts": "2026-05-20T15:00:00+00:00",
+                "p": 100.0,
+                "a": 102.0,
+                "e": 2.0,
+            },
+            {"ts": "missing-others"},
+            {"ts": "2026-05-20T16:00:00+00:00", "p": "not-a-number", "a": 0, "e": 0},
+        ]
+        out = deserialize_records(rows)
+        # Only the good row survives.
+        assert len(out) == 1
+        assert out[0].abs_pct_error == pytest.approx(2.0)
+
+    def test_deserialize_empty_or_none(self):
+        assert deserialize_records(None) == []
+        assert deserialize_records([]) == []
+
+
+class TestComputeDriftPayload:
+    def test_first_run_builds_per_model_entries(self):
+        new_records = {
+            "xgboost": _rec(0, 5.0),
+            "prophet": _rec(0, 8.0),
+        }
+        now = datetime(2026, 5, 20, 15, 0, 0, tzinfo=UTC)
+        payload = compute_drift_payload(
+            "PJM",
+            existing_payload=None,
+            new_records=new_records,
+            now_iso=now.isoformat(),
+        )
+        assert payload["region"] == "PJM"
+        assert set(payload["models"].keys()) == {"xgboost", "prophet"}
+        # n_records=1 means rolling MAPE is just that single record's error.
+        assert payload["models"]["xgboost"]["n_records"] == 1
+        assert payload["models"]["xgboost"]["rolling_mape_7d"] == pytest.approx(5.0)
+        assert payload["models"]["prophet"]["rolling_mape_7d"] == pytest.approx(8.0)
+
+    def test_merges_existing_records(self):
+        now = datetime(2026, 5, 20, 15, 0, 0, tzinfo=UTC)
+        existing_payload = {
+            "models": {
+                "xgboost": {
+                    "records": [
+                        {
+                            "ts": _ts(2, now=now),
+                            "p": 100,
+                            "a": 95,
+                            "e": 5.26,  # ~5.26% error
+                        }
+                    ]
+                }
+            }
+        }
+        new_records = {"xgboost": _rec(0, 4.0, now=now)}
+        payload = compute_drift_payload(
+            "PJM",
+            existing_payload=existing_payload,
+            new_records=new_records,
+            now_iso=now.isoformat(),
+        )
+        assert payload["models"]["xgboost"]["n_records"] == 2
+        # rolling_mape_7d = mean(5.26, 4.0) ≈ 4.63
+        assert payload["models"]["xgboost"]["rolling_mape_7d"] == pytest.approx(4.63, abs=0.01)
+
+    def test_preserves_model_with_existing_but_no_new_record(self):
+        # Prophet had records previously; this tick produced only an
+        # xgboost record (maybe Prophet failed to load this tick).
+        # Prophet's history should be preserved.
+        now = datetime(2026, 5, 20, 15, 0, 0, tzinfo=UTC)
+        existing = {
+            "models": {
+                "prophet": {"records": [{"ts": _ts(2, now=now), "p": 100, "a": 105, "e": 4.76}]}
+            }
+        }
+        new_records = {"xgboost": _rec(0, 3.0, now=now)}
+        payload = compute_drift_payload(
+            "PJM",
+            existing_payload=existing,
+            new_records=new_records,
+            now_iso=now.isoformat(),
+        )
+        assert "prophet" in payload["models"]
+        assert payload["models"]["prophet"]["n_records"] == 1
+        assert "xgboost" in payload["models"]
+
+    def test_record_window_trimmed_to_max(self):
+        now = datetime(2026, 5, 20, 15, 0, 0, tzinfo=UTC)
+        # Existing has DEFAULT_MAX_RECORDS records already.
+        existing_records = [
+            {"ts": _ts(h, now=now), "p": 100, "a": 100, "e": 0.0}
+            for h in range(DEFAULT_MAX_RECORDS, 0, -1)
+        ]
+        existing = {"models": {"xgboost": {"records": existing_records}}}
+        new_records = {"xgboost": _rec(0, 1.0, now=now)}
+        payload = compute_drift_payload(
+            "PJM",
+            existing_payload=existing,
+            new_records=new_records,
+            now_iso=now.isoformat(),
+        )
+        # New record added, oldest dropped → still exactly max_records.
+        assert payload["models"]["xgboost"]["n_records"] == DEFAULT_MAX_RECORDS
+
+    def test_includes_last_updated_at(self):
+        now = datetime(2026, 5, 20, 15, 0, 0, tzinfo=UTC)
+        payload = compute_drift_payload(
+            "PJM",
+            existing_payload=None,
+            new_records={"xgboost": _rec(0, 1.0, now=now)},
+            now_iso=now.isoformat(),
+        )
+        assert payload["last_updated_at"] == now.isoformat()


### PR DESCRIPTION
## Why

[#121](https://github.com/kristenmartino/gridpulse/issues/121) (Model drift monitoring) is a ~1 week investment. Decomposing into three parts shippable independently:

- **Part 1 (this PR)** — Backend infrastructure: continuous 1-hour-ahead drift measurement, rolling-window persistence to Redis
- **Part 2** — UI surfacing: Models tab drift indicator + degraded confidence badge
- **Part 3** — Ensemble weight integration: decision on live-MAPE vs stale-weights warning

This PR is **the "draft PR or partial implementation"** that satisfies success criterion (c) in [STATUS.md](https://github.com/kristenmartino/gridpulse/blob/main/STATUS.md).

## Design

At each hourly scoring tick:

1. Read the *current* `gridpulse:forecast:{region}:1h` payload **before** `predict_and_write_forecast` overwrites it
2. Find the row in the previous forecast whose timestamp now has a knowable actual (typically the 1-hour-ahead prediction from the previous tick)
3. Compute per-model absolute % error for that single point
4. Merge into a rolling per-model window in `gridpulse:drift:{region}` (default 30 days = 720 hourly records)
5. Compute 7d + 30d rolling MAPE per model alongside the records

Longer-horizon drift (e.g. 24h-ahead) would require *snapshotting* predictions at scoring time. Deliberately scoped out of part 1.

## Storage shape

```jsonc
{
  "region": "PJM",
  "last_updated_at": "2026-05-20T15:00:00+00:00",
  "models": {
    "xgboost": {
      "rolling_mape_7d": 5.42,
      "rolling_mape_30d": 6.18,
      "n_records": 168,
      "records": [
        {"ts": "2026-05-13T15:00:00+00:00", "p": 95234.5, "a": 98123.2, "e": 2.94},
        ...
      ]
    },
    "prophet": { ... },
    "arima": { ... },
    "ensemble": { ... }
  }
}
```

- ~230 KB per region × 51 regions ≈ **12 MB** total in Memorystore
- TTL: 86400s (matches existing forecast payload)

## Files

| File | Lines | Purpose |
|---|---|---|
| `models/drift.py` (new) | 352 | Pure-function module: `DriftRecord`, MAPE arithmetic (NaN-safe, zero-actual filtering), rolling-window logic, prediction-row extraction (tolerates `Z` suffix vs `+00:00`), record merge/trim with timestamp de-dup, serialize/deserialize for Redis, `compute_drift_payload` composing the final write |
| `jobs/phases.py` (modified) | +106 | `read_existing_forecast()` helper + `write_drift_metrics` phase. No-ops gracefully when previous forecast missing, actuals empty, or no matchable hour. Failures isolated — drift errors never block the broader scoring run |
| `jobs/scoring_job.py` (modified) | +18 | Snapshot forecast key BEFORE `write_actuals_and_weather` + invoke `write_drift_metrics` AFTER. Adds `drift` phase to per-region summary |
| `tests/unit/test_drift.py` (new) | 413 | **36 unit tests** covering pure-function arithmetic edge cases, forecast-row extraction edge cases, record building (most-recent matchable hour selection), merge/trim (de-dup, rolling window enforcement), serialize round-trip (tolerant of malformed historical rows), full payload construction |
| `STATUS.md` | +9/-3 | Marks success criterion (c) satisfied; updates Next 3 to reflect part 2/3 sequencing |

## Defensive behavior

- **First-ever scoring tick**: no previous forecast → phase returns `ok=True` with `skipped="no_previous_forecast"`
- **EIA publishing lag (NaN actuals)**: filtered before record creation
- **Zero actuals** (EIA missing-observation sentinel): filtered to avoid divide-by-zero MAPE
- **Malformed historical Redis row**: dropped during deserialize, doesn't poison the window
- **Phase failure**: caught, logged, returns `PhaseResult(ok=False)` — never raises up to the scoring loop

## Tests

```
.venv/bin/python -m pytest tests/unit/test_drift.py -v
================== 36 passed in 0.10s ==================

.venv/bin/python -m pytest tests/unit/ -q
================== 1625 passed, 4 warnings in 135.90s ==================
```

Up from 1,589 baseline — exactly +36 new tests. **Zero regressions.**

- `ruff check .` → all checks passed
- `ruff format --check .` → 253 files already formatted

## Acceptance progress (from #121)

- [x] Scoring-job-side comparison runs every hourly tick
- [x] Per-model rolling-window MAPE (7d / 30d) persisted to Redis
- [ ] UI surfaces the drift indicator in the Models tab — **part 2**
- [ ] Alert (log + degraded confidence badge) when live MAPE exceeds holdout MAPE by >X% — **part 2 (log line already in place via `drift_updated` structlog event) + part 3 (UI badge)**
- [ ] Ensemble weights incorporate live MAPE OR stale-weights warning surfaces — **part 3**

## What part 2 will look like

- Read `gridpulse:drift:{region}` in the Models tab callback
- Render a per-model drift indicator (sparkline or single MAPE figure with delta-vs-holdout coloring)
- Trigger the degraded confidence badge when any model's `rolling_mape_7d` exceeds its training-time holdout MAPE by a threshold (suggest 50%)
- ~1–2 days of focused work

## What part 3 will need to decide

Mid-flight call between two valid approaches:
- **Live-MAPE ensemble weighting**: rebuild the ensemble weights every scoring tick using `rolling_mape_7d` instead of the daily-frozen holdout MAPE
- **Stale-weights warning only**: keep weights as-is (avoiding hourly weight thrash) but surface a banner when holdout vs live MAPE diverge past a threshold

Decide after part 2 ships and we see how often the divergence actually fires in practice. The PJM 47 GW spread from 2026-05-19 is the canonical case to evaluate against.

## Operational notes

After this merges + the next hourly scoring tick runs, expect:
- New log line per region: `drift_updated region=PJM models=[xgboost, prophet, arima, ensemble] sample_rolling_7d=X`
- New Redis key `gridpulse:drift:{region}` populating for all 51 BAs
- First tick: each region writes 1 record. Reaches steady-state (168 records for 7d MAPE) after ~7 days

The first 7 days of `rolling_mape_7d` will be noisy (small sample). UI in part 2 should gate display on `n_records >= 24` or similar to avoid showing degenerate single-point MAPEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)