### PR TITLE
fix(forecast): recursive autoregressive features in production inference (PR-E)

### DIFF
--- a/jobs/phases.py
+++ b/jobs/phases.py
@@ -51,6 +51,20 @@ DEFAULT_BACKTEST_EXOG_MODE = "forecast_exog"
 BACKTEST_HORIZONS = (24, 168, 720)
 FORECAST_HORIZON_HOURS = 720
 
+# PR-E (2026-05-20) — depth of recursive autoregressive-feature inference.
+# For future hours 1..RECURSIVE_AUTOREGRESSIVE_HOURS, the XGBoost predict
+# loop computes ``demand_lag_*`` / ``ramp_rate`` / ``demand_roll_*`` from
+# recent actuals + prior predictions (chained), matching the inference
+# behavior validated by the training holdout. Past this depth the
+# autoregressive features fall back to the climatology baseline built
+# by ``_build_future_feature_frame``. The boundary aligns with
+# ``config.OPEN_METEO_FORECAST_HOURS`` (384) so the "real signal"
+# regime ends at the same day-16 mark for both weather and
+# autoregressive features — see ADR-008 in PRD.md.
+from config import OPEN_METEO_FORECAST_HOURS as _OM_HOURS  # noqa: E402
+
+RECURSIVE_AUTOREGRESSIVE_HOURS = _OM_HOURS
+
 _EIA_FUEL_MAP = {
     "SUN": "solar",
     "WND": "wind",
@@ -529,10 +543,13 @@ def _build_future_feature_frame(
             ``None``, the function falls back to the pre-PR-C
             climatology-only behavior.
 
-    Note on autoregressive features: ``demand_lag_*``, ``ramp_rate``,
-    and ``demand_roll_*`` are still filled from climatology in this PR.
-    PR-E will replace them with recursive computation from the model's
-    own prior predictions, mirroring what the training holdout does.
+    Note on autoregressive features: the climatology values placed here
+    by this function are used **only as the long-horizon fallback** —
+    XGBoost prediction overrides them per-row for the first
+    ``RECURSIVE_AUTOREGRESSIVE_HOURS`` (384) via
+    ``_predict_xgboost_with_recursive_autoregressive`` (PR-E). Beyond
+    that hour the climatology values produced here are what the model
+    actually sees. ARIMA and Prophet don't use these columns.
     """
     last_ts = featured["timestamp"].max()
     future_timestamps = pd.date_range(
@@ -586,6 +603,65 @@ def _build_future_feature_frame(
     return future_df
 
 
+def _predict_xgboost_with_recursive_autoregressive(
+    model: Any,
+    featured: pd.DataFrame,
+    future_df: pd.DataFrame,
+    horizon: int,
+    recursive_hours: int = RECURSIVE_AUTOREGRESSIVE_HOURS,
+) -> np.ndarray:
+    """XGBoost prediction with recursive autoregressive features for hours 1..N.
+
+    For the first ``recursive_hours`` of the forecast (default 384, aligned
+    with Open-Meteo's forecast horizon per ADR-008), the autoregressive
+    features ``demand_lag_*`` / ``ramp_rate`` / ``demand_roll_*`` are
+    computed via ``compute_autoregressive_snapshot`` from a growing
+    demand history — initial seed is recent actuals from ``featured``,
+    each predicted hour appends its prediction. This matches the
+    inference behavior validated by the training holdout in
+    ``training.py:113-122``.
+
+    Past hour ``recursive_hours``, the climatology-shaped autoregressive
+    features already present in ``future_df`` (built by
+    ``_build_future_feature_frame``) are used as-is. The vectorized
+    XGBoost predict over the tail of ``future_df`` produces the
+    long-horizon predictions in one call.
+
+    Returns a 1D array of length ``horizon`` (or shorter if the model
+    predicts fewer rows due to a column mismatch).
+    """
+    from data.feature_engineering import compute_autoregressive_snapshot
+    from models.xgboost_model import predict_xgboost
+
+    n_recursive = min(recursive_hours, horizon)
+
+    # Recursive zone: chain predictions hour by hour, seeded from recent
+    # actuals. Each iteration: build the feature row from the growing
+    # history, predict, append the prediction to history.
+    demand_history = featured["demand_mw"].tolist()
+    recursive_preds: list[float] = []
+    for i in range(n_recursive):
+        row = future_df.iloc[[i]].copy()
+        for col, val in compute_autoregressive_snapshot(demand_history).items():
+            if col in row.columns:
+                row[col] = val
+        row = row.ffill().bfill().fillna(0)
+        pred = float(predict_xgboost(model, row)[0])
+        recursive_preds.append(pred)
+        demand_history.append(pred)
+
+    if horizon <= n_recursive:
+        return np.asarray(recursive_preds, dtype=float)
+
+    # Climatology zone (hours N+1 to horizon): vectorized predict on the
+    # tail of future_df, which already has climatology-shaped autoregressive
+    # features from ``_build_future_feature_frame``. Weather features here
+    # are also climatology (per ADR-008), so both signals degrade together.
+    clim_df = future_df.iloc[n_recursive:horizon].copy()
+    clim_preds = np.asarray(predict_xgboost(model, clim_df), dtype=float)
+    return np.concatenate([np.asarray(recursive_preds, dtype=float), clim_preds])
+
+
 def _predict_one(
     model_name: str,
     model: Any,
@@ -595,8 +671,11 @@ def _predict_one(
 ) -> np.ndarray | None:
     """Dispatch a single model to its predict function and return point forecasts.
 
-    XGBoost takes the engineered future-feature frame directly. Prophet builds
-    its own future frame internally from the training data + a periods arg —
+    XGBoost runs through ``_predict_xgboost_with_recursive_autoregressive``
+    (PR-E, 2026-05-20) which uses recursive autoregressive features for
+    the first ``RECURSIVE_AUTOREGRESSIVE_HOURS`` (384) hours of the
+    horizon, falling back to climatology beyond. Prophet builds its
+    own future frame internally from the training data + a periods arg —
     so we hand it the training ``featured`` DataFrame instead.
 
     Returns ``None`` on a per-model failure so the caller can degrade gracefully
@@ -604,9 +683,9 @@ def _predict_one(
     """
     try:
         if model_name == "xgboost":
-            from models.xgboost_model import predict_xgboost
-
-            return np.asarray(predict_xgboost(model, future_df), dtype=float)
+            return _predict_xgboost_with_recursive_autoregressive(
+                model, featured, future_df, horizon
+            )
         if model_name == "prophet":
             from models.prophet_model import predict_prophet
 

--- a/scripts/audit/extended_holdout_check.py
+++ b/scripts/audit/extended_holdout_check.py
@@ -1,0 +1,209 @@
+"""Extended holdout MAPE check — does recursive prediction degrade past hour 168?
+
+The training holdout in ``training.py`` uses ``validation_hours=168`` (one
+week), so empirically we only have MAPE numbers for recursive-feature
+inference within that window. PR-E proposes extending the recursive
+zone to 384 hours (16 days, aligned with Open-Meteo's forecast horizon).
+Before shipping, we want to confirm the holdout MAPE for hours 169-384
+isn't materially worse than for hours 1-168.
+
+Procedure:
+
+1. Fetch EIA demand + Open-Meteo weather for the supplied region.
+2. Run engineer_features → take the last 384 rows as the val window.
+3. Train XGBoost on the prior rows (post-PR-D feature definitions, so
+   no leakage).
+4. Run recursive prediction for all 384 val hours using
+   ``compute_autoregressive_snapshot`` — exactly what PR-E would do.
+5. Compute per-window MAPE: 0-24, 25-72, 73-168, 169-384.
+6. Report whether 169-384 is materially worse than 1-168.
+
+Decision criterion: if MAPE(169-384) / MAPE(1-168) < 1.5, ship PR-E with
+the 384h cap. If the ratio is higher, fall back to the 168h cap.
+
+Run with::
+
+    PYTHONPATH=. .venv/bin/python scripts/audit/extended_holdout_check.py FPL
+    PYTHONPATH=. .venv/bin/python scripts/audit/extended_holdout_check.py ERCOT PJM CAISO
+
+A single region typically takes ~5-10 minutes (XGBoost CV + recursive
+prediction loop).
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+import numpy as np
+
+# Load environment variables from .env BEFORE importing config
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
+
+from data.eia_client import fetch_demand  # noqa: E402
+from data.feature_engineering import (  # noqa: E402
+    compute_autoregressive_snapshot,
+    engineer_features,
+)
+from data.preprocessing import merge_demand_weather  # noqa: E402
+from data.weather_client import fetch_weather  # noqa: E402
+from models.xgboost_model import predict_xgboost, train_xgboost  # noqa: E402
+
+VAL_HOURS = 384  # 16 days = aligned with Open-Meteo forecast horizon
+WINDOWS = [(0, 24), (24, 72), (72, 168), (168, 384)]
+
+
+def run_one(region: str) -> dict | None:
+    """Train + recursive holdout for one region. Returns per-window MAPE."""
+    print(f"\n{'=' * 72}")
+    print(f"  Extended holdout check — {region}")
+    print(f"{'=' * 72}")
+
+    t0 = time.time()
+    print(f"  Fetching EIA demand for {region}…")
+    demand_df = fetch_demand(region)
+    if demand_df is None or demand_df.empty:
+        print(f"  ✗ No demand data for {region}")
+        return None
+
+    print(f"  Fetching weather for {region}…")
+    weather_df = fetch_weather(region)
+    if weather_df is None or weather_df.empty:
+        print(f"  ✗ No weather data for {region}")
+        return None
+
+    print("  Merging + engineering features…")
+    merged = merge_demand_weather(demand_df, weather_df)
+    featured = engineer_features(merged).dropna(subset=["demand_mw"]).reset_index(drop=True)
+    if len(featured) < VAL_HOURS + 720:  # Need ~30 days train minimum
+        print(f"  ✗ Insufficient rows ({len(featured)}); need {VAL_HOURS + 720}+")
+        return None
+
+    print(f"  Total feature-engineered rows: {len(featured)}")
+    train_df = featured.iloc[:-VAL_HOURS].reset_index(drop=True)
+    val_df = featured.iloc[-VAL_HOURS:].reset_index(drop=True)
+    print(f"  Train: {len(train_df)} rows · Val: {len(val_df)} rows ({VAL_HOURS}h)")
+
+    print("  Training XGBoost (n_splits=3 for speed)…")
+    t_train = time.time()
+    xgb_result = train_xgboost(train_df, n_splits=3)
+    print(f"  ✓ Trained in {time.time() - t_train:.1f}s")
+
+    print(f"  Running recursive prediction for {VAL_HOURS} hours…")
+    t_pred = time.time()
+    demand_history = train_df["demand_mw"].tolist()
+    y_val = val_df["demand_mw"].values
+    preds = []
+    for i in range(len(val_df)):
+        row = val_df.iloc[[i]].copy()
+        for col, val in compute_autoregressive_snapshot(demand_history).items():
+            row[col] = val
+        row = row.ffill().bfill().fillna(0)
+        pred = float(predict_xgboost(xgb_result, row)[0])
+        preds.append(pred)
+        demand_history.append(pred)
+    preds = np.array(preds, dtype=float)
+    print(f"  ✓ Predicted {len(preds)} rows in {time.time() - t_pred:.1f}s")
+
+    # Per-window MAPE
+    results = {"region": region, "windows": {}}
+    print()
+    print("  Per-window holdout MAPE (recursive prediction, post-PR-D features):")
+    for lo, hi in WINDOWS:
+        if hi > len(preds):
+            continue
+        y_slice = y_val[lo:hi]
+        p_slice = preds[lo:hi]
+        mask = np.abs(y_slice) > 1e-6
+        if not mask.any():
+            continue
+        mape = float(np.mean(np.abs((y_slice[mask] - p_slice[mask]) / y_slice[mask])) * 100)
+        results["windows"][f"{lo}-{hi}h"] = mape
+        print(f"    hours {lo:3d}-{hi:3d}: MAPE = {mape:6.2f}%")
+
+    # Decision: ratio of 168-384 vs 72-168
+    mape_long = results["windows"].get("168-384h", 0)
+    mape_full_short = results["windows"].get("72-168h", 0)
+    if mape_full_short > 0 and mape_long > 0:
+        ratio = mape_long / mape_full_short
+        print()
+        print(f"  Ratio MAPE(168-384h) / MAPE(72-168h) = {ratio:.2f}")
+        if ratio < 1.5:
+            print("  ✓ DECISION: ship PR-E with 384h cap (168-384 degradation < 1.5×)")
+        elif ratio < 2.0:
+            print("  ⚠ DECISION: borderline — consider 168h cap for safety")
+        else:
+            print(
+                f"  ✗ DECISION: fall back to 168h cap "
+                f"(168-384 degradation {ratio:.2f}× is too high)"
+            )
+        results["ratio_168_384_vs_72_168"] = ratio
+
+    print(f"  Total time: {time.time() - t0:.1f}s")
+    return results
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("Usage: extended_holdout_check.py REGION [REGION ...]")
+        return 1
+
+    all_results = []
+    for region in argv:
+        try:
+            r = run_one(region)
+            if r:
+                all_results.append(r)
+        except Exception as e:
+            print(f"  ✗ Failed for {region}: {e}")
+            import traceback
+
+            traceback.print_exc()
+
+    if not all_results:
+        print("\nNo successful runs.")
+        return 1
+
+    print(f"\n{'=' * 72}")
+    print("  SUMMARY")
+    print(f"{'=' * 72}")
+    print(
+        f"  {'Region':10s} {'0-24h':>10s} {'25-72h':>10s} {'73-168h':>10s} {'169-384h':>10s} {'ratio':>8s}"
+    )
+    for r in all_results:
+        w = r.get("windows", {})
+        ratio = r.get("ratio_168_384_vs_72_168", 0)
+        # Keys are formatted as ``"{lo}-{hi}h"`` per ``WINDOWS``;
+        # lookups must include the ``h`` suffix.
+        print(
+            f"  {r['region']:10s}"
+            f" {w.get('0-24h', 0):>9.2f}%"
+            f" {w.get('24-72h', 0):>9.2f}%"
+            f" {w.get('72-168h', 0):>9.2f}%"
+            f" {w.get('168-384h', 0):>9.2f}%"
+            f" {ratio:>7.2f}x"
+        )
+
+    # Overall recommendation
+    ratios = [r.get("ratio_168_384_vs_72_168", 0) for r in all_results]
+    ratios = [r for r in ratios if r > 0]
+    if ratios:
+        max_ratio = max(ratios)
+        print()
+        if max_ratio < 1.5:
+            print(f"  ✓ OVERALL: SHIP PR-E with 384h cap (max ratio = {max_ratio:.2f}x)")
+        elif max_ratio < 2.0:
+            print(f"  ⚠ OVERALL: borderline — consider 168h cap (max ratio = {max_ratio:.2f}x)")
+        else:
+            print(f"  ✗ OVERALL: fall back to 168h cap (max ratio = {max_ratio:.2f}x)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/unit/test_phases_forecast.py
+++ b/tests/unit/test_phases_forecast.py
@@ -439,3 +439,192 @@ class TestOverlayWeatherForecast:
         future_no_wx = _build_future_feature_frame(featured, horizon=24)
 
         pd.testing.assert_frame_equal(future_with_empty, future_no_wx)
+
+
+# ────────────────────────────────────────────────────────────────────────
+# PR-E (2026-05-20) — XGBoost recursive autoregressive prediction
+# ────────────────────────────────────────────────────────────────────────
+
+
+class _FakeXgbModel:
+    """Minimal XGBoost-model stub for the recursive predict path.
+
+    Returns a prediction that's a deterministic function of
+    ``demand_lag_1h`` (the chained-prediction history's most recent
+    value). Lets the recursion be observed directly: pred[i] = f(pred[i-1]).
+    """
+
+    def __init__(self, feature_names: list[str], multiplier: float = 1.02):
+        self._feature_names = feature_names
+        self._mult = multiplier
+
+    def __getitem__(self, key):  # match dict-style access used by predict_xgboost
+        if key == "feature_names":
+            return self._feature_names
+        if key == "model":
+            return self
+        raise KeyError(key)
+
+
+def _fake_predict_xgboost(model_dict, df):
+    """Stand-in for ``predict_xgboost`` — returns ``demand_lag_1h * 1.02``.
+
+    Used by the recursive test path so we can verify the chaining works
+    (each step's input lag_1h equals the previous step's prediction).
+    """
+    lag_1h = df["demand_lag_1h"].fillna(20_000.0).astype(float).values
+    return lag_1h * 1.02
+
+
+class TestPredictXgboostRecursive:
+    """``_predict_xgboost_with_recursive_autoregressive`` runs a
+    chained per-hour predict loop for the recursive zone, then a
+    vectorized predict for the climatology tail. PR-E (#138).
+
+    These tests use a fake predict_xgboost that returns
+    ``demand_lag_1h * 1.02`` so we can observe chaining directly:
+    pred[i] = pred[i-1] * 1.02 once the chain starts.
+    """
+
+    @staticmethod
+    def _featured(n_hours: int = 200, last_demand: float = 20_000.0) -> pd.DataFrame:
+        ts = pd.date_range("2026-05-01", periods=n_hours, freq="h", tz="UTC")
+        return pd.DataFrame(
+            {
+                "timestamp": ts,
+                "demand_mw": np.full(n_hours, last_demand),
+            }
+        )
+
+    @staticmethod
+    def _future(n_hours: int) -> pd.DataFrame:
+        ts = pd.date_range("2026-05-20", periods=n_hours, freq="h", tz="UTC")
+        # Climatology-shaped autoregressive baseline that the helper
+        # will override row-by-row in the recursive zone.
+        return pd.DataFrame(
+            {
+                "timestamp": ts,
+                "hour": ts.hour,
+                "demand_lag_1h": np.full(n_hours, 30_000.0),  # baseline, will be overwritten
+                "demand_lag_3h": np.full(n_hours, 30_000.0),
+                "demand_lag_24h": np.full(n_hours, 30_000.0),
+                "demand_lag_168h": np.full(n_hours, 30_000.0),
+                "ramp_rate": np.zeros(n_hours),
+                "demand_roll_24h_mean": np.full(n_hours, 30_000.0),
+                "demand_roll_24h_std": np.full(n_hours, 100.0),
+                "demand_roll_24h_min": np.full(n_hours, 29_500.0),
+                "demand_roll_24h_max": np.full(n_hours, 30_500.0),
+                "demand_roll_72h_mean": np.full(n_hours, 30_000.0),
+                "demand_roll_72h_std": np.full(n_hours, 100.0),
+                "demand_roll_72h_min": np.full(n_hours, 29_500.0),
+                "demand_roll_72h_max": np.full(n_hours, 30_500.0),
+                "demand_roll_168h_mean": np.full(n_hours, 30_000.0),
+                "demand_roll_168h_std": np.full(n_hours, 100.0),
+                "demand_roll_168h_min": np.full(n_hours, 29_500.0),
+                "demand_roll_168h_max": np.full(n_hours, 30_500.0),
+                "demand_momentum_short": np.zeros(n_hours),
+                "demand_momentum_long": np.zeros(n_hours),
+                "demand_ratio_24h": np.ones(n_hours),
+                "demand_ratio_168h": np.ones(n_hours),
+            }
+        )
+
+    def test_recursive_zone_chains_from_recent_actuals(self, monkeypatch):
+        """First prediction uses the most recent actual (20,000 MW)
+        from ``featured`` — NOT the climatology baseline in future_df.
+        Each subsequent prediction uses the prior prediction. Verifies
+        the chain is seeded correctly."""
+        import jobs.phases as phases
+
+        monkeypatch.setattr("models.xgboost_model.predict_xgboost", _fake_predict_xgboost)
+
+        featured = self._featured(last_demand=20_000.0)
+        future_df = self._future(n_hours=5)
+        model = _FakeXgbModel(feature_names=list(future_df.columns))
+
+        preds = phases._predict_xgboost_with_recursive_autoregressive(
+            model, featured, future_df, horizon=5, recursive_hours=5
+        )
+
+        # Chain: 20000 → 20400 → 20808 → 21224 → 21649 (×1.02 each step)
+        # The first prediction reads lag_1h from history (20000 actuals),
+        # not 30000 (the climatology baseline).
+        expected = [20_000.0 * 1.02 ** (i + 1) for i in range(5)]
+        np.testing.assert_allclose(preds, expected, rtol=1e-6)
+
+    def test_recursive_then_climatology_horizon(self, monkeypatch):
+        """When horizon exceeds recursive_hours, first N predictions
+        chain from history, remaining predictions use the climatology-
+        shaped features in future_df (lag_1h=30000)."""
+        import jobs.phases as phases
+
+        monkeypatch.setattr("models.xgboost_model.predict_xgboost", _fake_predict_xgboost)
+
+        featured = self._featured(last_demand=20_000.0)
+        future_df = self._future(n_hours=10)
+        model = _FakeXgbModel(feature_names=list(future_df.columns))
+
+        preds = phases._predict_xgboost_with_recursive_autoregressive(
+            model, featured, future_df, horizon=10, recursive_hours=3
+        )
+
+        # First 3: recursive chain from 20000 ×1.02 each step
+        recursive_expected = [20_000.0 * 1.02 ** (i + 1) for i in range(3)]
+        np.testing.assert_allclose(preds[:3], recursive_expected, rtol=1e-6)
+
+        # Remaining 7: climatology predictions = 30000 × 1.02 = 30600 (all same)
+        clim_expected = [30_000.0 * 1.02] * 7
+        np.testing.assert_allclose(preds[3:], clim_expected, rtol=1e-6)
+
+    def test_recursive_hours_caps_at_horizon(self, monkeypatch):
+        """If recursive_hours > horizon, we just chain for ``horizon``
+        hours and skip the climatology tail."""
+        import jobs.phases as phases
+
+        monkeypatch.setattr("models.xgboost_model.predict_xgboost", _fake_predict_xgboost)
+
+        featured = self._featured()
+        future_df = self._future(n_hours=4)
+        model = _FakeXgbModel(feature_names=list(future_df.columns))
+
+        preds = phases._predict_xgboost_with_recursive_autoregressive(
+            model, featured, future_df, horizon=4, recursive_hours=384
+        )
+
+        assert len(preds) == 4
+        # All four are recursive
+        expected = [20_000.0 * 1.02 ** (i + 1) for i in range(4)]
+        np.testing.assert_allclose(preds, expected, rtol=1e-6)
+
+    def test_default_recursive_hours_matches_open_meteo_horizon(self):
+        """The default recursive depth (``RECURSIVE_AUTOREGRESSIVE_HOURS``)
+        must equal ``OPEN_METEO_FORECAST_HOURS`` so the two regimes —
+        "real signal" and "climatology baseline" — break at the same
+        day-16 boundary as ADR-008."""
+        from config import OPEN_METEO_FORECAST_HOURS
+        from jobs.phases import RECURSIVE_AUTOREGRESSIVE_HOURS
+
+        assert RECURSIVE_AUTOREGRESSIVE_HOURS == OPEN_METEO_FORECAST_HOURS
+        assert RECURSIVE_AUTOREGRESSIVE_HOURS == 384
+
+    def test_predict_one_xgboost_uses_recursive_path(self, monkeypatch):
+        """``_predict_one`` for XGBoost must dispatch through
+        ``_predict_xgboost_with_recursive_autoregressive`` so the
+        production scoring job picks up PR-E's behavior."""
+        import jobs.phases as phases
+
+        called: dict[str, bool] = {"recursive": False}
+
+        def _spy(model, featured, future_df, horizon, **kw):
+            called["recursive"] = True
+            return np.zeros(horizon, dtype=float)
+
+        monkeypatch.setattr(phases, "_predict_xgboost_with_recursive_autoregressive", _spy)
+
+        featured = self._featured()
+        future_df = self._future(n_hours=24)
+        model = _FakeXgbModel(feature_names=list(future_df.columns))
+
+        result = phases._predict_one("xgboost", model, featured, future_df, horizon=24)
+        assert result is not None
+        assert called["recursive"] is True


### PR DESCRIPTION
## Summary

Closes the train/serve gap for XGBoost's autoregressive features. The training holdout in `training.py:113-122` already computes `demand_lag_*` / `ramp_rate` / `demand_roll_*` recursively from real actuals + chained predictions — but production scoring was computing the same-named features from climatological (hour, dow) group means. Same name, different definition: a distribution shift between what the model was validated against and what it actually saw.

This is PR-E of the audit-driven punchlist. Mechanically straightforward + empirically validated before shipping.

## What changes

New `_predict_xgboost_with_recursive_autoregressive` helper in `jobs/phases.py`. For the first 384 hours of the forecast horizon, it runs a per-hour predict loop:

1. Take the climatology baseline from `future_df.iloc[[i]]`
2. Override the autoregressive features via `compute_autoregressive_snapshot(demand_history)` — same function the training holdout uses
3. Predict the single row
4. Append the prediction to `demand_history`

For hours 385-720, the climatology-shaped autoregressive features already in `future_df` are used as-is via a single vectorized predict.

## Cap choice — 384 hours (16 days)

Aligned with `config.OPEN_METEO_FORECAST_HOURS` so the "real signal" regime and "climatology baseline" regime break at the same point for both weather and autoregressive features. ADR-008 visualizes this boundary on the Forecast tab; PR-E makes it the actual model behavior.

| Hours | Days | Weather (PR-C) | Autoregressive (PR-E) |
|---|---|---|---|
| 1-168 | 1-7 | Real Open-Meteo | Recursive — operational sweet spot |
| 169-384 | 8-16 | Real Open-Meteo | Recursive — long-horizon real signal |
| 385-720 | 17-30 | Climatology | Climatology — labeled in UI per ADR-008 |

## Empirical validation

Ran `scripts/audit/extended_holdout_check.py FPL` (script also added in this PR). With post-PR-D feature definitions:

```
Per-window holdout MAPE (recursive prediction):
    hours   0- 24: MAPE = 4.78%
    hours  24- 72: MAPE = 8.21%   ← chained-error peak
    hours  72-168: MAPE = 6.78%
    hours 168-384: MAPE = 7.72%   ← only 1.14× the 72-168h zone
```

The day-17+ degradation is well within the 1.5× safety threshold I'd set before running. The recursive chain stabilizes after day 3 and stays roughly flat through day 16. Real weather forecast (PR-C) provides the anchoring that prevents long-horizon drift in this range.

Side observation worth flagging: XGBoost's top-5 features post-PR-D are `[demand_lag_24h, demand_lag_1h, demand_ratio_24h, demand_ratio_168h, demand_lag_168h]`. The previously-leaky `demand_roll_24h_min` (#2 feature pre-PR-D) is now out of the top 5 — confirming PR-D's training-side fix worked.

## Compute cost

168-384 single-row XGBoost predictions per region per scoring tick. ~1ms per predict × 384 × 51 regions ≈ 20 seconds added to the hourly scoring job. Well within the existing 5-minute budget.

## What this doesn't change

- **Prophet** still uses `predict_prophet(model, featured, periods=horizon)` — its own internal future-frame logic, no recursive feature loop needed
- **ARIMA** uses internal state for autoregression; exogenous variables are weather features which are already correct
- **Long-horizon vectorized predict** (hours 385-720) is unchanged

## Test plan

- [x] 5 new unit tests in `tests/unit/test_phases_forecast.py::TestPredictXgboostRecursive`:
  - `test_recursive_zone_chains_from_recent_actuals` — first prediction seeded from recent actual (not climatology baseline); each subsequent prediction reads its lag from the prior prediction
  - `test_recursive_then_climatology_horizon` — when horizon > recursive_hours, first N predictions chain, remainder use climatology features
  - `test_recursive_hours_caps_at_horizon` — no climatology tail when horizon < recursive_hours
  - `test_default_recursive_hours_matches_open_meteo_horizon` — pins the alignment with ADR-008's day-16 boundary
  - `test_predict_one_xgboost_uses_recursive_path` — verifies the `_predict_one` dispatch wiring
- [x] Full unit suite: **1714 passed** in 158s (1709 baseline + 5 new)
- [x] Lint + format clean
- [x] Extended holdout on FPL: ratio MAPE(168-384) / MAPE(72-168) = **1.14×** (well below 1.5× threshold)
- [ ] **Live drift check at +7 days post-deploy:** rolling 7d MAPE in `gridpulse:drift:{region}` should drop notably for ERCOT / FPL / PJM / CAISO / MISO (the weather-sensitive regions). If it doesn't drop or gets worse, that's a signal something's off and worth investigating before considering whether to remove the 168-384h recursion.

## Files changed

| File | Change |
|---|---|
| `jobs/phases.py` | New `RECURSIVE_AUTOREGRESSIVE_HOURS = 384` constant + `_predict_xgboost_with_recursive_autoregressive` helper + `_predict_one` dispatches XGBoost through it |
| `tests/unit/test_phases_forecast.py` | New `TestPredictXgboostRecursive` class (5 tests) |
| `scripts/audit/extended_holdout_check.py` (NEW) | Standalone validation script used to decide the 384h cap. Re-runnable per region. |

## Audit punchlist after this lands

| | PR | State |
|---|---|---|
| ✅ | PR-A (#134) — Overview honest signals | Merged |
| ✅ | PR-D (#135) — de-leak training features | Merged |
| ✅ | PR-C (#136) — real weather forecast in production | Merged |
| ✅ | #137 — ADR-008 + UI labeling | Merged |
| ⏳ | **This PR — recursive autoregressive features** | Open |
| ⏳ | PR-B — empirical CI on Overview chart | Final polish |

🤖 Generated with [Claude Code](https://claude.com/claude-code)