### PR TITLE
fix(features): impute sparse weather instead of collapsing rows [P0 mitigation] (#161)

### DIFF
--- a/data/feature_engineering.py
+++ b/data/feature_engineering.py
@@ -85,16 +85,41 @@ def engineer_features(df: pd.DataFrame) -> pd.DataFrame:
     if "temperature_2m" in df.columns and "hour_sin" in df.columns:
         df["temp_x_hour"] = compute_temp_hour_interaction(df["temperature_2m"], df["hour_sin"])
 
-    # --- Drop rows with NaN (from lag/rolling features at the start) ---
+    # --- Impute exogenous (weather) features, then drop only on the
+    #     demand-derived autoregressive warm-up (#161, 2026-05-29) ---
+    #
+    # Previously this did ``dropna(subset=<all feature cols>)``, which
+    # dropped a row if ANY of the ~50 features was NaN. That made a single
+    # sparse exogenous column able to collapse the entire row set: in the
+    # 2026-05-29 incident Open-Meteo's /forecast endpoint degraded its
+    # historical coverage and ``soil_temperature_0cm`` arrived non-null for
+    # only ~100 of ~2100 rows — dragging every region below the 168-row
+    # model threshold and taking down forecasts nationwide.
+    #
+    # A weather provider dropping one variable's coverage should degrade
+    # that feature, not zero out all forecasts. So: impute the exogenous
+    # (weather, raw + derived) columns — ffill → bfill → 0, the same
+    # NaN-defense Prophet/SARIMAX already apply to their regressors at
+    # predict time — and ``dropna`` only on the demand-derived
+    # autoregressive features, whose sole legitimate NaN is the lag/rolling
+    # warm-up prefix we genuinely want gone.
+    feature_cols = _get_feature_columns(df)
+    autoregressive = [c for c in AUTOREGRESSIVE_DEMAND_FEATURES if c in df.columns]
+    impute_cols = [c for c in feature_cols if c not in autoregressive]
+    if impute_cols:
+        df[impute_cols] = df[impute_cols].ffill().bfill().fillna(0.0)
+
     initial_rows = len(df)
-    df = df.dropna(subset=_get_feature_columns(df)).reset_index(drop=True)
+    drop_subset = autoregressive or feature_cols  # fall back if no AR cols present
+    df = df.dropna(subset=drop_subset).reset_index(drop=True)
     dropped = initial_rows - len(df)
 
     log.info(
         "feature_engineering_complete",
         output_rows=len(df),
         dropped_rows=dropped,
-        feature_count=len(_get_feature_columns(df)),
+        feature_count=len(feature_cols),
+        imputed_exogenous_cols=len(impute_cols),
     )
 
     return df

--- a/tests/unit/test_feature_engineering.py
+++ b/tests/unit/test_feature_engineering.py
@@ -255,6 +255,57 @@ class TestEngineerFeatures:
         result = engineer_features(pd.DataFrame())
         assert result.empty
 
+    # ── #161 regression: a sparse exogenous weather column must NOT
+    #    collapse the feature-row set below the model threshold ──
+
+    def test_fully_nan_weather_column_does_not_collapse_rows(self, merged_df):
+        """The 2026-05-29 P0: Open-Meteo served ``soil_temperature_0cm``
+        non-null for only ~100 of ~2100 rows. The old
+        ``dropna(subset=<all features>)`` collapsed every region below
+        the 168-row threshold → forecasts down nationwide.
+
+        With one weather column entirely NaN, the row count must stay
+        healthy (≈ input − warm-up), not collapse — that column is
+        imputed, not used to drop rows.
+        """
+        df = merged_df.copy()
+        df["soil_temperature_0cm"] = np.nan  # simulate the outage
+
+        result = engineer_features(df)
+
+        # Should keep ~all rows minus the ~168h autoregressive warm-up,
+        # NOT collapse to near-zero. Generous lower bound well above the
+        # 168-row model threshold.
+        assert len(result) > len(merged_df) - 250, (
+            f"sparse weather column collapsed rows to {len(result)} "
+            f"(input {len(merged_df)}) — #161 regression"
+        )
+        assert len(result) >= 168
+
+    def test_partially_sparse_weather_is_imputed(self, merged_df):
+        """A weather column missing its older 80% (the real incident
+        shape — recent data present, history dropped) must be imputed,
+        leaving no residual NaN and a healthy row count."""
+        df = merged_df.copy()
+        cutoff = int(len(df) * 0.8)
+        df.loc[df.index[:cutoff], "temperature_2m"] = np.nan
+
+        result = engineer_features(df)
+
+        feature_cols = [
+            c for c in result.select_dtypes(include=[np.number]).columns if c not in {"forecast_mw"}
+        ]
+        assert result[feature_cols].isna().sum().sum() == 0  # imputed, no residual NaN
+        assert len(result) >= 168
+
+    def test_autoregressive_warmup_still_dropped(self, merged_df):
+        """The fix must NOT stop dropping the legitimate lag/rolling
+        warm-up prefix — demand-derived features remain the drop subset."""
+        result = engineer_features(merged_df)
+        # demand_lag_168h is NaN for the first 168 rows; none should survive
+        assert result["demand_lag_168h"].isna().sum() == 0
+        assert len(result) < len(merged_df)  # warm-up was dropped
+
 
 class TestGetFeatureNames:
     """Feature name listing."""


### PR DESCRIPTION
**P0 mitigation for #161** — restores forecasts for all 51 regions.

## The outage

All regions stopped producing forecasts (2026-05-29). Open-Meteo's `/forecast?past_days=92` degraded its historical coverage; `soil_temperature_0cm` arrived non-null for only ~100 of ~2100 rows. `engineer_features` ended with `dropna(subset=<all 50 features>)` — drop a row if **any** feature is NaN — so one near-empty weather column collapsed every region to ~103 rows, below the 168-row model threshold → no forecast written.

**Caught by the deep `/health` check (#147) on its first production run.** The `curl / → 200` it replaced reported everything healthy throughout.

## Fix (option A of #161)

A weather provider dropping one variable's coverage should degrade that feature, not take down all forecasts nationwide. In `engineer_features`:

- **Impute** exogenous weather (raw + derived) columns: `ffill → bfill → 0` — the same NaN-defense Prophet/SARIMAX already apply to regressors at predict time.
- **`dropna` only on the demand-derived autoregressive features** — their sole legitimate NaN is the lag/rolling warm-up prefix we *want* dropped.

## Verified against the live degraded feed

| Region | before | after |
|---|---|---|
| FPL | 103 | **2009** |
| ERCOT | 103 | **2009** |
| CAISO | 103 | **2009** |

Zero residual NaN; all clear the 168 threshold.

## Tests (3 new)

- `test_fully_nan_weather_column_does_not_collapse_rows` — the exact #161 shape (one weather col entirely NaN) keeps a healthy row count
- `test_partially_sparse_weather_is_imputed` — older-80%-missing column imputed, no residual NaN
- `test_autoregressive_warmup_still_dropped` — fix doesn't stop dropping the legitimate warm-up prefix

Full suite: **1754 passed** (1751 + 3). Lint clean.

## Deploy plan

Merge → CI-gated deploy updates the scoring-job image. The job doesn't auto-execute, so I'll **manually trigger a scoring run** post-deploy to restore forecasts immediately rather than waiting for the hourly cron, then re-check `/health?deep=1` → expect `forecast_sample: ok`.

## Follow-up

**#161 option C** (separate PR): source historical weather from the archive endpoint (`fetch_historical_weather`, already exists) instead of `/forecast?past_days=92` — restores full *real* historical coverage for both scoring and training. This PR is the mitigation; C is the proper fix.

Partially addresses #161.