### PR TITLE
ci: gate prod + dev deploys behind CI success (PR-G2, closes #146)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,7 +1,12 @@
 name: Deploy -> Dev
 
+# Gated behind CI (PR-G2 / #146): runs only after the "CI" workflow
+# completes on dev. The job-level ``if`` requires CI success — mirrors
+# the production gating so staging can't ship a red build either.
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [dev]
 
 env:
@@ -10,6 +15,9 @@ env:
   SERVICE: gridpulse-dev
   REPO: portfolio
   IMAGE: us-east1-docker.pkg.dev/nextera-portfolio/portfolio/gridpulse-dev
+  # The exact commit CI validated — not dev's current HEAD. See the
+  # matching note in deploy-prod.yml.
+  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
 
 concurrency:
   group: deploy-dev
@@ -19,12 +27,15 @@ jobs:
   deploy-dev:
     name: Build & Deploy to Cloud Run (Dev)
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       id-token: write
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -41,16 +52,16 @@ jobs:
       - name: Build and push Docker image
         run: |
           docker build \
-            -t ${{ env.IMAGE }}:${{ github.sha }} \
+            -t ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }} \
             -t ${{ env.IMAGE }}:dev-latest \
             .
-          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}
           docker push ${{ env.IMAGE }}:dev-latest
 
       - name: Deploy to Cloud Run (Dev)
         run: |
           gcloud run deploy ${{ env.SERVICE }} \
-            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --image ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }} \
             --region ${{ env.REGION }} \
             --platform managed \
             --allow-unauthenticated \
@@ -62,14 +73,14 @@ jobs:
             --vpc-connector wattcast-connector \
             --set-secrets "EIA_API_KEY=eia-api-key:latest" \
             --set-env-vars "ENVIRONMENT=staging,LOG_LEVEL=DEBUG,GCS_BUCKET_NAME=nextera-portfolio-energy-cache,GCS_ENABLED=true,REDIS_HOST=${{ secrets.REDIS_HOST }},REDIS_PORT=6379,REQUIRE_REDIS=true,PRECOMPUTE_ENABLED=false" \
-            --tag "sha-$(echo ${{ github.sha }} | cut -c1-7)"
+            --tag "sha-$(echo ${{ env.DEPLOY_SHA }} | cut -c1-7)"
 
       # Staging Cloud Run Jobs: same image, different entrypoint. Suffixed
       # -dev so they can coexist with the production jobs in the same region.
       - name: Deploy scoring job (Dev)
         run: |
           gcloud run jobs deploy gridpulse-scoring-job-dev \
-            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --image ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }} \
             --region ${{ env.REGION }} \
             --service-account "gridpulse-job@${{ env.PROJECT_ID }}.iam.gserviceaccount.com" \
             --vpc-connector wattcast-connector \
@@ -85,7 +96,7 @@ jobs:
       - name: Deploy training job (Dev)
         run: |
           gcloud run jobs deploy gridpulse-training-job-dev \
-            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --image ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }} \
             --region ${{ env.REGION }} \
             --service-account "gridpulse-job@${{ env.PROJECT_ID }}.iam.gserviceaccount.com" \
             --vpc-connector wattcast-connector \
@@ -107,7 +118,7 @@ jobs:
           echo "url=$URL" >> $GITHUB_OUTPUT
           echo "### Deployed to Dev" >> $GITHUB_STEP_SUMMARY
           echo "**URL:** $URL" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.DEPLOY_SHA }}\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Smoke test dev
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,7 +1,15 @@
 name: Deploy -> Production
 
+# Gated behind CI (PR-G2 / #146): this workflow only runs after the "CI"
+# workflow completes on main. The job-level ``if`` below requires CI to
+# have *succeeded* — ``workflow_run`` fires on completion regardless of
+# outcome, so the guard is what actually blocks a broken commit from
+# deploying. Previously this triggered on every push to main independent
+# of CI, so a red build could ship to production.
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
     branches: [main]
 
 env:
@@ -10,6 +18,12 @@ env:
   SERVICE: gridpulse
   REPO: portfolio
   IMAGE: us-east1-docker.pkg.dev/nextera-portfolio/portfolio/gridpulse
