### PR TITLE
feat(health): deep /health endpoint + meaningful post-deploy smoke (PR-G3, closes #147)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -156,19 +156,59 @@ jobs:
           echo "**Image:** \`${{ env.DEPLOY_SHA }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**CI run:** [#${{ github.event.workflow_run.run_number }}](${{ github.event.workflow_run.html_url }})" >> $GITHUB_STEP_SUMMARY
 
+      # Meaningful post-deploy smoke (PR-G3 / #147). Hits /health?deep=1
+      # and applies deploy-scoped assertions:
+      #   HARD FAIL when the fresh revision is not serving, or cannot
+      #     reach Redis — both are deploy-config problems (broken image,
+      #     wrong VPC connector, bad REDIS_HOST/secret).
+      #   WARN ONLY when data is stale/empty (last_scored old, forecast
+      #     sample empty) — those are NOT caused by the deploy; the next
+      #     scoring tick fixes them and continuous monitoring (#150)
+      #     alerts on them. Rolling back a good revision for a stale-data
+      #     condition would be wrong.
       - name: Production health check
         run: |
           URL="${{ steps.url.outputs.url }}"
-          echo "Testing $URL ..."
+          echo "Probing $URL/health?deep=1 ..."
+          BODY=""
           for i in 1 2 3 4 5 6; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL/" || true)
-            if [ "$STATUS" = "200" ]; then
-              echo "Production is healthy (HTTP 200)"
-              exit 0
+            CODE=$(curl -s -o /tmp/health.json -w "%{http_code}" "$URL/health?deep=1" || true)
+            if [ "$CODE" = "200" ]; then
+              echo "App is serving (HTTP 200)"
+              BODY=$(cat /tmp/health.json)
+              break
             fi
-            echo "Attempt $i: HTTP $STATUS - retrying in 15s..."
+            echo "Attempt $i: HTTP $CODE - retrying in 15s..."
             sleep 15
           done
-          echo "Production health check failed - ROLLBACK MAY BE NEEDED"
-          echo "Run: gcloud run services update-traffic ${{ env.SERVICE }} --to-revisions=PREVIOUS_REVISION=100 --region ${{ env.REGION }}"
-          exit 1
+
+          if [ -z "$BODY" ]; then
+            echo "::error::Production not serving — /health never returned 200"
+            echo "ROLLBACK: gcloud run services update-traffic ${{ env.SERVICE }} --to-revisions=PREVIOUS=100 --region ${{ env.REGION }}"
+            exit 1
+          fi
+
+          echo "$BODY" | python3 -c "
+          import json, sys
+          d = json.load(sys.stdin)
+          print(json.dumps(d, indent=2))
+          status = d.get('status')
+          checks = d.get('checks', {})
+          redis = checks.get('redis', {})
+
+          # HARD FAIL: fresh prod revision must reach Redis (deploy-config).
+          if redis.get('status') == 'degraded':
+              print('::error::Fresh revision cannot reach Redis — check VPC connector / REDIS_HOST / secret')
+              sys.exit(1)
+
+          # WARN-ONLY: stale/empty data is not deploy-caused.
+          if status != 'healthy':
+              degraded = {k: v for k, v in checks.items() if v.get('status') == 'degraded'}
+              print(f'::warning::Deploy is serving + Redis reachable, but health is degraded (monitoring concern, not a deploy failure): {list(degraded)}')
+
+          print('Deploy smoke passed: serving + Redis reachable.')
+          " || exit 1
+
+          {
+            echo "**Post-deploy health:** \`$(echo "$BODY" | python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')\`"
+          } >> $GITHUB_STEP_SUMMARY

--- a/app.py
+++ b/app.py
@@ -176,18 +176,21 @@ if PRECOMPUTE_ENABLED:
 # ── Health check for Cloud Run ─────────────────────────────────
 @server.route("/health")
 def health():
-    from components.callbacks import _BACKTEST_CACHE, _MODEL_CACHE, _PREDICTION_CACHE
+    """Health endpoint (PR-G3 / #147).
 
-    return jsonify(
-        {
-            "status": "healthy",
-            "precompute": {
-                "models_cached": len(_MODEL_CACHE),
-                "predictions_cached": len(_PREDICTION_CACHE),
-                "backtests_cached": len(_BACKTEST_CACHE),
-            },
-        }
-    ), 200
+    Shallow by default (process + caches + Redis ping + last-scored
+    freshness); pass ``?deep=1`` to additionally validate a real
+    forecast payload. Always HTTP 200 — health is carried in the
+    ``status`` body field so a degraded-but-serving instance isn't
+    killed by the load balancer. See ``health.build_health_report``.
+    """
+    from flask import request as flask_request
+
+    from health import build_health_report
+
+    deep = flask_request.args.get("deep", "").lower() in ("1", "true", "yes")
+    body, code = build_health_report(deep=deep)
+    return jsonify(body), code
 
 
 # ── Performance metrics endpoint (internal only) ───────────────

--- a/health.py
+++ b/health.py
@@ -1,0 +1,211 @@
+"""Application health reporting for the ``/health`` endpoint (PR-G3 / #147).
+
+Two depths:
+
+* **shallow** (default ``/health``) — process-up + in-memory cache counts
+  + Redis ping + last-scored freshness. All cheap, safe for frequent
+  liveness polling (the Dockerfile ``HEALTHCHECK`` and Cloud Run / load
+  balancer probes hit this).
+* **deep** (``/health?deep=1``) — additionally reads a real forecast
+  payload from Redis and validates its shape. Heavier (deserializes a
+  full forecast), so it's opt-in: the post-deploy smoke check and ops
+  monitoring use it, the liveness probe does not.
+
+Status semantics:
+
+* ``"healthy"`` — every check that matters *in this environment* passed.
+* ``"degraded"`` — the process is up and serving, but a check that
+  matters here failed (Redis unreachable in production, forecasts
+  stale, forecast payload malformed).
+
+The endpoint returns **HTTP 200 in both cases**. A degraded-but-serving
+instance (e.g. cold Redis during warming) renders the correct "warming"
+UI and must NOT be killed by the load balancer — so health is carried in
+the ``status`` *field*, not the HTTP code. Consumers that care about full
+functionality (deploy smoke, monitoring) read ``status``.
+
+Redis-dependent checks are gated on ``config.REQUIRE_REDIS``: when Redis
+isn't required (development / CI containers), its absence is reported as
+``"skipped"`` rather than ``"degraded"``, so a Redis-less container still
+reports ``healthy``. This keeps the CI Docker health check (which runs
+the container with no Redis) green.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+# Scoring runs hourly (cron ``0 * * * *``). Allowing for ~12 min job
+# runtime + EIA publishing lag, anything older than 90 minutes means a
+# full scoring cycle was missed — that's the degraded threshold.
+LAST_SCORED_STALE_SECONDS = 90 * 60
+
+
+def _check_redis() -> dict[str, Any]:
+    """Ping Redis. Gated on REQUIRE_REDIS — absence is only a problem when
+    Redis is the required source of truth (staging / production)."""
+    from config import REQUIRE_REDIS
+    from data.redis_client import redis_available
+
+    required = bool(REQUIRE_REDIS)
+    try:
+        up = redis_available()
+    except Exception as exc:  # pragma: no cover — defensive
+        up = False
+        return {
+            "status": "degraded" if required else "skipped",
+            "required": required,
+            "up": False,
+            "error": str(exc),
+        }
+
+    if up:
+        return {"status": "ok", "required": required, "up": True}
+    # Redis down
+    return {
+        "status": "degraded" if required else "skipped",
+        "required": required,
+        "up": False,
+    }
+
+
+def _check_last_scored() -> dict[str, Any]:
+    """Read ``gridpulse:meta:last_scored`` and report its age.
+
+    Only meaningful when Redis is up. When Redis is required and the
+    last scoring run is older than ``LAST_SCORED_STALE_SECONDS`` (or the
+    marker is missing entirely), the check is degraded.
+    """
+    from config import REQUIRE_REDIS
+    from data.redis_client import redis_available, redis_get, redis_key
+
+    required = bool(REQUIRE_REDIS)
+    try:
+        if not redis_available():
+            return {"status": "skipped", "reason": "redis_unavailable"}
+        payload = redis_get(redis_key("meta:last_scored"))
+    except Exception as exc:  # pragma: no cover — defensive
+        return {"status": "degraded" if required else "skipped", "error": str(exc)}
+
+    if not isinstance(payload, dict) or "updated_at" not in payload:
+        # No scoring marker yet (fresh deploy, pre-first-run). Degraded
+        # only when Redis is required — otherwise we don't expect one.
+        return {
+            "status": "degraded" if required else "skipped",
+            "reason": "no_last_scored_marker",
+        }
+
+    try:
+        updated = datetime.fromisoformat(payload["updated_at"])
+        if updated.tzinfo is None:
+            updated = updated.replace(tzinfo=UTC)
+        age = (datetime.now(UTC) - updated).total_seconds()
+    except (ValueError, TypeError) as exc:
+        return {"status": "degraded" if required else "skipped", "error": str(exc)}
+
+    stale = age > LAST_SCORED_STALE_SECONDS
+    return {
+        "status": "degraded" if (stale and required) else "ok",
+        "age_seconds": int(age),
+        "threshold_seconds": LAST_SCORED_STALE_SECONDS,
+        "stale": stale,
+        "updated_at": payload["updated_at"],
+    }
+
+
+def _check_forecast_sample() -> dict[str, Any]:
+    """Validate one real forecast payload can be read + has the expected
+    shape. The heavy check (deserializes a full forecast), so deep-only.
+
+    Reads ``gridpulse:forecast:{PRECOMPUTE_DEFAULT_REGION}:1h`` and
+    asserts a non-empty ``forecasts`` list whose first row carries a
+    numeric ``predicted_demand_mw``.
+    """
+    from config import PRECOMPUTE_DEFAULT_REGION, REQUIRE_REDIS
+    from data.redis_client import redis_available, redis_get, redis_key
+
+    required = bool(REQUIRE_REDIS)
+    region = PRECOMPUTE_DEFAULT_REGION
+    try:
+        if not redis_available():
+            return {"status": "skipped", "reason": "redis_unavailable"}
+        payload = redis_get(redis_key(f"forecast:{region}:1h"))
+    except Exception as exc:  # pragma: no cover — defensive
+        return {"status": "degraded" if required else "skipped", "error": str(exc)}
+
+    if not isinstance(payload, dict):
+        return {
+            "status": "degraded" if required else "skipped",
+            "region": region,
+            "reason": "no_forecast_payload",
+        }
+
+    forecasts = payload.get("forecasts")
+    if not isinstance(forecasts, list) or not forecasts:
+        return {
+            "status": "degraded" if required else "skipped",
+            "region": region,
+            "reason": "empty_forecasts",
+        }
+
+    first = forecasts[0]
+    if not isinstance(first, dict) or not isinstance(
+        first.get("predicted_demand_mw"), (int, float)
+    ):
+        return {
+            "status": "degraded" if required else "skipped",
+            "region": region,
+            "reason": "malformed_forecast_row",
+        }
+
+    return {
+        "status": "ok",
+        "region": region,
+        "rows": len(forecasts),
+    }
+
+
+def build_health_report(deep: bool = False) -> tuple[dict[str, Any], int]:
+    """Build the ``/health`` response body + HTTP status code.
+
+    Args:
+        deep: When True, additionally runs the forecast-payload check.
+
+    Returns:
+        ``(body, http_status)``. ``http_status`` is always 200 — see the
+        module docstring for why a degraded instance still returns 200.
+    """
+    # In-memory cache counts (cheap, no I/O) — preserved from the original
+    # shallow /health for continuity with existing dashboards.
+    try:
+        from components.callbacks import _BACKTEST_CACHE, _MODEL_CACHE, _PREDICTION_CACHE
+
+        precompute = {
+            "models_cached": len(_MODEL_CACHE),
+            "predictions_cached": len(_PREDICTION_CACHE),
+            "backtests_cached": len(_BACKTEST_CACHE),
+        }
+    except Exception:  # pragma: no cover — defensive
+        precompute = {}
+
+    checks: dict[str, Any] = {
+        "redis": _check_redis(),
+        "last_scored": _check_last_scored(),
+    }
+    if deep:
+        checks["forecast_sample"] = _check_forecast_sample()
+
+    # Overall: degraded if any check is degraded; otherwise healthy.
+    # "skipped" and "ok" both count as not-degraded.
+    degraded = any(c.get("status") == "degraded" for c in checks.values())
+    status = "degraded" if degraded else "healthy"
+
+    body = {
+        "status": status,
+        "deep": deep,
+        "checks": checks,
+        "precompute": precompute,
+    }
+    # Always 200 — see module docstring. Status is carried in the body.
+    return body, 200

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,244 @@
+"""Unit tests for health.py — the deep /health report (PR-G3 / #147).
+
+Covers the three checks (redis / last_scored / forecast_sample), their
+REQUIRE_REDIS gating, and the overall status aggregation. Redis helpers
+are patched at ``data.redis_client.*`` and the env flag at
+``config.REQUIRE_REDIS`` — health.py imports both lazily inside each
+function, so source-module patches take effect per call.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import health
+
+# ── _check_redis ─────────────────────────────────────────────────────
+
+
+class TestCheckRedis:
+    def test_required_and_up_is_ok(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("data.redis_client.redis_available", return_value=True),
+        ):
+            r = health._check_redis()
+        assert r["status"] == "ok"
+        assert r["required"] is True
+        assert r["up"] is True
+
+    def test_required_and_down_is_degraded(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("data.redis_client.redis_available", return_value=False),
+        ):
+            r = health._check_redis()
+        assert r["status"] == "degraded"
+
+    def test_not_required_and_down_is_skipped(self):
+        """Dev / CI: Redis absence is expected, not a health failure."""
+        with (
+            patch("config.REQUIRE_REDIS", False),
+            patch("data.redis_client.redis_available", return_value=False),
+        ):
+            r = health._check_redis()
+        assert r["status"] == "skipped"
+
+
+# ── _check_last_scored ───────────────────────────────────────────────
+
+
+class TestCheckLastScored:
+    def _meta(self, *, minutes_ago: float) -> dict:
+        ts = (datetime.now(UTC) - timedelta(minutes=minutes_ago)).isoformat()
+        return {"updated_at": ts, "regions_scored": 51, "mode": "scoring-job"}
+
+    def test_fresh_marker_is_ok(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch("data.redis_client.redis_get", return_value=self._meta(minutes_ago=10)),
+        ):
+            r = health._check_last_scored()
+        assert r["status"] == "ok"
+        assert r["stale"] is False
+        assert r["age_seconds"] < health.LAST_SCORED_STALE_SECONDS
+
+    def test_stale_marker_required_is_degraded(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch("data.redis_client.redis_get", return_value=self._meta(minutes_ago=180)),
+        ):
+            r = health._check_last_scored()
+        assert r["status"] == "degraded"
+        assert r["stale"] is True
+
+    def test_stale_marker_not_required_is_ok(self):
+        """When Redis isn't required, staleness isn't held against health."""
+        with (
+            patch("config.REQUIRE_REDIS", False),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch("data.redis_client.redis_get", return_value=self._meta(minutes_ago=180)),
+        ):
+            r = health._check_last_scored()
+        assert r["status"] == "ok"  # stale, but not required → not degraded
+
+    def test_missing_marker_required_is_degraded(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch("data.redis_client.redis_get", return_value=None),
+        ):
+            r = health._check_last_scored()
+        assert r["status"] == "degraded"
+        assert r["reason"] == "no_last_scored_marker"
+
+    def test_redis_down_is_skipped(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("data.redis_client.redis_available", return_value=False),
+        ):
+            r = health._check_last_scored()
+        assert r["status"] == "skipped"
+
+    def test_naive_timestamp_is_treated_as_utc(self):
+        """A marker written without tzinfo must not crash the age math."""
+        naive = (datetime.now(UTC).replace(tzinfo=None) - timedelta(minutes=5)).isoformat()
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch("data.redis_client.redis_get", return_value={"updated_at": naive}),
+        ):
+            r = health._check_last_scored()
+        assert r["status"] == "ok"
+
+
+# ── _check_forecast_sample ───────────────────────────────────────────
+
+
+class TestCheckForecastSample:
+    def _good_payload(self) -> dict:
+        return {
+            "forecasts": [
+                {"timestamp": "2026-05-29T00:00:00+00:00", "predicted_demand_mw": 18342.0},
+                {"timestamp": "2026-05-29T01:00:00+00:00", "predicted_demand_mw": 17900.0},
+            ]
+        }
+
+    def test_valid_payload_is_ok(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("config.PRECOMPUTE_DEFAULT_REGION", "FPL"),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch("data.redis_client.redis_get", return_value=self._good_payload()),
+        ):
+            r = health._check_forecast_sample()
+        assert r["status"] == "ok"
+        assert r["rows"] == 2
+        assert r["region"] == "FPL"
+
+    def test_empty_forecasts_required_is_degraded(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("config.PRECOMPUTE_DEFAULT_REGION", "FPL"),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch("data.redis_client.redis_get", return_value={"forecasts": []}),
+        ):
+            r = health._check_forecast_sample()
+        assert r["status"] == "degraded"
+        assert r["reason"] == "empty_forecasts"
+
+    def test_malformed_row_required_is_degraded(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("config.PRECOMPUTE_DEFAULT_REGION", "FPL"),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch(
+                "data.redis_client.redis_get",
+                return_value={"forecasts": [{"timestamp": "x"}]},  # no predicted_demand_mw
+            ),
+        ):
+            r = health._check_forecast_sample()
+        assert r["status"] == "degraded"
+        assert r["reason"] == "malformed_forecast_row"
+
+    def test_no_payload_not_required_is_skipped(self):
+        with (
+            patch("config.REQUIRE_REDIS", False),
+            patch("config.PRECOMPUTE_DEFAULT_REGION", "FPL"),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch("data.redis_client.redis_get", return_value=None),
+        ):
+            r = health._check_forecast_sample()
+        assert r["status"] == "skipped"
+
+
+# ── build_health_report ──────────────────────────────────────────────
+
+
+class TestBuildHealthReport:
+    def test_shallow_omits_forecast_sample(self):
+        with (
+            patch("config.REQUIRE_REDIS", False),
+            patch("data.redis_client.redis_available", return_value=False),
+        ):
+            body, code = health.build_health_report(deep=False)
+        assert code == 200
+        assert body["deep"] is False
+        assert "redis" in body["checks"]
+        assert "last_scored" in body["checks"]
+        assert "forecast_sample" not in body["checks"]
+
+    def test_deep_includes_forecast_sample(self):
+        with (
+            patch("config.REQUIRE_REDIS", False),
+            patch("data.redis_client.redis_available", return_value=False),
+        ):
+            body, code = health.build_health_report(deep=True)
+        assert body["deep"] is True
+        assert "forecast_sample" in body["checks"]
+
+    def test_ci_like_no_redis_reports_healthy(self):
+        """The CI Docker container runs with no Redis + REQUIRE_REDIS
+        false. All Redis checks skip → overall healthy → keeps the CI
+        docker health assertion (status == 'healthy') green."""
+        with (
+            patch("config.REQUIRE_REDIS", False),
+            patch("data.redis_client.redis_available", return_value=False),
+        ):
+            body, code = health.build_health_report(deep=True)
+        assert code == 200
+        assert body["status"] == "healthy"
+
+    def test_production_redis_down_reports_degraded(self):
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("data.redis_client.redis_available", return_value=False),
+        ):
+            body, code = health.build_health_report(deep=True)
+        assert code == 200  # still 200 — degraded ≠ down
+        assert body["status"] == "degraded"
+        assert body["checks"]["redis"]["status"] == "degraded"
+
+    def test_always_returns_200_even_when_degraded(self):
+        """A degraded instance must stay 200 so the load balancer doesn't
+        kill a warming-but-serving container."""
+        with (
+            patch("config.REQUIRE_REDIS", True),
+            patch("data.redis_client.redis_available", return_value=True),
+            patch("data.redis_client.redis_get", return_value=None),  # no marker → degraded
+        ):
+            body, code = health.build_health_report(deep=False)
+        assert code == 200
+        assert body["status"] == "degraded"
+
+    def test_precompute_counts_present(self):
+        with (
+            patch("config.REQUIRE_REDIS", False),
+            patch("data.redis_client.redis_available", return_value=False),
+        ):
+            body, _ = health.build_health_report()
+        assert "precompute" in body
+        assert "models_cached" in body["precompute"]


