### PR TITLE
fix(overview): hero chart + insight read Redis forecast, not simulated

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -47,6 +47,14 @@ The Next 3 is intentionally thin right now. Part 3 of #121 has a 7-day timing ga
 
 ## Blocked / waiting on
 
+- **Forecast tab chart 1–4h gap between actual end and forecast start**
+  ([#129](https://github.com/kristenmartino/gridpulse/issues/129)) —
+  EIA publishing lag visualized as empty. Fix is in
+  `jobs/phases.predict_and_write_forecast`: backfill predictions for
+  trailing NaN-demand rows so the forecast trace starts at
+  `last_actual_demand_hour + 1h` instead of `featured.timestamp.max() + 1h`.
+  Different code path than this PR; ~3–4 hours when picked up.
+
 - **Cross-link this Project to portfolio-v2 / sift / future repos**
   ([#124](https://github.com/kristenmartino/gridpulse/issues/124)) —
   trigger condition (≥2 repos with their own state-management setup)
@@ -73,7 +81,8 @@ The Next 3 is intentionally thin right now. Part 3 of #121 has a 7-day timing ga
 
 ## Recent decisions (last 7 days)
 
-- **2026-05-20** PR-D2 — [#121](https://github.com/kristenmartino/gridpulse/issues/121) part 2 shipped. Models tab drift panel: `_build_drift_panel` reads `gridpulse:drift:{region}` + holdout MAPEs, renders per-model status chips (on track / drifting / degraded) with mixed-state support. 15 new tests. Full suite: 1,640 pass. [This PR]
+- **2026-05-20** Overview hero chart + insight: route to Redis instead of `_simulate_forecasts`. User-reported "looks off" surfaced that the Overview was rendering noisy historical actuals as forward forecasts (CLAUDE.md "Redis-only reads in web tier" invariant violation). Added `_read_ensemble_forecast_from_redis` helper; both surfaces now read `gridpulse:forecast:{region}:1h` (same key the Forecast tab uses). Drop simulated fallback entirely — render actual-only / drop forecast clause on cold cache. 12 new tests. Filed [#129](https://github.com/kristenmartino/gridpulse/issues/129) for the related Forecast-tab gap (separate code path). Full suite: 1,652 pass. [This PR]
+- **2026-05-20** PR-D2 — [#121](https://github.com/kristenmartino/gridpulse/issues/121) part 2 shipped. Models tab drift panel: `_build_drift_panel` reads `gridpulse:drift:{region}` + holdout MAPEs, renders per-model status chips (on track / drifting / degraded) with mixed-state support. 15 new tests. Full suite: 1,640 pass. [PR #128]
 - **2026-05-20** PR-D1 — [#121](https://github.com/kristenmartino/gridpulse/issues/121) part 1 shipped. `models/drift.py` (continuous 1-hour-ahead drift measurement) + `jobs/phases.write_drift_metrics` (hourly Redis writes to `gridpulse:drift:{region}`) + 36 new unit tests. Full suite: 1,625 pass. [PR #126]
 - **2026-05-20** PR-C1 — Recall artifacts shipped. Real `HOW_IT_WORKS.md` + 5 Mermaid diagrams + populated `CANONICAL_FACTS.md` + `INTERVIEW_PREP.md` STAR-story content. [PR #125]
 - **2026-05-20** Wider replan after multi-perspective review: confirmed Position A, deferred Path B beyond #121, reordered PR sequence to C → B (conditional) → D (deferred), and split PR-C into C1 (recall) + C2 (communication). [PR #123]

--- a/components/_callbacks_overview.py
+++ b/components/_callbacks_overview.py
@@ -90,6 +90,56 @@ from personas.config import get_persona
 log = structlog.get_logger()
 
 
+def _read_ensemble_forecast_from_redis(
+    region: str,
+) -> tuple[list[pd.Timestamp], np.ndarray, str | None] | None:
+    """Read the live ensemble forecast from ``gridpulse:forecast:{region}:1h``.
+
+    The Forecast tab already reads from this key (via
+    ``_outlook_tab_from_redis`` in ``_callbacks_forecast.py``). This helper
+    extracts the same shape for the Overview hero chart + insight card so
+    those surfaces stop falling back to ``models.model_service._simulate_forecasts``,
+    which was producing noisy historical actuals displayed as forward
+    forecasts (CLAUDE.md "Redis-only reads in the web tier" invariant
+    violation discovered 2026-05-20).
+
+    Returns:
+        ``(timestamps, ensemble_predictions, scored_at)`` when the Redis
+        payload exists and contains an ``ensemble`` key per row.
+        ``None`` when Redis is cold, the payload is malformed, or the
+        ensemble column isn't populated — the caller should render the
+        actual-only / warming state in that case (never the simulated
+        baseline).
+    """
+    cached = redis_get(redis_key(f"forecast:{region}:1h"))
+    if not isinstance(cached, dict):
+        return None
+    forecasts = cached.get("forecasts") or []
+    if not forecasts:
+        return None
+
+    # Prefer the explicit ensemble column. Fall back to predicted_demand_mw
+    # (which mirrors the primary model — XGBoost by default) only when the
+    # ensemble entry is missing entirely. We deliberately do not fall back
+    # to a single base model masquerading as ensemble.
+    first_row = forecasts[0]
+    if "ensemble" in first_row:
+        pred_key = "ensemble"
+    elif "predicted_demand_mw" in first_row:
+        pred_key = "predicted_demand_mw"
+    else:
+        return None
+
+    try:
+        timestamps = [pd.to_datetime(row["timestamp"]) for row in forecasts]
+        predictions = np.array([float(row.get(pred_key, 0)) for row in forecasts], dtype=float)
+    except (KeyError, TypeError, ValueError) as exc:
+        log.warning("overview_forecast_redis_parse_failed", region=region, error=str(exc))
+        return None
+
+    return timestamps, predictions, cached.get("scored_at")
+
+
 def _build_overview_title(region: str) -> html.Div:
     """Page-title block: region name + 1-line subtitle."""
 
@@ -201,41 +251,50 @@ def _build_overview_hero_chart(
         )
     )
 
-    # 24h forecast bridge (orange dashed) + confidence band
+    # 24h forecast bridge (orange dashed) + confidence band.
+    #
+    # Reads the live ensemble forecast from gridpulse:forecast:{region}:1h
+    # (written hourly by the scoring job). Falls back to actual-only chart
+    # when Redis is cold rather than to models.model_service._simulate_forecasts,
+    # which prior to 2026-05-20 was rendering noisy *historical* actuals at
+    # *forward* timestamps — producing visibly wrong forecast traces (e.g. FPL
+    # peak appearing at 04:00 instead of the real evening peak). See the
+    # 2026-05-20 "looks off" debug + the fix branch's PR for the full
+    # diagnosis.
     try:
-        from models.model_service import get_forecasts
+        forecast_payload = _read_ensemble_forecast_from_redis(region)
+        if forecast_payload is not None:
+            forecast_ts_all, ensemble_arr, _scored_at = forecast_payload
+            horizon = min(24, len(ensemble_arr))
+            forecast_ts = forecast_ts_all[:horizon]
+            ensemble_y = list(ensemble_arr[:horizon])
 
-        forecasts = get_forecasts(region, df, models_shown=["ensemble"])
-        ensemble = forecasts.get("ensemble")
-        upper_80 = forecasts.get("upper_80")
-        lower_80 = forecasts.get("lower_80")
-        if ensemble is not None and len(ensemble) > 0:
-            horizon = min(24, len(ensemble))
-            forecast_ts = pd.date_range(
-                start=last_ts + pd.Timedelta(hours=1),
-                periods=horizon,
-                freq="h",
-            )
-            ensemble_y = list(ensemble[:horizon])
-
-            # Confidence band — drawn first so it sits behind the line
-            if upper_80 is not None and lower_80 is not None and len(upper_80) >= horizon:
-                upper_y = list(upper_80[:horizon])
-                lower_y = list(lower_80[:horizon])
-                fig.add_trace(
-                    go.Scatter(
-                        x=list(forecast_ts) + list(forecast_ts[::-1]),
-                        y=upper_y + lower_y[::-1],
-                        fill="toself",
-                        fillcolor="rgba(249, 115, 22, 0.12)",
-                        line=dict(width=0),
-                        hoverinfo="skip",
-                        showlegend=False,
-                        name="80% confidence",
-                    )
+            # Heuristic ±3 % visual confidence band. The Redis payload
+            # doesn't carry empirical CI bounds (those are computed on
+            # the Forecast tab from recent residuals — overkill for the
+            # Overview hero). A simple ±3 % gives the chart a tinted
+            # ribbon visually equivalent to what was shipping pre-fix,
+            # without any pretense of calibration. The Forecast tab is
+            # the place to look for real CIs.
+            upper_y = [v * 1.03 for v in ensemble_y]
+            lower_y = [v * 0.97 for v in ensemble_y]
+            fig.add_trace(
+                go.Scatter(
+                    x=list(forecast_ts) + list(forecast_ts[::-1]),
+                    y=upper_y + lower_y[::-1],
+                    fill="toself",
+                    fillcolor="rgba(249, 115, 22, 0.12)",
+                    line=dict(width=0),
+                    hoverinfo="skip",
+                    showlegend=False,
+                    name="±3% band",
                 )
+            )
 
-            # Forecast line (bridged from last actual point — no gap)
+            # Forecast line bridged from the last actual point — gives a
+            # visually continuous transition. The bridge segment uses the
+            # last actual MW; the forward segment uses the real ensemble
+            # predictions per their Redis-stored timestamps.
             bridge_x = [last_ts, *forecast_ts]
             bridge_y = [last_mw, *ensemble_y]
             fig.add_trace(
@@ -349,25 +408,46 @@ def _build_overview_insight(
     else:
         peak_str = "—"
 
+    # Forecast clause — read from the same Redis payload the hero chart
+    # uses. Drop the clause entirely when Redis is cold (warming state)
+    # instead of fabricating it from the simulated baseline. Same fix
+    # arc as the hero chart above; see comment there for the prior-bug
+    # context.
     forecast_clause = "Next-cycle forecast confidence is updating."
     try:
-        from models.model_service import get_forecasts
+        forecast_payload = _read_ensemble_forecast_from_redis(region)
+        if forecast_payload is not None:
+            forecast_ts_all, ensemble_arr, _scored_at = forecast_payload
+            horizon = min(24, len(ensemble_arr))
+            if horizon > 0:
+                f_arr = ensemble_arr[:horizon]
+                f_peak = float(f_arr.max())
+                f_peak_idx = int(f_arr.argmax())
+                # Use the REAL timestamp from the Redis payload, not a
+                # computed offset off last_actual. The previous code
+                # computed ``last_ts + (f_peak_idx + 1)h`` which is
+                # meaningless against the simulated baseline (the
+                # ensemble array represented historical hours, not
+                # forward) and produced bogus peak times like "04:00".
+                f_peak_ts = forecast_ts_all[f_peak_idx]
 
-        forecasts = get_forecasts(region, df, models_shown=["ensemble"])
-        ensemble = forecasts.get("ensemble")
-        if ensemble is not None and len(ensemble) > 0:
-            horizon = min(24, len(ensemble))
-            f_arr = np.asarray(ensemble[:horizon])
-            f_peak = float(f_arr.max())
-            f_peak_idx = int(f_arr.argmax())
-            f_peak_ts = df["timestamp"].iloc[-1] + pd.Timedelta(hours=f_peak_idx + 1)
-            metrics_dict = forecasts.get("metrics") or {}
-            ens_metrics = metrics_dict.get("ensemble") or metrics_dict.get("xgboost") or {}
-            mape = float(ens_metrics.get("mape", 0.0))
-            forecast_clause = (
-                f"Next-24h forecast peaks at {f_peak:,.0f} MW around "
-                f"{f_peak_ts.strftime('%H:%M')} (MAPE {mape:.1f}%)."
-            )
+                # MAPE for the ensemble — sourced from the model service
+                # which resolves through training-time holdout
+                # meta.json. Falls back gracefully when unavailable.
+                try:
+                    from models.model_service import get_model_metrics
+
+                    metrics_dict = get_model_metrics(region) or {}
+                    ens_metrics = metrics_dict.get("ensemble") or metrics_dict.get("xgboost") or {}
+                    mape = float(ens_metrics.get("mape", 0.0))
+                except Exception:  # pragma: no cover — defensive
+                    mape = 0.0
+
+                mape_clause = f" (MAPE {mape:.1f}%)" if mape > 0 else ""
+                forecast_clause = (
+                    f"Next-24h forecast peaks at {f_peak:,.0f} MW around "
+                    f"{f_peak_ts.strftime('%H:%M')} UTC{mape_clause}."
+                )
     except Exception as exc:  # pragma: no cover
         log.warning("overview_insight_forecast_failed", region=region, error=str(exc))
 

--- a/tests/unit/test_overview_forecast_from_redis.py
+++ b/tests/unit/test_overview_forecast_from_redis.py
@@ -1,0 +1,284 @@
+"""Regression tests for the Overview hero chart + insight Redis-forecast fix.
+
+A bug discovered 2026-05-20: ``_build_overview_hero_chart`` and
+``_build_overview_insight`` were calling ``models.model_service.get_forecasts``
+inline. In the web tier that always falls back to ``_simulate_forecasts``
+(no trained pickles on the web container's disk), which returns
+``actual * (1 + noise)`` — an array of length ``len(actual)`` representing
+noisy *historical* predictions, not forward forecasts. The hero chart
+then plotted ``ensemble[:24]`` (first 24 hours of HISTORICAL data) at
+the *next 24 hours of timestamps*, producing a visibly wrong forecast
+trace. The insight summary computed peak timestamp the same way and
+emitted nonsense like "peaks at 04:00."
+
+The fix routes both surfaces to ``gridpulse:forecast:{region}:1h`` (same
+key the Forecast tab already reads). These tests pin the fix:
+
+- The new helper ``_read_ensemble_forecast_from_redis`` parses the
+  payload correctly and returns ``None`` on cold cache / malformed input
+- The hero chart includes a forecast trace when Redis is warm with the
+  correct timestamps + values from the payload
+- The hero chart omits the forecast trace (renders actual-only) when
+  Redis is cold — does NOT fall back to simulated
+- The insight summary's forecast clause uses the REAL timestamp from
+  the Redis payload (not a computed offset off last_actual)
+- The insight summary drops the forecast clause when Redis is cold —
+  does NOT fabricate one from simulated
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _demand_df(hours: int = 168) -> pd.DataFrame:
+    """Build a synthetic actuals dataframe ending at 2026-05-20 05:00 UTC."""
+    end = pd.Timestamp("2026-05-20 05:00:00", tz="UTC")
+    ts = pd.date_range(end=end, periods=hours, freq="h")
+    # Daily cycle 15k–22k MW (Florida-ish shape, May)
+    hours_in = np.arange(hours)
+    demand = 18500 + 3500 * np.sin(2 * np.pi * (hours_in - 18) / 24)
+    return pd.DataFrame({"timestamp": ts, "demand_mw": demand})
+
+
+def _redis_forecast_payload(
+    *, n_rows: int = 24, start_ts: str = "2026-05-20T06:00:00+00:00"
+) -> dict:
+    """Build a realistic gridpulse:forecast:{region}:1h payload.
+
+    Mirrors the shape ``jobs.phases.predict_and_write_forecast`` writes:
+    list of rows each with timestamp + predicted_demand_mw + per-model
+    keys + (optionally) ensemble + ensemble_weights at the top level.
+    """
+    start = pd.Timestamp(start_ts)
+    timestamps = pd.date_range(start=start, periods=n_rows, freq="h")
+    hours_in = np.arange(n_rows)
+    # Florida-style daily cycle, peak around 19:00 UTC = 15:00 EDT.
+    # start_ts = 06:00 UTC → peak at hours_in=13 → 19:00 UTC.
+    # sin((i-7)*2π/24) is 1 when i-7 = 6, i.e. i = 13. ✓
+    ensemble_pred = 17500 + 5000 * np.sin(2 * np.pi * (hours_in - 7) / 24)
+    forecasts = []
+    for i, ts in enumerate(timestamps):
+        forecasts.append(
+            {
+                "timestamp": ts.isoformat(),
+                "predicted_demand_mw": float(ensemble_pred[i]),
+                "xgboost": float(ensemble_pred[i] * 1.005),
+                "prophet": float(ensemble_pred[i] * 0.995),
+                "arima": float(ensemble_pred[i] * 1.010),
+                "ensemble": float(ensemble_pred[i]),
+            }
+        )
+    return {
+        "region": "FPL",
+        "scored_at": "2026-05-20T09:02:00+00:00",
+        "granularity": "1h",
+        "primary_model": "xgboost",
+        "forecasts": forecasts,
+        "ensemble_weights": {"xgboost": 0.58, "prophet": 0.29, "arima": 0.13},
+    }
+
+
+class TestReadEnsembleForecastFromRedis:
+    """The new helper ``_read_ensemble_forecast_from_redis``."""
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_returns_none_when_cache_miss(self, mock_redis_get):
+        from components._callbacks_overview import _read_ensemble_forecast_from_redis
+
+        mock_redis_get.return_value = None
+        assert _read_ensemble_forecast_from_redis("FPL") is None
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_returns_none_when_forecasts_empty(self, mock_redis_get):
+        from components._callbacks_overview import _read_ensemble_forecast_from_redis
+
+        mock_redis_get.return_value = {"region": "FPL", "forecasts": []}
+        assert _read_ensemble_forecast_from_redis("FPL") is None
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_returns_none_when_payload_is_not_dict(self, mock_redis_get):
+        from components._callbacks_overview import _read_ensemble_forecast_from_redis
+
+        mock_redis_get.return_value = "not a dict"  # malformed
+        assert _read_ensemble_forecast_from_redis("FPL") is None
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_returns_timestamps_predictions_scored_at_when_warm(self, mock_redis_get):
+        from components._callbacks_overview import _read_ensemble_forecast_from_redis
+
+        mock_redis_get.return_value = _redis_forecast_payload()
+        result = _read_ensemble_forecast_from_redis("FPL")
+        assert result is not None
+        timestamps, predictions, scored_at = result
+        assert len(timestamps) == 24
+        assert len(predictions) == 24
+        assert isinstance(predictions, np.ndarray)
+        # First timestamp matches the payload
+        assert timestamps[0] == pd.Timestamp("2026-05-20T06:00:00+00:00")
+        # scored_at threaded through
+        assert scored_at == "2026-05-20T09:02:00+00:00"
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_falls_back_to_predicted_demand_mw_when_ensemble_missing(self, mock_redis_get):
+        from components._callbacks_overview import _read_ensemble_forecast_from_redis
+
+        # Build a payload where rows don't have ensemble (e.g. only XGBoost
+        # was loadable during scoring). predicted_demand_mw fallback should
+        # kick in.
+        payload = _redis_forecast_payload()
+        for row in payload["forecasts"]:
+            del row["ensemble"]
+        mock_redis_get.return_value = payload
+        result = _read_ensemble_forecast_from_redis("FPL")
+        assert result is not None
+        _ts, predictions, _scored = result
+        # Should equal predicted_demand_mw column (which equals the
+        # synthetic ensemble in our fixture, but the resolver chose the
+        # fallback path)
+        assert predictions[0] == pytest.approx(payload["forecasts"][0]["predicted_demand_mw"])
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_reads_correct_redis_key(self, mock_redis_get):
+        from components._callbacks_overview import _read_ensemble_forecast_from_redis
+
+        mock_redis_get.return_value = None
+        _read_ensemble_forecast_from_redis("ERCOT")
+        # Key composition: gridpulse:forecast:{region}:1h
+        called_key = mock_redis_get.call_args[0][0]
+        assert called_key == "gridpulse:forecast:ERCOT:1h"
+
+
+class TestHeroChartReadsRedis:
+    """``_build_overview_hero_chart`` no longer calls get_forecasts inline."""
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_includes_forecast_trace_when_redis_warm(self, mock_redis_get):
+        from components._callbacks_overview import _build_overview_hero_chart
+
+        mock_redis_get.return_value = _redis_forecast_payload()
+        fig = _build_overview_hero_chart("FPL", _demand_df())
+
+        trace_names = [t.name for t in fig.data]
+        assert "Forecast (24h)" in trace_names
+
+        # The forecast trace's x-axis values match the timestamps in the
+        # Redis payload — NOT a computed offset. First forecast point
+        # after the bridge segment is 2026-05-20 06:00 UTC.
+        forecast_trace = next(t for t in fig.data if t.name == "Forecast (24h)")
+        # bridge_x = [last_actual_ts, *forecast_timestamps]
+        # last_actual_ts = 2026-05-20 05:00; forecast_ts[0] = 2026-05-20 06:00
+        assert pd.Timestamp(str(forecast_trace.x[1])) == pd.Timestamp("2026-05-20T06:00:00+00:00")
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_omits_forecast_trace_when_redis_cold(self, mock_redis_get):
+        """Cold cache → actual-only chart. Does NOT fall back to simulated."""
+        from components._callbacks_overview import _build_overview_hero_chart
+
+        mock_redis_get.return_value = None
+        fig = _build_overview_hero_chart("FPL", _demand_df())
+
+        trace_names = [t.name for t in fig.data]
+        assert "Forecast (24h)" not in trace_names
+        # Actuals still render
+        assert any("Actual" in str(t.name) or t.name is None for t in fig.data)
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_does_not_call_get_forecasts(self, mock_redis_get):
+        """Sanity: the new path doesn't accidentally also trigger the
+        old inline compute via model_service.get_forecasts. This pins
+        the architectural fix — web tier reads only."""
+        from components._callbacks_overview import _build_overview_hero_chart
+
+        mock_redis_get.return_value = _redis_forecast_payload()
+        with patch("models.model_service.get_forecasts") as mock_get_forecasts:
+            _build_overview_hero_chart("FPL", _demand_df())
+            mock_get_forecasts.assert_not_called()
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_confidence_band_renders_around_real_ensemble(self, mock_redis_get):
+        from components._callbacks_overview import _build_overview_hero_chart
+
+        mock_redis_get.return_value = _redis_forecast_payload()
+        fig = _build_overview_hero_chart("FPL", _demand_df())
+
+        # The confidence band is drawn as a filled scatter — the ±3 %
+        # heuristic band should bracket the forecast ensemble values.
+        band_traces = [t for t in fig.data if t.fill == "toself"]
+        assert len(band_traces) >= 1  # at least the actual area + the band
+
+        # Find the band whose y-range tracks the ensemble (the actual
+        # area uses fill="tozeroy", not "toself" — band is the toself one).
+        band = band_traces[0]
+        # Band y is [upper, ...upper, ...lower reversed], so the max
+        # should be > the max of the ensemble (because upper = ensemble * 1.03)
+        band_y = np.array([v for v in band.y if v is not None], dtype=float)
+        # Sample sanity check — the band's max should be > 22k (since
+        # ensemble peaks at ~22.5k in the fixture and 1.03× = 23.2k)
+        assert band_y.max() > 22_000
+
+
+class TestInsightSummaryReadsRedis:
+    """``_build_overview_insight``'s forecast clause uses real Redis timestamps."""
+
+    @patch("components._callbacks_overview.redis_get")
+    @patch("models.model_service.get_model_metrics")
+    def test_forecast_clause_uses_real_peak_timestamp(self, mock_metrics, mock_redis_get):
+        from components._callbacks_overview import _build_overview_insight
+
+        # Fixture peaks at index 13 of the 24-hour window starting at
+        # 2026-05-20 06:00 UTC → 2026-05-20 19:00 UTC.
+        mock_redis_get.return_value = _redis_forecast_payload()
+        mock_metrics.return_value = {"ensemble": {"mape": 3.85}}
+
+        card = _build_overview_insight("FPL", _demand_df(), "data_scientist")
+
+        # Walk the card's children to find the forecast clause text
+        rendered_text = _all_text(card)
+        # Real peak time is 19:00 UTC — not "04:00" or some computed offset
+        assert "19:00 UTC" in rendered_text
+        assert "MAPE 3.9%" in rendered_text
+        # Peak value should appear too (~22.5k MW per the fixture)
+        assert (
+            "22,500" in rendered_text or "22,499" in rendered_text or "22,500 MW" in rendered_text
+        )
+
+    @patch("components._callbacks_overview.redis_get")
+    def test_forecast_clause_drops_when_redis_cold(self, mock_redis_get):
+        """Cold cache → no fabricated forecast clause from simulated."""
+        from components._callbacks_overview import _build_overview_insight
+
+        mock_redis_get.return_value = None
+
+        card = _build_overview_insight("FPL", _demand_df(), "data_scientist")
+
+        text = _all_text(card)
+        # The fallback copy stays — no fake numbers
+        assert "Next-cycle forecast confidence is updating." in text
+        # No phantom MAPE / peak from the simulated path
+        assert "Next-24h forecast peaks" not in text
+
+
+def _all_text(node) -> str:
+    """Walk a Dash component tree and concatenate string children."""
+    pieces: list[str] = []
+
+    def walk(n):
+        if isinstance(n, str):
+            pieces.append(n)
+            return
+        children = getattr(n, "children", None)
+        if isinstance(children, str):
+            pieces.append(children)
+        elif isinstance(children, (list, tuple)):
+            for c in children:
+                walk(c)
+        elif children is not None:
+            walk(children)
+
+    walk(node)
+    return " ".join(pieces)


### PR DESCRIPTION
## Why

You spotted "this looks off" on the FPL Overview tab. Investigation revealed the Overview hero chart and the Overview insight summary were both rendering **noisy historical actuals drawn at future timestamps** — calling them a "forecast." The orange dashed line shape was real demand from 6 days ago, plotted at "tomorrow." That's why the chart looked low-magnitude and why the summary text said "peaks at 04:00" (Florida demand peaks late afternoon, not 4 AM).

## Root cause

`_build_overview_hero_chart` and `_build_overview_insight` both called `models.model_service.get_forecasts(region, df, ...)` inline. In the web tier that **always** falls back to `_simulate_forecasts` (no trained pickles on the web container — those only live on the Cloud Run Job container). `_simulate_forecasts` returns:

```python
ensemble[i] = actual[i] * (1 + np.random.normal(0, 0.018))
```

An array of length `len(actual)` representing noisy *historical* predictions, not a forward forecast. Both surfaces then plotted `ensemble[:24]` (first 24 hours of historical) at *the next 24 hours of timestamps* — physically meaningless mapping.

This was also a [`CLAUDE.md`](../blob/main/CLAUDE.md) invariant violation:

> Cloud Run Service — stateless Dash/Flask web app. Reads from Redis only; never fetches EIA/Open-Meteo or trains models in the request path.

`get_forecasts` triggers model loading + inline prediction in the web tier. Wrong by design and producing wrong output.

## The fix

Both surfaces now read from `gridpulse:forecast:{region}:1h` — the same key the Forecast tab already reads, populated hourly by the scoring job with **real ensemble predictions at real forward timestamps**.

New helper: `_read_ensemble_forecast_from_redis(region) -> (timestamps, predictions, scored_at) | None`.

Behavior changes:

- **Hero chart**: forecast trace + ±3% heuristic band drawn from the real Redis ensemble. When Redis cold, renders actual-only (no forecast trace) instead of falling back to simulated.
- **Insight summary**: peak value, peak timestamp, MAPE pulled from real payload + `get_model_metrics`. Peak timestamp uses the actual row timestamp from Redis, not `last_actual + (argmax_idx + 1) hours`. Drops the forecast clause entirely when Redis cold.

`_simulate_forecasts` itself isn't deleted — it stays useful for unit tests + offline dev mode of `get_forecasts`. The point is to not show *users* a "forecast" that's really noisy historical data.

## Before vs after

| State | Before (buggy) | After (fixed) |
|---|---|---|
| Redis warm + Florida May | Orange line shape = May 14 cycle drawn at May 20→21. Peak at "04:00" UTC. MAPE ~1.6% (simulated baseline). | Real ensemble forecast from `gridpulse:forecast:FPL:1h`. Peak at real afternoon hour. MAPE from training holdout. |
| Redis cold | Falls back to simulated baseline → fabricated forecast shown to user. | Actual-only chart. Insight summary omits forecast clause ("Next-cycle forecast confidence is updating."). Honest. |

## Files

| File | Lines | Purpose |
|---|---|---|
| `components/_callbacks_overview.py` | +54 / -50 | New `_read_ensemble_forecast_from_redis` helper. Hero chart + insight both swapped from inline `get_forecasts` to Redis read. |
| `tests/unit/test_overview_forecast_from_redis.py` (new) | 284 | **12 tests** — 6 on the helper (cache miss, malformed, warm shape, model-key fallback, Redis-key composition), 4 on the hero chart (forecast trace present/absent, `get_forecasts` not called, confidence band brackets ensemble), 2 on the insight summary (real timestamps, cold-cache drop). |
| `STATUS.md` | +6 / -1 | Recent decisions row + Blocked/waiting-on entry for related issue [#129](https://github.com/kristenmartino/gridpulse/issues/129). |

## Related issue filed separately

[#129 — Forecast tab chart: 1–4h gap between actual end and forecast start](https://github.com/kristenmartino/gridpulse/issues/129)

User also noticed a separate 4-hour visible gap on the Forecast tab between where actuals end (05:00 UTC) and where the forecast starts (09:00 UTC). Diagnosis: `_build_future_feature_frame` uses `featured.timestamp.max() + 1h`, where featured includes rows with NaN demand but real weather. The model COULD predict for the gap hours but `predict_and_write_forecast` only iterates over the future_df. Different code path — filed as a separate issue, not bundled into this PR.

## Tests

```
.venv/bin/python -m pytest tests/unit/test_overview_forecast_from_redis.py -v
================== 12 passed in 0.58s ==================

.venv/bin/python -m pytest tests/unit/ -q
================== 1652 passed in 158.84s ==================
```

Up from 1,640 baseline (PR #128) — exactly +12 new tests. **Zero regressions.**

Lint: `ruff check . && ruff format --check .` → clean.

## Production impact

Once this merges, every user landing on the Overview tab sees the **real ensemble forecast** (matching what the Forecast tab already shows) instead of noisy historical data masquerading as forward predictions. The visible fabricated-forecast bug that has been live since `_simulate_forecasts` shipped is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)