### PR TITLE
fix(forecast): close EIA-publishing-lag gap on Forecast tab (#129)

### DIFF
--- a/jobs/phases.py
+++ b/jobs/phases.py
@@ -510,10 +510,69 @@ def _overlay_weather_forecast(
     return future_df
 
 
+def _resolve_forecast_start(
+    featured: pd.DataFrame,
+    demand_df: pd.DataFrame,
+) -> pd.Timestamp:
+    """Pick the timestamp for hour 0 of the forecast.
+
+    Used by ``predict_and_write_forecast`` to close the EIA-publishing-lag
+    gap (#129) on the Forecast tab chart. Returns
+    ``last_real_demand_hour + 1h`` whenever a real-demand hour can be
+    identified — that anchor matches where the actuals trace ends, so
+    the forecast trace picks up immediately after it without a visible
+    multi-hour gap.
+
+    "Real demand" = non-NaN AND strictly positive. EIA-930 publishes
+    null for not-yet-available observations (which ``eia_client``
+    preserves as NaN). Literal zero is coerced to NaN upstream, but
+    we filter ``> 0`` defensively in case any zero-demand row slips
+    through (a balancing authority cannot have truly zero load).
+
+    Fallback chain when real demand can't be identified (degenerate
+    cases — empty demand_df, all-NaN demand, brand-new region during
+    first scoring tick):
+
+    1. Last real demand from ``demand_df`` (the desired anchor) — ``+ 1h``
+    2. Last timestamp in ``featured`` (pre-fix behavior, may leave a gap)
+    3. ``demand_df.timestamp.max() + 1h`` as the last-resort floor
+
+    Args:
+        featured: Engineered DataFrame (post-merge, post-dropna).
+        demand_df: Raw EIA demand DataFrame from ``data.demand_df``.
+
+    Returns:
+        Forecast-start timestamp (timezone-aware UTC).
+    """
+    last_featured_ts = featured["timestamp"].max()
+
+    if demand_df is None or demand_df.empty:
+        return last_featured_ts + pd.Timedelta(hours=1)
+
+    # Filter to real demand readings — must be non-NaN AND strictly
+    # positive. A balancing authority cannot have zero load; any zero
+    # is a missing-data artifact.
+    mask = demand_df["demand_mw"].notna() & (demand_df["demand_mw"] > 0)
+    real_demand = demand_df.loc[mask, "timestamp"]
+    if real_demand.empty:
+        return last_featured_ts + pd.Timedelta(hours=1)
+
+    last_real_demand = real_demand.max()
+
+    # Cap at last_featured so we don't generate a forecast row for
+    # which we can't compute autoregressive lag context. This means
+    # ``last_real > last_featured`` (theoretically possible if
+    # feature-engineering drops rows for reasons unrelated to demand
+    # NaN-ness) falls back to last_featured + 1h.
+    anchor = min(last_real_demand, last_featured_ts)
+    return anchor + pd.Timedelta(hours=1)
+
+
 def _build_future_feature_frame(
     featured: pd.DataFrame,
     horizon: int,
     weather_df: pd.DataFrame | None = None,
+    start_ts: pd.Timestamp | None = None,
 ) -> pd.DataFrame:
     """Build a feature frame for the forecast horizon.
 
@@ -539,9 +598,18 @@ def _build_future_feature_frame(
         weather_df: Optional raw weather DataFrame (from
             ``data.weather_client.fetch_weather``) covering both the
             historical and forecast periods. Only the forecast portion
-            (timestamps after ``featured.timestamp.max()``) is used. When
+            (timestamps after the forecast start) is used. When
             ``None``, the function falls back to the pre-PR-C
             climatology-only behavior.
+        start_ts: Optional explicit timestamp for hour 0 of the forecast.
+            When ``None``, defaults to ``featured["timestamp"].max() +
+            1h`` (the existing behavior). Passed explicitly by
+            ``predict_and_write_forecast`` to anchor the forecast at
+            ``last_real_demand_hour + 1h`` instead of
+            ``featured.timestamp.max() + 1h`` — closes the 1-4h gap
+            on the Forecast tab between the last EIA-published actual
+            and the start of the forecast trace when EIA's publishing
+            lag is non-zero. See #129.
 
     Note on autoregressive features: the climatology values placed here
     by this function are used **only as the long-horizon fallback** —
@@ -551,9 +619,10 @@ def _build_future_feature_frame(
     that hour the climatology values produced here are what the model
     actually sees. ARIMA and Prophet don't use these columns.
     """
-    last_ts = featured["timestamp"].max()
+    if start_ts is None:
+        start_ts = featured["timestamp"].max() + pd.Timedelta(hours=1)
     future_timestamps = pd.date_range(
-        start=last_ts + pd.Timedelta(hours=1),
+        start=start_ts,
         periods=horizon,
         freq="h",
     )
@@ -638,7 +707,17 @@ def _predict_xgboost_with_recursive_autoregressive(
     # Recursive zone: chain predictions hour by hour, seeded from recent
     # actuals. Each iteration: build the feature row from the growing
     # history, predict, append the prediction to history.
-    demand_history = featured["demand_mw"].tolist()
+    #
+    # Filter the seed to real demand readings (non-NaN, > 0). Zero or
+    # NaN trailing rows that slip through ``engineer_region_features``
+    # would corrupt the autoregressive lag/rolling features computed
+    # by ``compute_autoregressive_snapshot`` — a single zero in
+    # demand_history poisons the next 168 rolling-window features.
+    # See #129 for the production symptom.
+    raw_history = featured["demand_mw"].tolist()
+    demand_history: list[float] = [
+        float(v) for v in raw_history if v is not None and not pd.isna(v) and v > 0
+    ]
     recursive_preds: list[float] = []
     for i in range(n_recursive):
         row = future_df.iloc[[i]].copy()
@@ -762,11 +841,28 @@ def predict_and_write_forecast(
 
     try:
         featured = data.featured_df
+
+        # Anchor the forecast at ``last_real_demand_hour + 1h`` instead
+        # of ``featured.timestamp.max() + 1h`` (#129, 2026-05-21). When
+        # EIA's publishing lag is non-zero, ``featured`` can extend past
+        # the last hour with real demand — either via trailing zero rows
+        # that survive ``dropna(subset=["demand_mw"])`` or via the
+        # asymmetric publishing lag between EIA (demand) and Open-Meteo
+        # (weather). Anchoring on the last real demand reading closes
+        # the 1-4h gap that was visible on the Forecast tab chart
+        # between actuals end and forecast start. When there's no
+        # publishing-lag gap, this is a no-op:
+        # ``last_real_demand == featured.timestamp.max()``.
+        forecast_start = _resolve_forecast_start(featured, data.demand_df)
+
         # Pass the raw weather DataFrame so the future-feature builder can
         # overlay actual Open-Meteo forecast values (next ~16 days) onto
         # the climatology baseline. See ``_overlay_weather_forecast``.
         future_df = _build_future_feature_frame(
-            featured, FORECAST_HORIZON_HOURS, weather_df=data.weather_df
+            featured,
+            FORECAST_HORIZON_HOURS,
+            weather_df=data.weather_df,
+            start_ts=forecast_start,
         )
         future_ts = future_df["timestamp"]
 

--- a/tests/unit/test_phases_forecast.py
+++ b/tests/unit/test_phases_forecast.py
@@ -68,11 +68,13 @@ def _patch_predict_one(monkeypatch, predictions_by_name):
     monkeypatch.setattr(
         phases,
         "_build_future_feature_frame",
-        # PR-C (2026-05-20): function gained ``weather_df`` kwarg. Lambda
-        # accepts and ignores it — tests here exercise ``predict_and_write_forecast``
-        # ensemble logic, not the future-frame builder itself (which has
-        # its own dedicated test class below).
-        lambda featured, horizon, weather_df=None: pd.DataFrame(
+        # PR-C (2026-05-20): function gained ``weather_df`` kwarg.
+        # #129 (2026-05-21): function gained ``start_ts`` kwarg.
+        # Lambda accepts and ignores both — tests here exercise
+        # ``predict_and_write_forecast``'s ensemble logic, not the
+        # future-frame builder itself (which has its own dedicated
+        # test classes below).
+        lambda featured, horizon, weather_df=None, start_ts=None: pd.DataFrame(
             {"timestamp": pd.date_range("2024-02-01", periods=horizon, freq="h", tz="UTC")}
         ),
     )
@@ -628,3 +630,219 @@ class TestPredictXgboostRecursive:
         result = phases._predict_one("xgboost", model, featured, future_df, horizon=24)
         assert result is not None
         assert called["recursive"] is True
+
+
+# ────────────────────────────────────────────────────────────────────────
+# #129 — Forecast tab gap fix (anchor on last_real_demand_hour + 1h)
+# ────────────────────────────────────────────────────────────────────────
+
+
+class TestResolveForecastStart:
+    """``_resolve_forecast_start`` picks the timestamp for hour 0 of the
+    forecast. The normal case (no publishing-lag gap) returns
+    ``featured.timestamp.max() + 1h``; the gap case returns
+    ``last_real_demand_hour + 1h``. See #129.
+    """
+
+    @staticmethod
+    def _featured(end_ts: str, n_hours: int = 200) -> pd.DataFrame:
+        end = pd.Timestamp(end_ts, tz="UTC")
+        ts = pd.date_range(end=end, periods=n_hours, freq="h")
+        return pd.DataFrame({"timestamp": ts, "demand_mw": np.full(n_hours, 20_000.0)})
+
+    @staticmethod
+    def _demand_df(end_ts: str, n_hours: int = 200) -> pd.DataFrame:
+        end = pd.Timestamp(end_ts, tz="UTC")
+        ts = pd.date_range(end=end, periods=n_hours, freq="h")
+        return pd.DataFrame({"timestamp": ts, "demand_mw": np.full(n_hours, 20_000.0)})
+
+    def test_no_gap_returns_featured_max_plus_1h(self):
+        """Normal case: demand_df and featured end at the same timestamp
+        (EIA fully caught up). Forecast starts at that timestamp + 1h."""
+        from jobs.phases import _resolve_forecast_start
+
+        same_end = "2026-05-20 14:00"
+        featured = self._featured(same_end)
+        demand_df = self._demand_df(same_end)
+
+        forecast_start = _resolve_forecast_start(featured, demand_df)
+        assert forecast_start == pd.Timestamp(same_end, tz="UTC") + pd.Timedelta(hours=1)
+
+    def test_publishing_lag_gap_anchors_on_real_demand(self):
+        """Gap case: featured extends to 14:00 UTC but demand_df has
+        real readings only through 10:00 UTC (4-hour EIA publishing
+        lag — the production scenario from #129). Forecast must start
+        at 11:00 UTC, not 15:00 UTC."""
+        from jobs.phases import _resolve_forecast_start
+
+        featured = self._featured("2026-05-20 14:00")
+        demand_df = self._demand_df("2026-05-20 10:00")
+
+        forecast_start = _resolve_forecast_start(featured, demand_df)
+        assert forecast_start == pd.Timestamp("2026-05-20 11:00", tz="UTC")
+
+    def test_trailing_nan_demand_treated_as_missing(self):
+        """If demand_df includes trailing rows with NaN demand (EIA's
+        sentinel for unpublished hours), those don't count as 'real
+        demand' — the anchor is the last non-NaN hour."""
+        from jobs.phases import _resolve_forecast_start
+
+        featured = self._featured("2026-05-20 14:00")
+        demand_df = self._demand_df("2026-05-20 14:00")
+        # Last 4 hours have NaN demand (unpublished)
+        demand_df.loc[demand_df.index[-4:], "demand_mw"] = np.nan
+
+        forecast_start = _resolve_forecast_start(featured, demand_df)
+        # Last real demand hour = 10:00 UTC; forecast starts at 11:00 UTC
+        assert forecast_start == pd.Timestamp("2026-05-20 11:00", tz="UTC")
+
+    def test_trailing_zero_demand_treated_as_missing(self):
+        """Defense in depth: even though ``eia_client`` coerces 0 → NaN,
+        any zero rows that slip through (e.g., via cache from a
+        pre-fix version) are still treated as 'missing' since a BA
+        cannot have zero demand."""
+        from jobs.phases import _resolve_forecast_start
+
+        featured = self._featured("2026-05-20 14:00")
+        demand_df = self._demand_df("2026-05-20 14:00")
+        demand_df.loc[demand_df.index[-3:], "demand_mw"] = 0.0
+
+        forecast_start = _resolve_forecast_start(featured, demand_df)
+        # Last real demand = 11:00 UTC (last index minus 3 → 14:00 - 3h)
+        assert forecast_start == pd.Timestamp("2026-05-20 12:00", tz="UTC")
+
+    def test_empty_demand_df_falls_back_to_featured(self):
+        """Defensive — empty demand_df → fall back to old behavior."""
+        from jobs.phases import _resolve_forecast_start
+
+        featured = self._featured("2026-05-20 14:00")
+        empty = pd.DataFrame(columns=["timestamp", "demand_mw"])
+
+        forecast_start = _resolve_forecast_start(featured, empty)
+        assert forecast_start == pd.Timestamp("2026-05-20 15:00", tz="UTC")
+
+    def test_all_nan_demand_falls_back_to_featured(self):
+        """If every demand row is NaN (degenerate fetch failure), fall
+        back to ``featured.max + 1h`` rather than failing the phase."""
+        from jobs.phases import _resolve_forecast_start
+
+        featured = self._featured("2026-05-20 14:00")
+        demand_df = self._demand_df("2026-05-20 14:00")
+        demand_df["demand_mw"] = np.nan
+
+        forecast_start = _resolve_forecast_start(featured, demand_df)
+        assert forecast_start == pd.Timestamp("2026-05-20 15:00", tz="UTC")
+
+    def test_last_real_demand_after_featured_caps_at_featured(self):
+        """If last_real_demand somehow exceeds featured.max (e.g., feature
+        engineering dropped trailing rows for reasons unrelated to
+        demand-NaN), cap the anchor at featured.max so we don't
+        generate forecast rows without lag context."""
+        from jobs.phases import _resolve_forecast_start
+
+        featured = self._featured("2026-05-20 12:00")
+        demand_df = self._demand_df("2026-05-20 14:00")
+
+        forecast_start = _resolve_forecast_start(featured, demand_df)
+        assert forecast_start == pd.Timestamp("2026-05-20 13:00", tz="UTC")
+
+
+class TestBuildFutureFeatureFrameStartTs:
+    """``_build_future_feature_frame`` accepts an explicit ``start_ts``
+    kwarg (#129). Default behavior unchanged when ``start_ts=None``."""
+
+    def test_explicit_start_ts_anchors_first_row(self):
+        """When ``start_ts`` is provided, the first future row's
+        timestamp equals that anchor (NOT ``featured.max + 1h``)."""
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist(n_hours=168 * 2, last_ts="2026-05-20 14:00")
+        # Anchor forecast at 11:00 UTC (4 hours BEFORE featured.max)
+        anchor = pd.Timestamp("2026-05-20 11:00", tz="UTC")
+        future_df = _build_future_feature_frame(featured, horizon=24, start_ts=anchor)
+
+        assert pd.Timestamp(future_df["timestamp"].iloc[0]) == anchor
+
+    def test_no_start_ts_preserves_old_behavior(self):
+        """Without ``start_ts``, the function still anchors at
+        ``featured.max + 1h`` — pre-#129 behavior."""
+        from jobs.phases import _build_future_feature_frame
+
+        featured = _build_featured_hist(n_hours=168 * 2, last_ts="2026-05-20 14:00")
+        future_df = _build_future_feature_frame(featured, horizon=24)
+
+        expected_first = pd.Timestamp("2026-05-20 15:00", tz="UTC")
+        assert pd.Timestamp(future_df["timestamp"].iloc[0]) == expected_first
+
+
+class TestRecursivePredictDemandHistorySeed:
+    """``_predict_xgboost_with_recursive_autoregressive`` filters its
+    demand_history seed against NaN/zero values (#129). A single zero
+    or NaN trailing row would otherwise poison the next 168 rolling
+    features computed by ``compute_autoregressive_snapshot``.
+    """
+
+    def test_seed_filters_nan_and_zero_demand(self, monkeypatch):
+        """Build a ``featured`` whose last 4 rows have NaN/zero demand.
+        The recursive predict's first prediction should be seeded from
+        the LAST GOOD demand (20,000.0), not from NaN/zero."""
+        import jobs.phases as phases
+
+        # Fake predict_xgboost returns lag_1h × 1.02 — same as the
+        # PR-E test infrastructure. Lets us observe what got seeded.
+        def _fake_predict(model, df):
+            lag = df["demand_lag_1h"].fillna(-1.0).astype(float).values
+            return lag * 1.02
+
+        monkeypatch.setattr("models.xgboost_model.predict_xgboost", _fake_predict)
+
+        ts = pd.date_range("2026-05-01", periods=200, freq="h", tz="UTC")
+        # First 196 rows: real demand 20,000. Last 4 rows: NaN/zero noise.
+        demand = np.full(200, 20_000.0)
+        demand[-4:-2] = np.nan
+        demand[-2:] = 0.0
+        featured = pd.DataFrame({"timestamp": ts, "demand_mw": demand})
+
+        future_ts = pd.date_range("2026-05-20", periods=5, freq="h", tz="UTC")
+        future_df = pd.DataFrame(
+            {
+                "timestamp": future_ts,
+                "demand_lag_1h": np.full(5, 30_000.0),  # baseline overridden by recursion
+            }
+        )
+        # Add the autoregressive feature columns the snapshot fills
+        for col in [
+            "demand_lag_3h",
+            "demand_lag_24h",
+            "demand_lag_168h",
+            "ramp_rate",
+            "demand_momentum_short",
+            "demand_momentum_long",
+            "demand_ratio_24h",
+            "demand_ratio_168h",
+            "demand_roll_24h_mean",
+            "demand_roll_24h_std",
+            "demand_roll_24h_min",
+            "demand_roll_24h_max",
+            "demand_roll_72h_mean",
+            "demand_roll_72h_std",
+            "demand_roll_72h_min",
+            "demand_roll_72h_max",
+            "demand_roll_168h_mean",
+            "demand_roll_168h_std",
+            "demand_roll_168h_min",
+            "demand_roll_168h_max",
+        ]:
+            future_df[col] = 0.0
+
+        model = _FakeXgbModel(feature_names=list(future_df.columns))
+        preds = phases._predict_xgboost_with_recursive_autoregressive(
+            model, featured, future_df, horizon=5, recursive_hours=5
+        )
+
+        # First prediction = lag_1h × 1.02 = LAST REAL demand × 1.02
+        # = 20,000 × 1.02 = 20,400. NOT 0 × 1.02 = 0 (which would
+        # happen if NaN/zero values made it into demand_history).
+        assert preds[0] == pytest.approx(20_400.0, rel=1e-6)
+        # The chain continues at 1.02× per step
+        assert preds[1] == pytest.approx(20_808.0, rel=1e-6)


### PR DESCRIPTION
Closes #129.

## Symptom

User observed on Forecast tab (2026-05-20, FPL, scoring job ran at 09:02 UTC):
- Actuals trace ends at **05:00 UTC** (last EIA-published hour)
- Forecast trace starts at **09:00 UTC**
- 4-hour visual gap where neither trace renders

To viewers, looks like missing data.

## Fix

Anchor the forecast on `last_real_demand_hour + 1h` instead of `featured.timestamp.max() + 1h`. When there's no publishing-lag gap, this is a no-op (`last_real_demand == featured.timestamp.max()`).

Three coordinated changes in `jobs/phases.py`:

1. **New `_resolve_forecast_start(featured, demand_df)` helper.** Filters `demand_df` to real readings (non-NaN AND `> 0` — a BA cannot have zero load) and returns `min(last_real_demand, last_featured) + 1h`. Defensive against degenerate cases (empty demand_df, all-NaN demand, last_real > last_featured).

2. **`_build_future_feature_frame` gains an optional `start_ts` kwarg.** Default `None` preserves pre-fix behavior; when provided, anchors hour 0 of the forecast.

3. **`_predict_xgboost_with_recursive_autoregressive` filters its demand_history seed against NaN/zero.** A single zero or NaN in the seed would poison the next 168 rolling-window features computed by `compute_autoregressive_snapshot`. Defense-in-depth against any zero/NaN trailing row that slips through `dropna`.

## Why the gap exists in practice

`eia_client` returns `null` for unpublished hours and coerces literal 0 → NaN. After `merge_demand_weather` (left join on demand) + `engineer_region_features.dropna(subset=["demand_mw"])`, trailing-NaN rows should be gone. **But the bug was observed in production.** Possible mechanisms:

- A pre-fix cached demand_df where 0-coercion hadn't yet happened
- A merge edge case I can't reproduce in my local cache  
- Asymmetric publishing lag manifesting differently across regions or hours

Rather than relying on the exact mechanism, this PR makes the fix **mechanism-agnostic**: filter on real demand directly from `demand_df`, anchor the forecast on that, defensively reject NaN/zero from the recursive seed. Closes the bug regardless of root cause.

## Acceptance (per issue body)

- [x] `gridpulse:forecast:{region}:1h` payload's earliest row timestamp = `(last hour with non-NaN demand_mw in demand_df) + 1h`
- [x] Tests verify the trailing-NaN AND trailing-zero handling
- [ ] **Production verification:** Forecast tab chart's forecast trace visibly connects to the actual trace without a multi-hour gap. Will be visible on the next hourly scoring tick after merge.
- [ ] **Production verification:** when EIA backfills the gap hours at the next tick, those rows correctly switch from "predicted" to "actual" without leaving residual forecast values.

## Test plan

- [x] 10 new unit tests covering:
  - **`TestResolveForecastStart`** (7 tests) — no-gap no-op, 4h lag, trailing NaN, trailing zero, empty demand_df, all-NaN demand, last_real > last_featured cap
  - **`TestBuildFutureFeatureFrameStartTs`** (2 tests) — explicit `start_ts` honored, default behavior preserved
  - **`TestRecursivePredictDemandHistorySeed`** (1 test) — seed filters NaN/zero, first recursive prediction reflects last GOOD demand
- [x] Full unit suite: **1727 passed** (1717 baseline + 10 new) in 141s
- [x] Lint + format clean
- [x] Existing `TestPredictAndWriteForecast` monkeypatch lambda updated to accept new `start_ts` kwarg (same pattern as PR-C's `weather_df` kwarg)

## Files changed

| File | Change |
|---|---|
| `jobs/phases.py` | New `_resolve_forecast_start` helper. `_build_future_feature_frame` accepts `start_ts` kwarg. `_predict_xgboost_with_recursive_autoregressive` filters demand_history seed. `predict_and_write_forecast` plumbs `forecast_start` through. |
| `tests/unit/test_phases_forecast.py` | 10 new tests in three new classes + monkeypatch lambda update |

## Risk + rollback

The change is additive when there's no gap (the resolver returns the same value the old code computed). Behavioral change only kicks in when `featured` extends past last-real-demand — exactly the bug scenario. Independently revertable: roll the scoring job's image to the prior tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)