### PR DESCRIPTION
Closes #147. Second **Phase 2** item in the [\`prod-readiness\`](https://github.com/kristenmartino/gridpulse/issues?q=is%3Aopen+label%3Aprod-readiness) campaign.

## Problem

`/health` returned `status: healthy` unconditionally — HTTP 200 even with Redis unreachable or forecasts stale. The deploy-prod post-deploy check only verified `curl /` → 200, a near-meaningless regression guard.

## New: `health.build_health_report(deep)`

A testable module (`health.py`) running real checks:

| Check | What | Degraded when |
|---|---|---|
| `redis` | ping | `REQUIRE_REDIS` + unreachable (else `skipped`) |
| `last_scored` | age of `gridpulse:meta:last_scored` | required + > 90 min (missed hourly cycle) |
| `forecast_sample` *(deep only)* | reads `forecast:{default}:1h`, validates shape | required + missing/empty/malformed |

**Status semantics:** `healthy` when every env-relevant check passes, `degraded` when one fails — but **always HTTP 200**. A degraded-but-serving instance (cold Redis during warming) renders the correct "warming" UI and must not be killed by the load balancer. Health lives in the `status` *field*, which deploy-smoke + monitoring read.

**Depth:** `/health` shallow by default (ping + tiny meta read → safe for frequent liveness polling). `?deep=1` adds the heavier forecast-payload read.