+  # Race-free deploy target: the exact commit CI validated, NOT main's
+  # current HEAD. Under ``workflow_run`` a newer commit may have landed
+  # on main between CI passing and this workflow starting; deploying
+  # ``github.sha`` (main HEAD) would ship un-validated code. Pin to the
+  # SHA the triggering CI run actually tested.
+  DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
 
 concurrency:
   group: deploy-prod
@@ -19,6 +33,10 @@ jobs:
   deploy-production:
     name: Build & Deploy to Cloud Run (Production)
     runs-on: ubuntu-latest
+    # Only deploy when the triggering CI run SUCCEEDED. ``workflow_run``
+    # delivers failed + cancelled runs too; without this guard a red CI
+    # would still deploy.
+    if: github.event.workflow_run.conclusion == 'success'
     environment: production
     permissions:
       contents: read
@@ -26,6 +44,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Check out the exact commit CI validated (see DEPLOY_SHA note).
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -42,16 +63,16 @@ jobs:
       - name: Build and push Docker image
         run: |
           docker build \
-            -t ${{ env.IMAGE }}:${{ github.sha }} \
+            -t ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }} \
             -t ${{ env.IMAGE }}:prod-latest \
             .
-          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}
           docker push ${{ env.IMAGE }}:prod-latest
 
       - name: Deploy to Cloud Run (Production)
         run: |
           gcloud run deploy ${{ env.SERVICE }} \
-            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --image ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }} \
             --region ${{ env.REGION }} \
             --platform managed \
             --allow-unauthenticated \
@@ -73,7 +94,7 @@ jobs:
       - name: Deploy scoring job (Production)
         run: |
           gcloud run jobs deploy gridpulse-scoring-job \
-            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --image ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }} \
             --region ${{ env.REGION }} \
             --service-account "gridpulse-job@${{ env.PROJECT_ID }}.iam.gserviceaccount.com" \
             --vpc-connector wattcast-connector \
@@ -108,7 +129,7 @@ jobs:
         # where this one left off, don't waste a retry.
         run: |
           gcloud run jobs deploy gridpulse-training-job \
-            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --image ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }} \
             --region ${{ env.REGION }} \
             --service-account "gridpulse-job@${{ env.PROJECT_ID }}.iam.gserviceaccount.com" \
             --vpc-connector wattcast-connector \
@@ -132,7 +153,8 @@ jobs:
           echo "url=$URL" >> $GITHUB_OUTPUT
           echo "### Deployed to Production" >> $GITHUB_STEP_SUMMARY
           echo "**URL:** $URL" >> $GITHUB_STEP_SUMMARY
-          echo "**Image:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.DEPLOY_SHA }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**CI run:** [#${{ github.event.workflow_run.run_number }}](${{ github.event.workflow_run.html_url }})" >> $GITHUB_STEP_SUMMARY
 
       - name: Production health check
         run: |

--- a/docs/SCHEDULED_JOBS.md
+++ b/docs/SCHEDULED_JOBS.md
@@ -158,13 +158,45 @@ gcloud scheduler jobs update http gridpulse-scoring-hourly \
 Staging mirrors with `gridpulse-scoring-hourly-dev` /
 `gridpulse-training-daily-dev` pointing at the `-dev` jobs.
 
