### PR TITLE
feat(overview): empirical confidence interval on hero chart (PR-B)

### DIFF
--- a/components/_callbacks_overview.py
+++ b/components/_callbacks_overview.py
@@ -70,6 +70,7 @@ from components._callbacks_shared import (
     _GENERATION_CACHE,
     _PREDICTION_CACHE,
     DEFAULT_BACKTEST_EXOG_MODE,
+    _empirical_interval_from_backtests,
     _empty_figure,
     _latest_real_demand,
     _layout,
@@ -406,15 +407,37 @@ def _build_overview_hero_chart(
             forecast_ts = forecast_ts_all[:horizon]
             ensemble_y = list(ensemble_arr[:horizon])
 
-            # Heuristic ±3 % visual confidence band. The Redis payload
-            # doesn't carry empirical CI bounds (those are computed on
-            # the Forecast tab from recent residuals — overkill for the
-            # Overview hero). A simple ±3 % gives the chart a tinted
-            # ribbon visually equivalent to what was shipping pre-fix,
-            # without any pretense of calibration. The Forecast tab is
-            # the place to look for real CIs.
-            upper_y = [v * 1.03 for v in ensemble_y]
-            lower_y = [v * 0.97 for v in ensemble_y]
+            # Confidence band (PR-B, 2026-05-20): prefer calibrated
+            # empirical quantiles of recent backtest residuals, fall back
+            # to a ±3 % heuristic only when the calibration window is too
+            # small (typically <24 residual samples — first week
+            # post-deploy, or for newly-added regions).
+            #
+            # The empirical method is the same one the Forecast tab uses
+            # (``_empirical_interval_from_backtests`` →
+            # ``apply_empirical_interval``); see
+            # ``components._callbacks_shared:385-409`` and
+            # ``components._callbacks_forecast:108-170``. Sharing the
+            # method across surfaces means both views show a band
+            # calibrated to the same residual distribution — no
+            # surface-specific tuning that would silently diverge.
+            interval_meta = _empirical_interval_from_backtests(region, "ensemble", horizon)
+            empirical_ok = bool(interval_meta.get("available"))
+            if empirical_ok:
+                # Additive bands: lower_error / upper_error are quantiles
+                # of (actual - predicted) residuals, so band_y = pred + q.
+                lower_err = float(interval_meta["lower_error"])
+                upper_err = float(interval_meta["upper_error"])
+                upper_y = [v + upper_err for v in ensemble_y]
+                lower_y = [v + lower_err for v in ensemble_y]
+                band_name = (
+                    f"80% prediction interval "
+                    f"(empirical, n={int(interval_meta.get('sample_size', 0))})"
+                )
+            else:
+                upper_y = [v * 1.03 for v in ensemble_y]
+                lower_y = [v * 0.97 for v in ensemble_y]
+                band_name = "±3% indicative range"
             fig.add_trace(
                 go.Scatter(
                     x=list(forecast_ts) + list(forecast_ts[::-1]),
@@ -424,7 +447,7 @@ def _build_overview_hero_chart(
                     line=dict(width=0),
                     hoverinfo="skip",
                     showlegend=False,
-                    name="±3% band",
+                    name=band_name,
                 )
             )
 

--- a/tests/unit/test_overview_forecast_from_redis.py
+++ b/tests/unit/test_overview_forecast_from_redis.py
@@ -222,6 +222,122 @@ class TestHeroChartReadsRedis:
         assert band_y.max() > 22_000
 
 
+# ────────────────────────────────────────────────────────────────────────
+# PR-B (2026-05-20) — empirical confidence interval on Overview hero chart
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestHeroChartEmpiricalConfidenceInterval:
+    """``_build_overview_hero_chart`` uses empirical residual quantiles when
+    enough backtest residuals exist; falls back to ±3 % heuristic otherwise.
+
+    PR-B (2026-05-20): replaces the always-heuristic ±3% band with the
+    same calibration the Forecast tab uses, so both surfaces show
+    intervals derived from the same residual distribution. See
+    ``components._callbacks_shared._empirical_interval_from_backtests``
+    for the data source and gating rules.
+    """
+
+    @patch("components._callbacks_overview._empirical_interval_from_backtests")
+    @patch("components._callbacks_overview.redis_get")
+    def test_empirical_band_used_when_residuals_available(self, mock_redis_get, mock_empirical):
+        """When backtest residuals exist (sample_size >= threshold), the
+        band is built from additive residual quantiles, NOT ±3 % of
+        each prediction. The band-trace name carries the source label
+        so the legend / debug can show calibration provenance."""
+        from components._callbacks_overview import _build_overview_hero_chart
+
+        mock_redis_get.return_value = _redis_forecast_payload()
+        # Asymmetric quantiles to distinguish from heuristic (which is
+        # symmetric ±3%): lower at -800 MW, upper at +1200 MW.
+        mock_empirical.return_value = {
+            "available": True,
+            "lower_error": -800.0,
+            "upper_error": 1200.0,
+            "sample_size": 144,
+            "target_coverage": 0.80,
+            "calibration_window_hours": 144,
+        }
+
+        fig = _build_overview_hero_chart("FPL", _demand_df())
+
+        band_traces = [t for t in fig.data if t.fill == "toself"]
+        # The toself band is the empirical interval (the actuals area
+        # uses fill="tozeroy"). Walk fig.data to find the band whose
+        # name contains "empirical".
+        emp_band = next(
+            (t for t in fig.data if t.name and "empirical" in t.name.lower()),
+            None,
+        )
+        assert emp_band is not None, (
+            f"No empirical band found. Trace names: {[t.name for t in band_traces]}"
+        )
+        # Band name carries sample size — surfaces calibration provenance
+        assert "n=144" in emp_band.name
+
+        # Band asymmetry verifies additive residual quantiles, not
+        # multiplicative ±x%. Upper offset (+1200) > lower offset (800)
+        # in absolute value → the band should sit higher above the
+        # ensemble than below.
+        band_y = np.array([v for v in emp_band.y if v is not None], dtype=float)
+        # The band's max should exceed ~22500 + 1200 ≈ 23700 (ensemble peak + upper_error)
+        assert band_y.max() > 23_500, (
+            f"Empirical band max {band_y.max()} doesn't reflect +1200 offset above ensemble peak"
+        )
+
+    @patch("components._callbacks_overview._empirical_interval_from_backtests")
+    @patch("components._callbacks_overview.redis_get")
+    def test_heuristic_fallback_when_residuals_insufficient(self, mock_redis_get, mock_empirical):
+        """When the calibration window is too small (first week
+        post-deploy / newly-added region), the helper returns
+        ``{available: False}`` and the chart falls back to the ±3 %
+        heuristic band, labeled as ``"±3% indicative range"`` so the
+        legend never claims a calibration it doesn't have."""
+        from components._callbacks_overview import _build_overview_hero_chart
+
+        mock_redis_get.return_value = _redis_forecast_payload()
+        mock_empirical.return_value = {"available": False}
+
+        fig = _build_overview_hero_chart("FPL", _demand_df())
+
+        # Should NOT have an empirical-labeled band
+        emp_bands = [t for t in fig.data if t.name and "empirical" in t.name.lower()]
+        assert emp_bands == [], (
+            f"Empirical band rendered despite insufficient residuals; "
+            f"names: {[t.name for t in fig.data]}"
+        )
+
+        # Should have the heuristic band, labeled honestly
+        heur_band = next(
+            (t for t in fig.data if t.name == "±3% indicative range"),
+            None,
+        )
+        assert heur_band is not None, (
+            f"Heuristic fallback band missing. Trace names: {[t.name for t in fig.data]}"
+        )
+
+    @patch("components._callbacks_overview._empirical_interval_from_backtests")
+    @patch("components._callbacks_overview.redis_get")
+    def test_empirical_helper_called_with_correct_args(self, mock_redis_get, mock_empirical):
+        """The hero chart shows a 24-hour ensemble forecast, so the
+        empirical helper must be called with model_name='ensemble' and
+        horizon_hours=24. Pinning the args prevents a future refactor
+        from silently querying a different residual bucket."""
+        from components._callbacks_overview import _build_overview_hero_chart
+
+        mock_redis_get.return_value = _redis_forecast_payload()
+        mock_empirical.return_value = {"available": False}
+
+        _build_overview_hero_chart("FPL", _demand_df())
+
+        mock_empirical.assert_called_once()
+        call_args = mock_empirical.call_args
+        # Positional args: (region, model_name, horizon_hours)
+        assert call_args[0][0] == "FPL"
+        assert call_args[0][1] == "ensemble"
+        assert call_args[0][2] == 24
+
+
 class TestInsightSummaryReadsRedis:
     """``_build_overview_insight``'s forecast clause uses real Redis timestamps."""
 


### PR DESCRIPTION
## Summary

Replaces the always-on ±3% heuristic band on the Overview hero chart with the calibrated empirical residual-quantile method the Forecast tab already uses. Falls back to ±3% only when the calibration window is too small (typically <24 residual samples — first week post-deploy or newly-added regions). Band trace name surfaces calibration provenance.

This is the **last item of the forecast-pipeline audit** — closes the punchlist.

## Why this matters

Pre-PR-B, both surfaces showed an "80%" band, but only the Forecast tab's was actually calibrated. The Overview's ribbon was a fixed ±3% of each prediction regardless of how the model had been performing — visually informative but not honest about the model's actual error distribution.

After PR-B, both surfaces draw bands from the same residual distribution. A user cross-checking the Overview ribbon against the Forecast tab CI for the same region will see them agree.

## What changes

**`components/_callbacks_overview.py:_build_overview_hero_chart`** — replaces these two lines:

```python
# before
upper_y = [v * 1.03 for v in ensemble_y]
lower_y = [v * 0.97 for v in ensemble_y]
```

with a 16-line block that calls `_empirical_interval_from_backtests(region, "ensemble", horizon=24)`, branches on `available`, and uses additive quantiles when calibration is sufficient. Band trace name reflects the source:

- Empirical: `"80% prediction interval (empirical, n=144)"`
- Heuristic fallback: `"±3% indicative range"`

That sample-size suffix in the empirical name lets a viewer cross-check the calibration window — a band labeled `n=24` is statistically thinner than one labeled `n=300`.

## Test plan

- [x] 3 new unit tests in `tests/unit/test_overview_forecast_from_redis.py::TestHeroChartEmpiricalConfidenceInterval`:
  - `test_empirical_band_used_when_residuals_available` — asymmetric quantiles (lower=-800, upper=+1200) produce an asymmetric band; band name contains `"empirical, n=144"`
  - `test_heuristic_fallback_when_residuals_insufficient` — `{available: False}` → band labeled `"±3% indicative range"`, no `"empirical"` band rendered
  - `test_empirical_helper_called_with_correct_args` — pins `(region, "ensemble", 24)` so future refactors can't silently swap horizon or model
- [x] Full unit suite: **1717 passed** (1714 baseline + 3 new) in 175s
- [x] Lint + format clean
- [ ] **Manual UI verification after merge:** open Overview tab in production. For regions with established backtest residuals (every region after >24 hours of training-job runs), the ribbon should look subtly different from the symmetric ±3% — typically asymmetric, sometimes wider in one direction. For brand-new regions (V1.α additions still warming up), the label should still read "±3% indicative range" until residuals accumulate.

## What this doesn't change

- The empirical method itself (`_empirical_interval_from_backtests` and `apply_empirical_interval`). Both predate this PR.
- The Forecast tab's CI rendering — unchanged.
- The data source: residuals from Redis backtest keys via `_collect_backtest_residuals`. PR-B just routes the Overview through the same path.

## Audit punchlist after this merges

The forecast-pipeline audit from earlier today is now fully closed:

| | PR | State |
|---|---|---|
| ✅ | PR-A (#134) — Overview honest signals | Merged |
| ✅ | PR-D (#135) — de-leak training features | Merged |
| ✅ | PR-C (#136) — real weather forecast in production | Merged |
| ✅ | #137 — ADR-008 + UI labeling | Merged |
| ✅ | PR-E (#138) — recursive autoregressive features | Merged |
| ⏳ | **This PR (PR-B) — empirical CI on Overview** | Open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)