## CI compatibility (the tricky part)

The CI Docker container runs with **no Redis + `REQUIRE_REDIS=false`**. All Redis checks `skip` → overall `healthy` → the existing `assert status=='healthy'` docker check **stays green without modification**. `redis_client._get_redis()` returns None instantly when `REDIS_HOST` is unset (no hang). Confirmed in `test_ci_like_no_redis_reports_healthy`.

## Post-deploy smoke — correctly scoped

Rewrote deploy-prod's health step to hit `/health?deep=1` with deploy-appropriate severity:

- **HARD FAIL** — not serving, or `redis` check `degraded`. Both are deploy-config problems (broken image, wrong VPC connector, bad `REDIS_HOST`/secret). A fresh prod revision *must* reach its data store.
- **WARN ONLY** — stale/empty data (`last_scored` old, forecast empty). Not deploy-caused; the next scoring tick fixes it and continuous monitoring (#150) alerts on it. Rolling back a good revision for a stale-data condition would be wrong.

## Test plan

- ✅ 19 new unit tests (`test_health.py`): each check's ok/degraded/skipped paths, `REQUIRE_REDIS` gating, naive-timestamp handling, always-200 invariant, CI-no-Redis-stays-healthy
- ✅ Route wiring verified via Flask test client (`/health` + `/health?deep=1`)
- ✅ Full unit suite: **1751 passed** (1732 + 19)
- ✅ Lint + format clean
- ⏳ Post-merge: the gated deploy's smoke step now exercises `?deep=1` against live prod (Redis warm) — expect `status: healthy`

## Files

| File | Change |
|---|---|
| `health.py` *(new)* | `build_health_report` + 3 checks |
| `app.py` | `/health` route reads `?deep=`, delegates to `build_health_report` |
| `.github/workflows/deploy-prod.yml` | meaningful post-deploy smoke (hard-fail serving/Redis, warn-only on stale data) |
| `tests/unit/test_health.py` *(new)* | 19 tests |

## Phase 2 progress

- ✅ #146 PR-G2 — gate deploys behind CI *(merged + prod-verified)*
- ⏳ **#147 PR-G3 (this PR) — deep /health**
- ⏳ #150 PR-G10 — alerting on training/scheduler failures