+## Deploy gating (CI → deploy)
+
+Deploys are **gated behind CI** (PR-G2 / #146). The `deploy-prod.yml` /
+`deploy-dev.yml` workflows do **not** run on push directly — they run on
+`workflow_run` after the **CI** workflow completes, and only when CI
+*succeeded*:
+
+```
+push to main ──▶ CI (security · lint · test · coverage · docker)
+                  │
+                  ├─ red  ──▶ deploy SKIPPED (if: conclusion == 'success')
+                  └─ green ─▶ Deploy → Production
+                              builds image tagged with the *exact* SHA
+                              CI validated (workflow_run.head_sha), not
+                              main's current HEAD — so a commit that lands
+                              after CI passed can't ride out un-validated.
+```
+
+Before PR-G2 the deploy fired on every push to `main` independent of CI,
+so a red build could ship. Now a failing test, lint error, or broken
+Docker build blocks the deploy.
+
+**One operational note:** under `workflow_run` the GitHub OIDC token's
+`event_name` claim is `workflow_run` rather than `push`. If the GCP
+Workload Identity Federation provider ever gets an attribute condition
+pinned on `event_name`, deploy auth would break — the standard
+`google-github-actions` WIF setup binds on `repository`, not event, so
+this is not currently a problem. If a deploy ever fails at the
+"Authenticate to Google Cloud" step right after this change, that's the
+first thing to check. Rollback is a one-line revert of the `on:` trigger.
+
 ## Bootstrap (first deploy)
 
 Models must exist in GCS before scoring can produce forecasts. First
 deploy:
 
-1. Push to the target branch → CI builds + deploys the web service and
-   both Cloud Run Jobs.
+1. Push to the target branch → CI runs; **on green**, the deploy
+   workflow builds + ships the web service and both Cloud Run Jobs.
+   (A red CI blocks the deploy — see "Deploy gating" above.)
 2. Run the training job once manually so GCS has models:
 
    ```bash


### PR DESCRIPTION
Closes #146. First **Phase 2** item (deploy + observability) in the [\`prod-readiness\`](https://github.com/kristenmartino/gridpulse/issues?q=is%3Aopen+label%3Aprod-readiness) campaign.

## Problem

The external review's most legitimately serious finding: deploy ran on **every push to main, independently of CI**. A red build — failing test, lint error, broken Docker image — could ship to production. The only guard was a post-deploy `curl /` returning 200.

## Change

Both deploy workflows move from `on: push` to `on: workflow_run` gated on the **CI** workflow:

```
push to main ──▶ CI (security · lint · test · coverage · docker)
                  ├─ red  ──▶ deploy SKIPPED
                  └─ green ─▶ Deploy → Production
```

| Aspect | Before | After |
|---|---|---|
| Trigger | `push: [main]` | `workflow_run: ["CI"] / completed / [main]` |
| Gate | none | `if: workflow_run.conclusion == 'success'` |
| Deploy SHA | `github.sha` (main HEAD) | `workflow_run.head_sha` (the commit CI validated) |
| Checkout | default | pinned to validated SHA |

The **race-free SHA** matters: under `workflow_run`, a newer commit can land on main between CI passing and deploy starting. Deploying `github.sha` (HEAD) would ship un-validated code. Pinning every image tag + the checkout to `DEPLOY_SHA = workflow_run.head_sha` deploys exactly what CI tested.

Dev (`deploy-dev.yml`) gets the identical treatment for `branches: [dev]` so staging can't ship red either.

## Why `workflow_run` over `needs:` consolidation

Both are listed in the issue. `workflow_run` keeps CI and deploy as separate concerns (CI runs on PRs; deploy is main/dev-only) and avoids a perpetually-skipped deploy job appearing on every PR. The issue lists it first.

## ⚠️ Operational caveat — watch the first deploy

Under `workflow_run` the GitHub OIDC token's `event_name` claim becomes `workflow_run` instead of `push`. The standard `google-github-actions` WIF setup binds on `repository` (not event), so **auth should be unaffected** — but if the first post-merge deploy fails at "Authenticate to Google Cloud", that's the cause. Rollback is a one-line revert of the `on:` trigger. Documented in `docs/SCHEDULED_JOBS.md` → "Deploy gating".

**I'll watch the first deploy after this merges and confirm it authenticates + ships cleanly before calling it done.**

## Test plan

- ✅ All three workflow files parse as valid YAML
- ✅ CI workflow `name: CI` exactly matches `workflows: ["CI"]` reference
- ✅ Zero remaining `github.sha` references in deploy steps (all → `DEPLOY_SHA`)
- ✅ App-imports smoke test green (no Python changed — workflows + docs only)
- ⏳ **Post-merge:** confirm CI→deploy chain fires, WIF auth succeeds, image tagged with validated SHA

## Files

| File | Change |
|---|---|
| `.github/workflows/deploy-prod.yml` | trigger → workflow_run + CI-success guard + race-free SHA |
| `.github/workflows/deploy-dev.yml` | same, for dev branch |
| `docs/SCHEDULED_JOBS.md` | new "Deploy gating (CI → deploy)" section + WIF caveat + bootstrap note fix |

## Phase 2 progress

- ⏳ **#146 PR-G2 (this PR) — gate deploys behind CI**
- ⏳ #147 PR-G3 — deep /health + meaningful post-deploy smoke
- ⏳ #150 PR-G10 — alerting on training/scheduler failures