### PR TITLE
fix(forecast): use Open-Meteo forecast for future weather features

### DIFF
--- a/data/weather_client.py
+++ b/data/weather_client.py
@@ -33,7 +33,7 @@ REQUEST_TIMEOUT = 30
 def fetch_weather(
     region: str,
     past_days: int = 92,
-    forecast_days: int = 7,
+    forecast_days: int = 16,
     use_cache: bool = True,
 ) -> pd.DataFrame:
     """
@@ -45,7 +45,13 @@ def fetch_weather(
     Args:
         region: Balancing authority code (e.g., "ERCOT", "FPL").
         past_days: Number of historical days to include (default 92 = ~3 months).
-        forecast_days: Number of forecast days (default 7).
+        forecast_days: Number of forecast days (default 16 = Open-Meteo's GFS
+            forecast horizon; 384 hourly rows). Bumped from 7 → 16 on
+            2026-05-20 so the scoring job's 720-hour demand forecast can use
+            actual weather forecasts for the first ~53% of its horizon
+            instead of falling back to climatology for everything beyond
+            day 7. See PR-C of the forecast-pipeline audit
+            (``jobs/phases.py:_build_future_feature_frame``).
         use_cache: Whether to check cache first.
 
     Returns:

--- a/jobs/phases.py
+++ b/jobs/phases.py
@@ -377,11 +377,162 @@ def write_interchange(region: str) -> PhaseResult:
 # ── Phase: forecast (scoring) ────────────────────────────────
 
 
-def _build_future_feature_frame(featured: pd.DataFrame, horizon: int) -> pd.DataFrame:
-    """Mirror the climatology-style future-feature builder used by populate_redis.
+def _overlay_weather_forecast(
+    future_df: pd.DataFrame,
+    featured: pd.DataFrame,
+    weather_df: pd.DataFrame,
+    horizon: int,
+) -> pd.DataFrame:
+    """Overlay actual Open-Meteo forecast values onto a climatology-built ``future_df``.
 
-    Uses per-(hour, dow) historical means for non-time features so the
-    forecast has sane exogenous inputs without external weather forecasts.
+    For future timestamps covered by ``weather_df`` (typically the next
+    ~16 days from Open-Meteo's ``/forecast`` endpoint), raw weather columns
+    are replaced with their forecasted values and the derived weather
+    features (CDD/HDD/wind_power/solar_capacity_factor/temp_x_hour/
+    temperature_deviation) are recomputed from those forecasted raw values.
+    Hours beyond the forecast horizon keep their (hour, dow) climatology
+    values from the existing builder. Returns a NEW DataFrame; does not
+    mutate inputs.
+
+    Why this exists (2026-05-20, PR-C of the forecast-pipeline audit):
+    pre-fix, ``_build_future_feature_frame`` populated future weather
+    features entirely from historical (hour, day-of-week) group means.
+    The model was trained on actual weather but served with climatology —
+    a train/serve gap that caused weather to barely move the demand
+    forecast in production. After this overlay, the first ~384 hours
+    of the forecast horizon use real Open-Meteo data; beyond that
+    we still fall back to climatology because Open-Meteo's free GFS
+    forecast caps at 16 days.
+    """
+    from config import WEATHER_VARIABLES
+    from data.feature_engineering import (
+        compute_cdd,
+        compute_hdd,
+        compute_solar_capacity_factor,
+        compute_temp_hour_interaction,
+        compute_temperature_deviation,
+        compute_wind_power,
+    )
+
+    future_df = future_df.copy()
+
+    if weather_df is None or weather_df.empty:
+        return future_df
+
+    wx = weather_df.copy()
+    wx["timestamp"] = pd.to_datetime(wx["timestamp"], utc=True)
+    wx = wx.drop_duplicates(subset="timestamp", keep="last")
+
+    # Restrict to the raw weather columns we actually use as model features.
+    raw_in_wx = [c for c in WEATHER_VARIABLES if c in wx.columns]
+    if not raw_in_wx:
+        return future_df
+
+    # Index by timestamp for fast point lookup
+    wx_indexed = wx.set_index("timestamp")[raw_in_wx]
+    ts = pd.to_datetime(future_df["timestamp"], utc=True)
+
+    # Coverage diagnostic — useful for confirming Open-Meteo forecast hours
+    # actually align with the demand forecast horizon in production logs.
+    n_covered = int(ts.isin(wx_indexed.index).sum())
+    log.info(
+        "future_frame_weather_forecast_coverage",
+        horizon=horizon,
+        forecast_covered_hours=n_covered,
+        climatology_fallback_hours=horizon - n_covered,
+    )
+
+    if n_covered == 0:
+        # Nothing to overlay — climatology stays as-is.
+        return future_df
+
+    # Overlay each raw weather column where forecast exists. Other rows
+    # keep their climatological value from the existing builder.
+    for col in raw_in_wx:
+        forecast_values = ts.map(
+            lambda t, c=col: (
+                float(wx_indexed.loc[t, c])
+                if t in wx_indexed.index and pd.notna(wx_indexed.loc[t, c])
+                else np.nan
+            )
+        )
+        if col not in future_df.columns:
+            future_df[col] = np.nan
+        mask = forecast_values.notna()
+        future_df.loc[mask, col] = forecast_values[mask].values
+
+    # Recompute derived weather features from the (now possibly-updated)
+    # raw values. Apply to the whole frame so derived columns stay
+    # internally consistent with raw columns regardless of which source
+    # (forecast or climatology) provided each row.
+    if "temperature_2m" in future_df.columns:
+        future_df["cooling_degree_days"] = compute_cdd(future_df["temperature_2m"]).values
+        future_df["heating_degree_days"] = compute_hdd(future_df["temperature_2m"]).values
+
+        # temperature_deviation = current_temp - 720h rolling mean. The
+        # rolling window must include historical context (the 30 days
+        # preceding `now`) or the deviation collapses to ~0 for all
+        # future rows. Concatenate hist + future, compute, take tail.
+        if "temperature_2m" in featured.columns and len(featured) > 0:
+            hist_temp = featured["temperature_2m"].reset_index(drop=True)
+            future_temp = future_df["temperature_2m"].reset_index(drop=True)
+            combined = pd.concat([hist_temp, future_temp], ignore_index=True)
+            deviation = compute_temperature_deviation(combined)
+            future_df["temperature_deviation"] = deviation.tail(horizon).values
+
+    if "wind_speed_80m" in future_df.columns:
+        future_df["wind_power_estimate"] = compute_wind_power(future_df["wind_speed_80m"]).values
+
+    if "shortwave_radiation" in future_df.columns:
+        future_df["solar_capacity_factor"] = compute_solar_capacity_factor(
+            future_df["shortwave_radiation"]
+        ).values
+
+    if "temperature_2m" in future_df.columns and "hour_sin" in future_df.columns:
+        future_df["temp_x_hour"] = compute_temp_hour_interaction(
+            future_df["temperature_2m"], future_df["hour_sin"]
+        ).values
+
+    return future_df
+
+
+def _build_future_feature_frame(
+    featured: pd.DataFrame,
+    horizon: int,
+    weather_df: pd.DataFrame | None = None,
+) -> pd.DataFrame:
+    """Build a feature frame for the forecast horizon.
+
+    Two-stage build:
+
+    1. **Climatology baseline (always)** — every non-time feature column
+       in ``featured`` is filled from per-(hour, dow) historical group
+       means. This is the existing behavior; it produces a usable
+       feature frame even when no weather forecast is available.
+    2. **Weather-forecast overlay (when ``weather_df`` is provided)** —
+       for future timestamps covered by ``weather_df`` (typically the
+       next ~16 days from Open-Meteo), raw weather columns are
+       overwritten with actual forecast values and derived weather
+       features are recomputed. Hours beyond the forecast horizon keep
+       their climatology values.
+
+    Args:
+        featured: Engineered historical DataFrame (post-merge,
+            post-feature-engineering). Drives the climatology baseline
+            and provides historical temperature for the rolling
+            ``temperature_deviation`` window.
+        horizon: Number of future hours to build.
+        weather_df: Optional raw weather DataFrame (from
+            ``data.weather_client.fetch_weather``) covering both the
+            historical and forecast periods. Only the forecast portion
+            (timestamps after ``featured.timestamp.max()``) is used. When
+            ``None``, the function falls back to the pre-PR-C
+            climatology-only behavior.
+
+    Note on autoregressive features: ``demand_lag_*``, ``ramp_rate``,
+    and ``demand_roll_*`` are still filled from climatology in this PR.
+    PR-E will replace them with recursive computation from the model's
+    own prior predictions, mirroring what the training holdout does.
     """
     last_ts = featured["timestamp"].max()
     future_timestamps = pd.date_range(
@@ -426,6 +577,11 @@ def _build_future_feature_frame(featured: pd.DataFrame, horizon: int) -> pd.Data
     for col in feature_cols:
         if col not in future_df.columns:
             future_df[col] = 0
+
+    # Overlay actual Open-Meteo forecast where available. For hours
+    # beyond the forecast horizon (~day 16+), climatology stays.
+    if weather_df is not None and not weather_df.empty:
+        future_df = _overlay_weather_forecast(future_df, featured, weather_df, horizon)
 
     return future_df
 
@@ -527,7 +683,12 @@ def predict_and_write_forecast(
 
     try:
         featured = data.featured_df
-        future_df = _build_future_feature_frame(featured, FORECAST_HORIZON_HOURS)
+        # Pass the raw weather DataFrame so the future-feature builder can
+        # overlay actual Open-Meteo forecast values (next ~16 days) onto
+        # the climatology baseline. See ``_overlay_weather_forecast``.
+        future_df = _build_future_feature_frame(
+            featured, FORECAST_HORIZON_HOURS, weather_df=data.weather_df
+        )
         future_ts = future_df["timestamp"]
 
         # Run every model defensively — a single per-model failure can't

--- a/tests/unit/test_phases_forecast.py
+++ b/tests/unit/test_phases_forecast.py
@@ -68,7 +68,11 @@ def _patch_predict_one(monkeypatch, predictions_by_name):
     monkeypatch.setattr(
         phases,
         "_build_future_feature_frame",
-        lambda featured, horizon: pd.DataFrame(
+        # PR-C (2026-05-20): function gained ``weather_df`` kwarg. Lambda
+        # accepts and ignores it — tests here exercise ``predict_and_write_forecast``
+        # ensemble logic, not the future-frame builder itself (which has
+        # its own dedicated test class below).
+        lambda featured, horizon, weather_df=None: pd.DataFrame(
             {"timestamp": pd.date_range("2024-02-01", periods=horizon, freq="h", tz="UTC")}
         ),
     )
@@ -192,3 +196,246 @@ class TestPredictAndWriteForecast:
         assert "ensemble" not in row0
         assert row0["xgboost"] == 41_000.0
         assert row0["predicted_demand_mw"] == 41_000.0
+
+
+# ────────────────────────────────────────────────────────────────────────
+# PR-C (2026-05-20) — Open-Meteo forecast overlay on future feature frame
+# ────────────────────────────────────────────────────────────────────────
+
+
+def _build_featured_hist(n_hours: int = 168 * 2, last_ts: str = "2026-05-20 14:00") -> pd.DataFrame:
+    """Build a synthetic engineered-historical DataFrame ending at ``last_ts``.
+
+    Includes raw weather columns + derived features so it looks like
+    real output from ``engineer_features``. Used to exercise the
+    climatology baseline + weather overlay path.
+    """
+    end = pd.Timestamp(last_ts, tz="UTC")
+    ts = pd.date_range(end=end, periods=n_hours, freq="h")
+    hours = np.arange(n_hours)
+    return pd.DataFrame(
+        {
+            "timestamp": ts,
+            "demand_mw": 20_000 + 5_000 * np.sin(2 * np.pi * hours / 24),
+            "temperature_2m": 70.0 + 15.0 * np.sin(2 * np.pi * hours / 24),
+            "apparent_temperature": 72.0 + 15.0 * np.sin(2 * np.pi * hours / 24),
+            "wind_speed_80m": 12.0 + 3.0 * np.sin(2 * np.pi * hours / 12),
+            "shortwave_radiation": np.maximum(0, 600 * np.sin(2 * np.pi * hours / 24)),
+            "cloud_cover": 30.0 + 20.0 * np.cos(2 * np.pi * hours / 24),
+            "cooling_degree_days": np.maximum(0, 70.0 + 15.0 * np.sin(2 * np.pi * hours / 24) - 65),
+            "heating_degree_days": np.maximum(
+                0, 65 - (70.0 + 15.0 * np.sin(2 * np.pi * hours / 24))
+            ),
+            "temperature_deviation": np.zeros(n_hours),
+            "wind_power_estimate": 0.4 + 0.1 * np.sin(2 * np.pi * hours / 12),
+            "solar_capacity_factor": np.maximum(0, 0.6 * np.sin(2 * np.pi * hours / 24)),
+            "demand_lag_24h": 20_000 + 5_000 * np.sin(2 * np.pi * (hours - 24) / 24),
+        }
+    )
+
+
+def _build_weather_forecast(
+    start_ts: str = "2026-05-20 15:00",
+    n_hours: int = 168,
+    temperature: float = 95.0,  # deliberately HOT, distinct from historical baseline
+) -> pd.DataFrame:
+    """Build a synthetic weather forecast DataFrame for the first ``n_hours``
+    after ``start_ts``. Constant temperature so test assertions are easy.
+    """
+    start = pd.Timestamp(start_ts, tz="UTC")
+    ts = pd.date_range(start=start, periods=n_hours, freq="h")
+    return pd.DataFrame(
+        {
+            "timestamp": ts,
+            "temperature_2m": np.full(n_hours, temperature),
+            "apparent_temperature": np.full(n_hours, temperature + 2),
+            "wind_speed_80m": np.full(n_hours, 18.0),
+            "shortwave_radiation": np.full(n_hours, 750.0),
+            "cloud_cover": np.full(n_hours, 5.0),  # clear sky
+        }
+    )
+
+
+class TestBuildFutureFeatureFrameNoOverlay:
+    """PR-C invariants: without weather_df, behavior matches pre-PR-C climatology."""
+
+    def test_no_weather_df_falls_back_to_climatology(self):
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist()
+        future_df = _build_future_feature_frame(featured, horizon=24)
+
+        # All future temperatures should come from (hour, dow) group means.
+        # Historical mean temperature is ~70°F (the baseline of our synthetic
+        # signal), so future temperatures cluster near 70°F.
+        assert future_df["temperature_2m"].between(50.0, 90.0).all()
+        # NOT the test forecast value (95) — that's only present when
+        # weather_df is passed.
+        assert (future_df["temperature_2m"] == pytest.approx(95.0, abs=1e-3)).sum() == 0
+
+
+class TestOverlayWeatherForecast:
+    """PR-C — actual forecast overlay onto climatology baseline."""
+
+    def test_overlay_within_horizon_uses_forecast_values(self):
+        """For future hours covered by weather_df, raw weather columns
+        must match the forecast values, NOT climatology."""
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist()
+        weather_df = _build_weather_forecast(n_hours=168, temperature=95.0)
+        future_df = _build_future_feature_frame(featured, horizon=168, weather_df=weather_df)
+
+        # Every hour of the 168-hour horizon is covered by weather_df.
+        # Use np.allclose for series-wide approx comparisons —
+        # ``Series == pytest.approx(scalar)`` doesn't broadcast as expected.
+        assert np.allclose(future_df["temperature_2m"].values, 95.0)
+        assert np.allclose(future_df["wind_speed_80m"].values, 18.0)
+        assert np.allclose(future_df["shortwave_radiation"].values, 750.0)
+
+    def test_overlay_recomputes_derived_features(self):
+        """When raw weather is overlaid with forecast, derived features
+        (CDD/HDD/wind_power/solar_cf/temp_x_hour) must be recomputed
+        from the FORECAST values — not left at climatological values."""
+        from data.feature_engineering import (
+            compute_cdd,
+            compute_hdd,
+            compute_solar_capacity_factor,
+            compute_wind_power,
+        )
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist()
+        # Forecast temp 95°F → CDD = 30, HDD = 0
+        weather_df = _build_weather_forecast(n_hours=168, temperature=95.0)
+        future_df = _build_future_feature_frame(featured, horizon=168, weather_df=weather_df)
+
+        expected_cdd = float(compute_cdd(pd.Series([95.0])).iloc[0])
+        expected_hdd = float(compute_hdd(pd.Series([95.0])).iloc[0])
+        expected_wind = float(compute_wind_power(pd.Series([18.0])).iloc[0])
+        expected_solar = float(compute_solar_capacity_factor(pd.Series([750.0])).iloc[0])
+
+        assert future_df["cooling_degree_days"].iloc[0] == pytest.approx(expected_cdd, abs=1e-6)
+        assert future_df["heating_degree_days"].iloc[0] == pytest.approx(expected_hdd, abs=1e-6)
+        assert future_df["wind_power_estimate"].iloc[0] == pytest.approx(expected_wind, abs=1e-6)
+        assert future_df["solar_capacity_factor"].iloc[0] == pytest.approx(expected_solar, abs=1e-6)
+
+    def test_overlay_partial_coverage_falls_back_to_climatology_beyond(self):
+        """If weather_df covers only the first 168 of 720 hours, the
+        remaining 552 hours must use climatological values (not zero,
+        not NaN, not the last forecast value)."""
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist()
+        # Forecast covers only 168 of 720 horizon hours
+        weather_df = _build_weather_forecast(n_hours=168, temperature=95.0)
+        future_df = _build_future_feature_frame(featured, horizon=720, weather_df=weather_df)
+
+        # First 168 hours: actual forecast
+        assert np.allclose(future_df["temperature_2m"].iloc[:168].values, 95.0)
+
+        # Beyond hour 168: climatology, which should be near the
+        # historical 70°F baseline of our synthetic series. Should NOT
+        # be 95°F (the forecast value) or 0 (a NaN-fill mistake).
+        beyond_temp = future_df["temperature_2m"].iloc[168:]
+        assert beyond_temp.between(50.0, 90.0).all()
+        # No more than a trivial number of climatology rows happen to
+        # equal 95 by coincidence — strict zero on a synthetic series.
+        assert int(np.isclose(beyond_temp.values, 95.0, atol=1e-3).sum()) == 0
+
+    def test_overlay_with_no_overlap_keeps_climatology(self):
+        """When weather_df timestamps don't overlap the future horizon
+        at all (e.g., stale weather cache), behavior reverts to climatology."""
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist()
+        # Weather forecast starts AFTER our 24-hour horizon ends
+        wx_start = pd.Timestamp("2026-06-20 00:00", tz="UTC")
+        weather_df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range(start=wx_start, periods=168, freq="h"),
+                "temperature_2m": np.full(168, 95.0),
+            }
+        )
+        future_df = _build_future_feature_frame(featured, horizon=24, weather_df=weather_df)
+
+        # No row in the 24-hour horizon overlaps weather_df → climatology
+        # 95°F should not appear anywhere.
+        assert int(np.isclose(future_df["temperature_2m"].values, 95.0, atol=1e-3).sum()) == 0
+        # And climatology should produce reasonable temperatures
+        assert future_df["temperature_2m"].between(50.0, 90.0).all()
+
+    def test_overlay_preserves_time_features(self):
+        """The overlay must not corrupt time features (hour_sin, dow_sin,
+        is_weekend) that are computed from future timestamps."""
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist()
+        weather_df = _build_weather_forecast(n_hours=168, temperature=95.0)
+        future_df = _build_future_feature_frame(featured, horizon=168, weather_df=weather_df)
+
+        # hour_sin should range over [-1, 1] across a 24-hour window
+        first_24 = future_df["hour_sin"].iloc[:24]
+        assert first_24.min() < 0 and first_24.max() > 0
+        # is_weekend should be 0 or 1
+        assert future_df["is_weekend"].isin([0, 1]).all()
+
+    def test_overlay_temperature_deviation_uses_historical_context(self):
+        """temperature_deviation = current_temp - 720h rolling mean. The
+        rolling window must include historical context, otherwise
+        deviation collapses to ~0 for future rows when the forecast is
+        constant."""
+        from jobs.phases import _build_future_feature_frame
+
+        # Historical baseline ~70°F, forecast is constant 95°F.
+        # If rolling context is included: deviation ≈ 95 - 70 = 25°F.
+        # If rolling computed over future rows alone (forecast constant):
+        # deviation ≈ 95 - 95 = 0°F.
+        featured = _build_featured_hist(n_hours=720 * 2)  # 2 months of history
+        weather_df = _build_weather_forecast(n_hours=168, temperature=95.0)
+        future_df = _build_future_feature_frame(featured, horizon=168, weather_df=weather_df)
+
+        # Deviation should be substantially > 0 — the forecast is much
+        # hotter than the historical rolling 30-day mean.
+        deviation_at_hour_24 = float(future_df["temperature_deviation"].iloc[24])
+        assert deviation_at_hour_24 > 5.0, (
+            f"temperature_deviation collapsed to {deviation_at_hour_24} — "
+            "rolling window probably not including historical context"
+        )
+
+    def test_overlay_missing_columns_silently_skipped(self):
+        """If weather_df is missing some raw columns (e.g., older Open-Meteo
+        format), the overlay should only touch the columns it has and
+        leave the rest at their climatology values."""
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist()
+        # Only provide temperature; other raw columns absent from forecast
+        weather_df = pd.DataFrame(
+            {
+                "timestamp": pd.date_range(
+                    start="2026-05-20 15:00", periods=168, freq="h", tz="UTC"
+                ),
+                "temperature_2m": np.full(168, 95.0),
+            }
+        )
+        future_df = _build_future_feature_frame(featured, horizon=168, weather_df=weather_df)
+
+        # Temperature got forecast values
+        assert np.allclose(future_df["temperature_2m"].values, 95.0)
+        # wind_speed_80m stayed at climatology (not 0, not NaN)
+        assert future_df["wind_speed_80m"].notna().all()
+        assert (future_df["wind_speed_80m"] == 0).sum() < len(future_df)
+
+    def test_overlay_with_empty_weather_df_no_op(self):
+        """An empty weather_df should produce identical output to the
+        no-weather_df case (climatology baseline)."""
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist()
+        empty_wx = pd.DataFrame(columns=["timestamp", "temperature_2m"])
+
+        future_with_empty = _build_future_feature_frame(featured, horizon=24, weather_df=empty_wx)
+        future_no_wx = _build_future_feature_frame(featured, horizon=24)
+
+        pd.testing.assert_frame_equal(future_with_empty, future_no_wx)


### PR DESCRIPTION
## Summary

Production scoring job was serving the demand-forecast model climatological weather (per-(hour, dow) historical group means) instead of actual Open-Meteo forecast values — even though ``fetch_weather`` already returns 7-16 days of forecast in the same call as the 92-day history. The forecast data was being dropped at the ``merge_demand_weather`` step.

This PR plumbs actual weather forecast values through to the future feature frame for the hours Open-Meteo covers, falling back to climatology only beyond the forecast horizon.

This is PR-C of the forecast-pipeline audit. Independent of (and complementary to) PR-D which de-leaks training features. PR-E (recursive autoregressive features) will follow.

## Why this matters

The user's original concern: *"those MAPE #s look too clean... temperature predictions can't be having a significant impact we can't see on the forecast right?"*

They were right. The Weather Correlation tab showed that a 10°F temperature shift would change demand by N MW based on historical patterns, but the demand forecast itself ignored that signal — every future hour got the climatological "typical Wednesday 2pm" temperature regardless of whether Open-Meteo predicted a heatwave or a cold snap.

After this PR: real weather forecast for the first ~16 days of the 30-day demand-forecast horizon → temperature anomalies actually move the demand curve.

## Three changes

### 1. ``forecast_days=7`` → ``forecast_days=16`` in ``fetch_weather``

Open-Meteo's free GFS-based ``/forecast`` endpoint supports up to 16 days of forecast. Bumping from the previous 7-day default gives us 384 hourly rows of real forecast covering ~53% of the 720-hour demand horizon (versus 23% pre-fix). Beyond day 16 we still use climatology — that's a different problem (multi-model ensembling of long-range weather) and out of scope here.

### 2. New ``_overlay_weather_forecast`` helper

Given the climatology-built ``future_df``, walks each future timestamp and replaces raw weather columns with Open-Meteo forecast values where the timestamp is covered. Logs coverage (``forecast_covered_hours`` / ``climatology_fallback_hours``) for observability. Hours beyond Open-Meteo's horizon keep their climatology values untouched.

### 3. Derived weather features recomputed from forecasted values

After overlaying raw columns, the derived features are re-derived:

| Feature | Source | Computation |
|---|---|---|
| ``cooling_degree_days`` | forecasted ``temperature_2m`` | ``compute_cdd`` |
| ``heating_degree_days`` | forecasted ``temperature_2m`` | ``compute_hdd`` |
| ``wind_power_estimate`` | forecasted ``wind_speed_80m`` | ``compute_wind_power`` |
| ``solar_capacity_factor`` | forecasted ``shortwave_radiation`` | ``compute_solar_capacity_factor`` |
| ``temp_x_hour`` | forecasted ``temperature_2m`` × time-feature ``hour_sin`` | ``compute_temp_hour_interaction`` |
| ``temperature_deviation`` | hist + forecast temperature concatenated, 720h rolling mean, ``.tail(horizon)`` | (see note) |

**Note on ``temperature_deviation``:** this is a 720-hour rolling deviation. If you compute it over the forecast window alone, it collapses to ~0 when the forecast is roughly constant. The fix concatenates the historical temperature series with the future temperature series, computes the rolling mean over the union, and takes the tail. A dedicated test (``test_overlay_temperature_deviation_uses_historical_context``) guards this — it builds a series with hist mean ~70°F and forecast constant 95°F and asserts deviation > 5°F at the future rows.

## Backward compatibility

- ``_build_future_feature_frame`` keeps its 2-positional-arg signature. The new ``weather_df`` parameter is a kwarg defaulting to ``None``; when omitted, behavior is bit-identical to the pre-PR climatology-only path.
- Existing ``test_phases_forecast`` monkeypatch lambda was updated to accept (and ignore) the new kwarg.

## What this does NOT change

- **Prophet's prediction path** still uses ``predict_prophet(model, featured, periods=horizon)`` which forward-fills weather regressors from the last historical row. Prophet's contribution to the ensemble is ~5-7% per BACKTEST_RESULTS.md, so the impact is small. Can be addressed in a follow-up — would require deciding whether Prophet should consume forecast weather inline or whether a hybrid (forecast for some regressors, ffill for others) makes more sense.
- **Autoregressive demand features** (``demand_lag_*``, ``ramp_rate``, ``demand_roll_*``) still use climatology. That's PR-E.

## Test plan

- [x] 9 new unit tests covering:
  - No-weather_df → behaves like pre-PR climatology
  - Full coverage → raw weather columns match forecast values exactly
  - Derived features recomputed from forecast values (CDD/HDD/wind/solar)
  - Partial coverage (first 168 of 720 hours) → first 168 forecast, hours 168-720 climatology
  - No-overlap (stale weather cache scenario) → climatology preserved
  - Time features (hour_sin, dow_sin, is_weekend) not corrupted
  - ``temperature_deviation`` uses hist+future rolling context, not collapsed
  - Partial Open-Meteo response (missing columns) → only present columns overlaid
  - Empty weather_df → identical to no-weather_df case
- [x] Full unit suite: **1699 passed** (1690 baseline + 9 new) in 437s
- [x] Lint + format clean
- [ ] **Manual verification after merge:** check scoring-job logs for ``future_frame_weather_forecast_coverage`` events — should show ``forecast_covered_hours=384`` for most regions
- [ ] **Manual UI verification after merge:** in production, change region with extreme weather forecast (heat advisory in TX, winter storm in NE) — demand forecast curve should reflect the temperature anomaly

## Files changed

| File | Change |
|---|---|
| ``data/weather_client.py`` | Bump ``forecast_days`` default from 7 to 16 |
| ``jobs/phases.py`` | New ``_overlay_weather_forecast`` helper; ``_build_future_feature_frame`` accepts ``weather_df`` kwarg; ``predict_and_write_forecast`` passes ``data.weather_df`` |
| ``tests/unit/test_phases_forecast.py`` | New ``TestBuildFutureFeatureFrameNoOverlay`` and ``TestOverlayWeatherForecast`` classes (9 tests) + monkeypatch lambda updated for new kwarg |

## Relation to other PRs from the audit

- **PR-D** (https://github.com/kristenmartino/gridpulse/pull/135, training-feature leakage): mechanically independent — touches ``data/feature_engineering.py``, no conflict with this PR. Best landed first because the training-side honesty improves model quality which then compounds with the inference-side honesty here.
- **PR-E** (next, recursive autoregressive features): will touch ``_build_future_feature_frame`` again to remove the climatology fallback for ``demand_lag_*`` / ``ramp_rate`` / ``demand_roll_*``. After PR-E, the only climatology in the function will be for the weather hours beyond Open-Meteo's 16-day horizon.
- **PR-B** (empirical CI on Overview chart): unrelated, polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)