### PR TITLE
fix(overview): rescue 2 commits orphaned by early PR #130 merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,47 @@ the canonical list; expansion history is `Original 8 → V1.α +8 → V3.ζ +35`
 
 Setup + bootstrap procedure: `docs/SCHEDULED_JOBS.md`.
 
+### Web tier I/O guardrail (added 2026-05-20 after PR #130)
+
+The Cloud Run Service container is **stateless** and has **no trained
+models, no meta.json files, no pickles on disk**. Those files live only
+on the Cloud Run Job container after GCS pull. Any call from
+`components/` to a function that reads from local disk or GCS will
+silently fall back to a simulated/baseline path in production.
+
+**Watchlist** (functions that have a local-disk path):
+
+- `models.model_service.get_forecasts(region, df)` — falls back to
+  `_simulate_forecasts` (noisy actuals at forward timestamps) when
+  no local pickle is present
+- `models.model_service.is_trained(region)` — pre-2026-05-20 checked
+  local disk; now Redis-first with local-pickle as dev fallback
+- `models.model_service.get_model_metrics(region)` — 6-layer fallback
+  chain; layers 1–3 and 5 all require meta.json/pickle on local disk,
+  so in production always falls through to **layer 6 (simulated
+  baseline)**. See [#131](https://github.com/kristenmartino/gridpulse/issues/131)
+
+**The rule for component callbacks:**
+
+> If a component callback needs model output, feature data, or model
+> metadata in the request path, **it MUST read from Redis**, not from
+> `models.model_service` or anywhere that touches disk. The scoring
+> job is the only writer; the web tier is read-only.
+
+When adding a new callback that needs ML-side data, the default
+question is: **"is this value in a `gridpulse:*` Redis key
+somewhere?"** If yes, use it. If no, the scoring job needs to write
+it first — file an issue, don't paper over with an inline compute.
+
+Two real bugs caused by violating this guardrail, both surfaced
+2026-05-20 within one session:
+
+- [PR #130 commit 7832633](https://github.com/kristenmartino/gridpulse/pull/130/commits/7832633) — Overview hero chart was
+  rendering noisy historical actuals at forward timestamps for every
+  page load
+- [PR #130 commit c2d6c20](https://github.com/kristenmartino/gridpulse/pull/130/commits/c2d6c20) — Overview model card badge
+  always said "simulated" even when forecasts in Redis were real
+
 ### Active top-level tabs in the current shell
 - Overview
 - Historical Demand

--- a/STATUS.md
+++ b/STATUS.md
@@ -47,6 +47,14 @@ The Next 3 is intentionally thin right now. Part 3 of #121 has a 7-day timing ga
 
 ## Blocked / waiting on
 
+- **Overview model card MAPE shows simulated baseline values**
+  ([#131](https://github.com/kristenmartino/gridpulse/issues/131)) — the
+  `is_trained` badge was fixed in PR #130 (now reads Redis), but the
+  MAPE / RMSE / MAE / R² displayed on the card still come from
+  `_simulate_forecasts` because the web tier can't read meta.json from
+  the Job container's disk. Real fix: scoring job writes `model_metrics`
+  into the forecast Redis payload, web tier reads from there. ~4 hours.
+
 - **Forecast tab chart 1–4h gap between actual end and forecast start**
   ([#129](https://github.com/kristenmartino/gridpulse/issues/129)) —
   EIA publishing lag visualized as empty. Fix is in

--- a/models/model_service.py
+++ b/models/model_service.py
@@ -198,13 +198,56 @@ def get_ensemble_weights(region: str) -> dict[str, float]:
 
 
 def is_trained(region: str) -> bool:
-    """Check if trained models exist for a region."""
+    """Check if a real trained-model forecast is available for the region.
+
+    The web tier's source of truth is Redis: ``gridpulse:forecast:{region}:1h``
+    is written hourly by the scoring job, and the ``ensemble_weights`` field
+    is only present when ≥2 trained base models produced finite predictions
+    during that tick. Presence of ``ensemble_weights`` is therefore the
+    tightest "real trained models are live for this region" signal we can
+    read without scanning GCS.
+
+    The pre-2026-05-20 implementation checked for a local ``trained_models/
+    {region}_models.pkl`` file, which in production *always* returns False
+    on the web tier (only the Cloud Run Job container has trained pickles
+    on disk). That caused every region to render the "simulated" badge on
+    the Overview model card even when real trained-model output was being
+    rendered in the forecast chart and Forecast tab.
+
+    Falls back to the legacy local-pickle check when Redis isn't reachable
+    (dev mode with no Memorystore). Returns False for unknown regions.
+    """
     from models.training import _safe_model_path, _validate_region
 
     try:
         _validate_region(region)
     except ValueError:
         return False
+
+    # Primary path: Redis forecast with ensemble_weights → real trained models
+    try:
+        from data.redis_client import redis_get, redis_key
+
+        payload = redis_get(redis_key(f"forecast:{region}:1h"))
+        if isinstance(payload, dict):
+            weights = payload.get("ensemble_weights")
+            if isinstance(weights, dict) and weights:
+                return True
+            # Forecast exists but no ensemble weights — could mean only one
+            # model loaded, OR weights were dropped. Treat as "live but
+            # not full ensemble" — still trained.
+            forecasts = payload.get("forecasts") or []
+            if forecasts:
+                first_row = forecasts[0]
+                # Any per-model column populated (xgboost / prophet / arima)
+                # indicates a real trained-model prediction in flight.
+                model_cols = {"xgboost", "prophet", "arima"}
+                if any(isinstance(first_row.get(k), (int, float)) for k in model_cols):
+                    return True
+    except Exception as exc:  # pragma: no cover — defensive
+        log.debug("is_trained_redis_check_failed", region=region, error=str(exc))
+
+    # Fallback: legacy local-pickle check for dev environments without Redis
     filepath = _safe_model_path(MODEL_DIR, region)
     return os.path.exists(filepath)
 

--- a/tests/unit/test_is_trained_reads_redis.py
+++ b/tests/unit/test_is_trained_reads_redis.py
@@ -1,0 +1,130 @@
+"""Tests for the updated ``models.model_service.is_trained`` — 2026-05-20.
+
+Bug: ``is_trained(region)`` used to check for ``trained_models/{region}_models.pkl``
+on local disk. In production the Cloud Run **Service** container has no
+such directory (trained pickles live only on the Cloud Run **Job**
+container), so ``is_trained`` returned False for every region every time.
+
+Surface impact: the Overview model card's ``[trained] / [simulated]``
+badge was always "[simulated]" in production, even when the chart and
+the Forecast tab were correctly rendering real trained-model output
+from Redis.
+
+The fix shifts the primary signal to Redis: ``gridpulse:forecast:{region}:1h``
+with a populated ``ensemble_weights`` (or any per-model column populated)
+indicates real trained-model output is live for that region.
+
+These tests pin the new behavior and lock the architectural pattern.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+class TestIsTrainedReadsRedis:
+    """Primary path: Redis forecast with ensemble_weights → trained."""
+
+    @patch("data.redis_client.redis_get")
+    def test_ensemble_weights_present_returns_true(self, mock_redis_get):
+        from models.model_service import is_trained
+
+        mock_redis_get.return_value = {
+            "region": "FPL",
+            "forecasts": [
+                {
+                    "timestamp": "2026-05-20T06:00:00+00:00",
+                    "predicted_demand_mw": 18000.0,
+                    "xgboost": 18000.0,
+                    "ensemble": 18000.0,
+                }
+            ],
+            "ensemble_weights": {"xgboost": 0.58, "prophet": 0.29, "arima": 0.13},
+        }
+        assert is_trained("FPL") is True
+
+    @patch("data.redis_client.redis_get")
+    def test_per_model_column_without_ensemble_weights_still_trained(self, mock_redis_get):
+        """When only one model was loadable during scoring, ensemble_weights
+        is absent but the per-model prediction is real — still trained."""
+        from models.model_service import is_trained
+
+        mock_redis_get.return_value = {
+            "region": "FPL",
+            "forecasts": [
+                {
+                    "timestamp": "2026-05-20T06:00:00+00:00",
+                    "predicted_demand_mw": 18000.0,
+                    "xgboost": 18000.0,
+                }
+            ],
+            # No ensemble_weights here
+        }
+        assert is_trained("FPL") is True
+
+    @patch("os.path.exists")
+    @patch("data.redis_client.redis_get")
+    def test_empty_redis_falls_back_to_local_pickle(self, mock_redis_get, mock_exists):
+        """No Redis data → check the legacy local-pickle path for dev mode."""
+        from models.model_service import is_trained
+
+        mock_redis_get.return_value = None
+        mock_exists.return_value = True  # Local pickle exists (dev mode)
+
+        assert is_trained("FPL") is True
+        mock_exists.assert_called()
+
+    @patch("os.path.exists")
+    @patch("data.redis_client.redis_get")
+    def test_no_redis_no_local_returns_false(self, mock_redis_get, mock_exists):
+        from models.model_service import is_trained
+
+        mock_redis_get.return_value = None
+        mock_exists.return_value = False
+
+        assert is_trained("FPL") is False
+
+    @patch("data.redis_client.redis_get")
+    def test_invalid_region_returns_false(self, mock_redis_get):
+        """Region name fails validation → False without consulting Redis."""
+        from models.model_service import is_trained
+
+        assert is_trained("not-a-real-region!") is False
+        # The Redis check should be skipped for invalid regions.
+        mock_redis_get.assert_not_called()
+
+    @patch("data.redis_client.redis_get")
+    def test_empty_forecasts_list_with_no_weights_falls_back_to_local(self, mock_redis_get):
+        """Redis exists but forecasts is empty — falls back to local check."""
+        from models.model_service import is_trained
+
+        mock_redis_get.return_value = {
+            "region": "FPL",
+            "forecasts": [],
+            # No ensemble_weights
+        }
+        # With mock_redis_get returning this empty-but-present payload,
+        # is_trained should fall through to the legacy local check.
+        # In test env (no local pickle), result is False.
+        with patch("os.path.exists", return_value=False):
+            assert is_trained("FPL") is False
+
+    @patch("data.redis_client.redis_get")
+    def test_malformed_redis_payload_falls_back_to_local(self, mock_redis_get):
+        """Redis returns non-dict — fall back to local check."""
+        from models.model_service import is_trained
+
+        mock_redis_get.return_value = "not a dict"
+        with patch("os.path.exists", return_value=False):
+            assert is_trained("FPL") is False
+
+    @patch("data.redis_client.redis_get")
+    def test_uses_correct_redis_key(self, mock_redis_get):
+        from models.model_service import is_trained
+
+        mock_redis_get.return_value = None
+        with patch("os.path.exists", return_value=False):
+            is_trained("ERCOT")
+
+        called_key = mock_redis_get.call_args[0][0]
+        assert called_key == "gridpulse:forecast:ERCOT:1h"


### PR DESCRIPTION
## Why this PR exists

[PR #130](https://github.com/kristenmartino/gridpulse/pull/130) was merged at **09:56 UTC** with only its first commit (`7832633` — chart + insight Redis read). Two follow-up commits landed on the same branch ~2 minutes later but **were never included in the merge**:

- `c2d6c20` — `is_trained` reads Redis (closes the `[simulated]` badge bug)
- `e85ffcf` — CLAUDE.md Web tier I/O guardrail (documents the architectural pattern)

This PR cherry-picks both onto a fresh branch off main so they actually ship.

## Symptom that surfaced this

User on PACW Overview tab today: badge still shows `[simulated]` next to "Ensemble" even though the chart trace (from `7832633`) renders correctly. Scoring logs confirm all three models (`xgboost`, `prophet`, `arima`) loaded for PACW at 11:07 UTC — Redis has the data. Investigation showed:

- `git log origin/main`: `03d534a Merge pull request #130` → parent is `7832633`, NOT `c2d6c20`
- The fix that swaps `is_trained` to read Redis (instead of the always-missing local pickle on the web tier) never reached production

## What's in this PR

Identical content to the two orphaned commits, cherry-picked verbatim:

1. **`models/model_service.is_trained` swapped to Redis-first** with local-pickle as dev fallback. Checks `gridpulse:forecast:{region}:1h` for `ensemble_weights` (full ensemble) or any per-model column populated (single-model output). Falls back to legacy pickle check only when Redis is unreachable.

2. **`docs/CLAUDE.md` "Web tier I/O guardrail"** documenting the architectural rule (web tier MUST read Redis, never local disk) plus a watchlist of the three known-suspect functions (`get_forecasts`, `is_trained`, `get_model_metrics`).

3. **`tests/unit/test_is_trained_reads_redis.py`** — 8 tests covering ensemble_weights path, per-model-column fallback, local-pickle dev fallback, invalid region short-circuit, malformed payload resilience, correct key composition.

## Process note (the third time this happened)

The same merge-before-follow-ups pattern hit PR #123 (touch-ups missed), PR #125 (PITCH expansion missed), and now PR #130 (is_trained + CLAUDE.md missed). For me, the lesson is: **don't push follow-up commits to an in-flight PR — bundle everything into the initial push, OR send a "PR ready, X commits, safe to merge" signal before adding more.** Recovering by cherry-pick is fine but it's now ~30 min of extra work per occurrence.

I'll be more disciplined about this going forward.

## Tests

- 8 new tests pass
- This PR diffs only against main — no regressions possible against #131's branch since they touch different parts of `model_service.py`

## What you'll see after merge + deploy

PACW (and every other region with a populated forecast in Redis) — badge changes from `[simulated]` to `[trained]`. The MAPE values themselves remain from the simulated baseline until [PR #132](https://github.com/kristenmartino/gridpulse/pull/132) (which fixes #131) also merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)