### PR TITLE
fix(weather): stitch archive (ERA5) history + forecast — proper P0 fix (#161 option C)

### DIFF
--- a/data/weather_client.py
+++ b/data/weather_client.py
@@ -6,8 +6,14 @@ centroid. No API key required for non-commercial use.
 
 Key design decisions:
 - Always request Fahrenheit/mph (CDD/HDD use 65°F baseline, sliders use mph)
-- &past_days=92 seamlessly joins 3 months historical with 7-day forecast
-- All 17 weather variables fetched in a single call per region
+- ``fetch_weather`` stitches the archive (ERA5) endpoint for deep history
+  with the /forecast endpoint for recent + future (#161). The older
+  single ``/forecast?past_days=92`` call silently degraded its historical
+  coverage in 2026-05, so the bulk of history now comes from the archive
+  endpoint, which is purpose-built for it.
+- All 17 weather variables requested; the archive endpoint lacks 3 of
+  them (wind_speed_80m/120m, soil_temperature_0cm) on deep history —
+  those stay imputed by ``engineer_features`` (see #161).
 
 API docs: https://open-meteo.com/en/docs
 """
@@ -30,6 +36,96 @@ log = structlog.get_logger()
 # Open-Meteo is generous with rate limits, but be respectful
 REQUEST_TIMEOUT = 30
 
+# ERA5 archive reanalysis lags real-time by ~5 days. Beyond that boundary
+# only the /forecast endpoint has data; before it the archive has full
+# coverage for 14 of the 17 variables. The 3 it lacks
+# (wind_speed_80m/120m, soil_temperature_0cm) stay imputed on deep history
+# by ``data.feature_engineering.engineer_features`` (#161 option A).
+ARCHIVE_LAG_DAYS = 5
+ARCHIVE_URL = "https://archive-api.open-meteo.com/v1/archive"
+
+
+def _fetch_forecast_endpoint(region: str, past_days: int, forecast_days: int) -> pd.DataFrame:
+    """Lean GET against Open-Meteo's /forecast endpoint (recent + future).
+
+    No cache / GCS / fallback of its own — ``fetch_weather`` owns those
+    once for the combined result. Raises ``requests.RequestException`` on
+    HTTP failure so the caller can run the existing fallback chain.
+    """
+    coords = REGION_COORDINATES[region]
+    params = {
+        "latitude": coords["lat"],
+        "longitude": coords["lon"],
+        "hourly": ",".join(WEATHER_VARIABLES),
+        "past_days": past_days,
+        "forecast_days": forecast_days,
+        "temperature_unit": "fahrenheit",
+        "wind_speed_unit": "mph",
+        "timezone": "UTC",
+    }
+    resp = requests.get(f"{OPEN_METEO_BASE_URL}/forecast", params=params, timeout=REQUEST_TIMEOUT)
+    resp.raise_for_status()
+    return _parse_weather_response(resp.json())
+
+
+def _fetch_archive_endpoint(region: str, start_date: str, end_date: str) -> pd.DataFrame:
+    """Lean GET against Open-Meteo's archive (ERA5) endpoint for deep history.
+
+    No cache / fallback of its own (distinct from the public
+    ``fetch_historical_weather``, which has both — reusing that here would
+    pollute ``fetch_weather``'s cache-call accounting). Raises
+    ``requests.RequestException`` on HTTP failure.
+    """
+    coords = REGION_COORDINATES[region]
+    params = {
+        "latitude": coords["lat"],
+        "longitude": coords["lon"],
+        "hourly": ",".join(WEATHER_VARIABLES),
+        "start_date": start_date,
+        "end_date": end_date,
+        "temperature_unit": "fahrenheit",
+        "wind_speed_unit": "mph",
+        "timezone": "UTC",
+    }
+    resp = requests.get(ARCHIVE_URL, params=params, timeout=REQUEST_TIMEOUT)
+    resp.raise_for_status()
+    return _parse_weather_response(resp.json())
+
+
+def _stitch_weather(
+    archive_df: pd.DataFrame | None,
+    forecast_df: pd.DataFrame,
+    boundary: pd.Timestamp,
+) -> pd.DataFrame:
+    """Combine archive history (ts <= boundary) with forecast (ts > boundary).
+
+    Archive (ERA5 reanalysis) is preferred for the overlap region because
+    it's more accurate for past hours than the forecast model's backfill.
+    Concatenates, de-dups on timestamp (keeping the archive row in any
+    tie), and sorts ascending.
+    """
+    parts: list[pd.DataFrame] = []
+    if archive_df is not None and not archive_df.empty:
+        a = archive_df.copy()
+        a["timestamp"] = pd.to_datetime(a["timestamp"], utc=True)
+        parts.append(a[a["timestamp"] <= boundary])
+    if forecast_df is not None and not forecast_df.empty:
+        f = forecast_df.copy()
+        f["timestamp"] = pd.to_datetime(f["timestamp"], utc=True)
+        parts.append(f[f["timestamp"] > boundary])
+
+    if not parts:
+        return pd.DataFrame(columns=["timestamp"] + WEATHER_VARIABLES)
+
+    combined = pd.concat(parts, ignore_index=True)
+    # archive rows were appended first; keep="first" prefers them on a tie
+    combined = (
+        combined.drop_duplicates(subset="timestamp", keep="first")
+        .sort_values("timestamp")
+        .reset_index(drop=True)
+    )
+    return combined
+
 
 def fetch_weather(
     region: str,
@@ -40,20 +136,29 @@ def fetch_weather(
     """
     Fetch historical + forecast weather data for a balancing authority centroid.
 
-    Uses Open-Meteo's &past_days parameter to seamlessly join historical
-    data with the forecast in a single API call.
+    Stitches two Open-Meteo endpoints (#161):
+
+    * **/forecast** — recent days + the ``forecast_days`` horizon. Fetched
+      first; it's the data the demand forecast actually consumes, and its
+      failure drives the stale-cache → GCS → empty fallback chain.
+    * **archive (ERA5)** — the deep historical window
+      ``[today-past_days, today-ARCHIVE_LAG_DAYS]``. Fetched second as
+      enrichment; archive failure degrades gracefully to forecast-only.
+
+    The older single ``/forecast?past_days=92`` call silently lost most of
+    its historical coverage in 2026-05 (one variable down to ~5% of rows),
+    which collapsed the feature pipeline below the model threshold and
+    took down forecasts for all regions — see #161. Sourcing deep history
+    from the purpose-built archive endpoint restores ~full coverage for
+    14 of 17 variables; the 3 the archive lacks (wind_speed_80m/120m,
+    soil_temperature_0cm) stay imputed by ``engineer_features``.
 
     Args:
         region: Balancing authority code (e.g., "ERCOT", "FPL").
-        past_days: Number of historical days to include (default 92 = ~3 months).
-        forecast_days: Number of forecast days (default
-            ``config.OPEN_METEO_FORECAST_DAYS`` = 16 = Open-Meteo's free GFS
-            forecast horizon; 384 hourly rows). Bumped from 7 → 16 on
-            2026-05-20 (PR-C of the forecast-pipeline audit) so the scoring
-            job's 720-hour demand forecast can use actual weather forecasts
-            for the first ~53% of its horizon instead of falling back to
-            climatology for everything beyond day 7. The remaining 47%
-            (days 17-30) is climatology by design — see ADR-008 in PRD.md.
+        past_days: Total historical days to include (default 92 = ~3 months).
+        forecast_days: Forecast horizon days (default
+            ``config.OPEN_METEO_FORECAST_DAYS`` = 16, Open-Meteo's free GFS
+            horizon). See ADR-008 in PRD.md.
         use_cache: Whether to check cache first.
 
     Returns:
@@ -73,27 +178,9 @@ def fetch_weather(
     coords = REGION_COORDINATES[region]
     log.info("weather_fetching", region=region, lat=coords["lat"], lon=coords["lon"])
 
-    params = {
-        "latitude": coords["lat"],
-        "longitude": coords["lon"],
-        "hourly": ",".join(WEATHER_VARIABLES),
-        "past_days": past_days,
-        "forecast_days": forecast_days,
-        "temperature_unit": "fahrenheit",
-        "wind_speed_unit": "mph",
-        "timezone": "UTC",
-    }
-
-    try:
-        resp = requests.get(
-            f"{OPEN_METEO_BASE_URL}/forecast",
-            params=params,
-            timeout=REQUEST_TIMEOUT,
-        )
-        resp.raise_for_status()
-        data = resp.json()
-    except requests.RequestException as e:
-        log.error("weather_request_failed", region=region, error=str(e))
+    def _fallback(reason: str) -> pd.DataFrame:
+        """Shared stale-cache → GCS → empty fallback (unchanged behavior)."""
+        log.warning("weather_request_failed", region=region, reason=reason)
         stale = cache.get(cache_key, allow_stale=True)
         if stale is not None:
             return stale
@@ -105,25 +192,50 @@ def fetch_weather(
             return gcs_df
         return pd.DataFrame(columns=["timestamp"] + WEATHER_VARIABLES)
 
-    df = _parse_weather_response(data)
-    if df.empty:
-        log.warning("weather_empty_response", region=region)
-        stale = cache.get(cache_key, allow_stale=True)
-        if stale is not None:
-            return stale
-        from data.gcs_store import read_parquet
+    # 1. Forecast endpoint (recent + future). Short past_days — just enough
+    #    to overlap the archive boundary; deep history comes from archive.
+    try:
+        forecast_df = _fetch_forecast_endpoint(region, ARCHIVE_LAG_DAYS + 2, forecast_days)
+    except requests.RequestException as e:
+        return _fallback(str(e))
 
-        gcs_df = read_parquet("weather", region)
-        if gcs_df is not None and not gcs_df.empty:
-            log.info("weather_gcs_fallback", region=region, rows=len(gcs_df))
-            return gcs_df
-        return df
+    if forecast_df.empty:
+        return _fallback("empty_forecast_response")
+
+    # 2. Archive endpoint (deep history). Enrichment only — on failure we
+    #    keep the forecast-only result rather than dropping to fallback.
+    from datetime import UTC, datetime, timedelta
+
+    today = datetime.now(UTC).date()
+    boundary = pd.Timestamp(today - timedelta(days=ARCHIVE_LAG_DAYS), tz="UTC") + pd.Timedelta(
+        hours=23
+    )
+    archive_df: pd.DataFrame | None = None
+    try:
+        archive_df = _fetch_archive_endpoint(
+            region,
+            (today - timedelta(days=past_days)).isoformat(),
+            (today - timedelta(days=ARCHIVE_LAG_DAYS)).isoformat(),
+        )
+    except requests.RequestException as e:
+        log.warning("weather_archive_failed_forecast_only", region=region, error=str(e))
+
+    # 3. Stitch. Never return empty when forecast had data.
+    df = _stitch_weather(archive_df, forecast_df, boundary)
+    if df.empty:
+        df = forecast_df
 
     cache.set(cache_key, df, ttl=CACHE_TTL_SECONDS)
     from data.gcs_store import write_parquet
 
     write_parquet(df, "weather", region)
-    log.info("weather_cached", region=region, rows=len(df))
+    log.info(
+        "weather_cached",
+        region=region,
+        rows=len(df),
+        archive_rows=0 if archive_df is None else len(archive_df),
+        forecast_rows=len(forecast_df),
+    )
     return df
 
 

--- a/tests/unit/test_weather_client.py
+++ b/tests/unit/test_weather_client.py
@@ -305,9 +305,12 @@ class TestFetchWeather:
         pd.testing.assert_frame_equal(result, gcs_df)
 
     @patch("data.weather_client.get_cache")
-    def test_api_called_with_correct_params(self, mock_get_cache, mock_weather_response):
-        """API request uses correct coordinates, variables, and units."""
-        from data.weather_client import fetch_weather
+    def test_calls_both_endpoints_with_correct_params(self, mock_get_cache, mock_weather_response):
+        """fetch_weather now hits TWO endpoints (#161): /forecast for
+        recent+future, archive for deep history. Verify each is called
+        with the right params — coords/units shared, forecast uses a
+        short past_days + forecast_days, archive uses start/end dates."""
+        from data.weather_client import ARCHIVE_LAG_DAYS, fetch_weather
 
         mock_cache = MagicMock()
         mock_cache.get.return_value = None
@@ -323,16 +326,33 @@ class TestFetchWeather:
         ):
             fetch_weather("ERCOT", past_days=30, forecast_days=3)
 
-        _, kwargs = mock_get.call_args
-        params = kwargs["params"]
-        assert params["latitude"] == 31.0
-        assert params["longitude"] == -97.0
-        assert params["past_days"] == 30
-        assert params["forecast_days"] == 3
-        assert params["temperature_unit"] == "fahrenheit"
-        assert params["wind_speed_unit"] == "mph"
-        assert params["timezone"] == "UTC"
-        assert "temperature_2m" in params["hourly"]
+        # Two HTTP calls: forecast first, archive second.
+        assert mock_get.call_count == 2
+        forecast_call, archive_call = mock_get.call_args_list
+
+        # Forecast endpoint: short past_days (overlap only), the requested
+        # forecast horizon, shared coords/units.
+        f_url = forecast_call.args[0] if forecast_call.args else forecast_call.kwargs.get("url", "")
+        f_params = forecast_call.kwargs["params"]
+        assert "/forecast" in f_url
+        assert f_params["latitude"] == 31.0
+        assert f_params["longitude"] == -97.0
+        assert f_params["past_days"] == ARCHIVE_LAG_DAYS + 2
+        assert f_params["forecast_days"] == 3
+        assert f_params["temperature_unit"] == "fahrenheit"
+        assert f_params["wind_speed_unit"] == "mph"
+        assert "temperature_2m" in f_params["hourly"]
+
+        # Archive endpoint: start/end dates instead of past_days, same
+        # coords/units.
+        a_url = archive_call.args[0] if archive_call.args else archive_call.kwargs.get("url", "")
+        a_params = archive_call.kwargs["params"]
+        assert "archive" in a_url
+        assert "start_date" in a_params
+        assert "end_date" in a_params
+        assert "past_days" not in a_params
+        assert a_params["latitude"] == 31.0
+        assert a_params["temperature_unit"] == "fahrenheit"
 
     @patch("data.weather_client.get_cache")
     def test_http_500_triggers_fallback_chain(self, mock_get_cache):
@@ -468,3 +488,149 @@ class TestFetchHistoricalWeather:
 
         with pytest.raises(ValueError, match="Invalid start_date format"):
             fetch_historical_weather("ERCOT", None, "2024-01-31")
+
+
+# ---------------------------------------------------------------------------
+# #161 (C): archive + forecast stitch
+# ---------------------------------------------------------------------------
+
+
+class TestStitchWeather:
+    """Unit tests for _stitch_weather — boundary split + dedup."""
+
+    @staticmethod
+    def _df(start: str, n: int, temp: float) -> pd.DataFrame:
+        ts = pd.date_range(start, periods=n, freq="h", tz="UTC")
+        return pd.DataFrame({"timestamp": ts, "temperature_2m": [temp] * n})
+
+    def test_archive_before_boundary_forecast_after(self):
+        from data.weather_client import _stitch_weather
+
+        boundary = pd.Timestamp("2026-05-20 23:00", tz="UTC")
+        archive = self._df("2026-05-19 00:00", 48, temp=70.0)  # spans the boundary
+        forecast = self._df("2026-05-20 00:00", 72, temp=99.0)  # spans + after
+
+        out = _stitch_weather(archive, forecast, boundary)
+        before = out[out["timestamp"] <= boundary]
+        after = out[out["timestamp"] > boundary]
+        # Everything <= boundary came from archive (70), everything after
+        # from forecast (99).
+        assert (before["temperature_2m"] == 70.0).all()
+        assert (after["temperature_2m"] == 99.0).all()
+        # No duplicate timestamps across the seam.
+        assert out["timestamp"].is_unique
+        assert out["timestamp"].is_monotonic_increasing
+
+    def test_archive_none_returns_forecast_after_boundary(self):
+        from data.weather_client import _stitch_weather
+
+        boundary = pd.Timestamp("2026-05-20 23:00", tz="UTC")
+        forecast = self._df("2026-05-21 00:00", 24, temp=88.0)
+        out = _stitch_weather(None, forecast, boundary)
+        assert len(out) == 24
+        assert (out["temperature_2m"] == 88.0).all()
+
+    def test_empty_inputs_return_empty_frame(self):
+        from data.weather_client import _stitch_weather
+
+        out = _stitch_weather(None, pd.DataFrame(), pd.Timestamp("2026-05-20", tz="UTC"))
+        assert out.empty
+        assert "timestamp" in out.columns
+
+
+class TestFetchWeatherStitchOrchestration:
+    """fetch_weather's archive-enrichment orchestration (#161)."""
+
+    @patch("data.weather_client.get_cache")
+    def test_archive_failure_degrades_to_forecast_only(self, mock_get_cache):
+        """If the archive endpoint fails, keep the forecast result rather
+        than dropping to the stale/GCS fallback — forecast is the data the
+        model actually consumes."""
+        from data.weather_client import fetch_weather
+
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_get_cache.return_value = mock_cache
+
+        fc = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-05-25", periods=10, freq="h", tz="UTC"),
+                "temperature_2m": [80.0] * 10,
+            }
+        )
+
+        with (
+            patch("data.weather_client._fetch_forecast_endpoint", return_value=fc),
+            patch(
+                "data.weather_client._fetch_archive_endpoint",
+                side_effect=requests.ConnectionError("archive down"),
+            ),
+            patch("data.gcs_store.write_parquet"),
+        ):
+            result = fetch_weather("ERCOT", use_cache=False)
+
+        # Forecast-only result, no exception, cached normally.
+        assert not result.empty
+        assert len(result) == 10
+        mock_cache.set.assert_called_once()
+
+    @patch("data.weather_client.get_cache")
+    def test_combines_archive_history_with_forecast(self, mock_get_cache):
+        """Happy path: deep archive history + recent/future forecast are
+        stitched into one frame covering both."""
+        from data.weather_client import fetch_weather
+
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_get_cache.return_value = mock_cache
+
+        # Archive: 60 days ago up to ~now-5d. Forecast: ~now-7d into future.
+        archive = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-03-01", periods=500, freq="h", tz="UTC"),
+                "temperature_2m": [60.0] * 500,
+            }
+        )
+        forecast = pd.DataFrame(
+            {
+                "timestamp": pd.date_range("2026-05-29", periods=200, freq="h", tz="UTC"),
+                "temperature_2m": [95.0] * 200,
+            }
+        )
+
+        with (
+            patch("data.weather_client._fetch_forecast_endpoint", return_value=forecast),
+            patch("data.weather_client._fetch_archive_endpoint", return_value=archive),
+            patch("data.gcs_store.write_parquet"),
+        ):
+            result = fetch_weather("ERCOT", use_cache=False)
+
+        # Result should contain BOTH the deep-history archive rows and the
+        # recent/future forecast rows — far more than either alone could
+        # provide under the degraded single-endpoint path.
+        assert len(result) > 500
+        assert result["timestamp"].is_unique
+        # Has both temperature regimes (archive 60, forecast 95).
+        temps = set(result["temperature_2m"].unique())
+        assert 60.0 in temps and 95.0 in temps
+
+    @patch("data.weather_client.get_cache")
+    def test_forecast_failure_uses_fallback_chain(self, mock_get_cache):
+        """If the FORECAST endpoint fails, the stale-cache fallback runs
+        (archive is never reached) — preserves the original contract."""
+        from data.weather_client import fetch_weather
+
+        stale = pd.DataFrame({"timestamp": [1], "temperature_2m": [50.0]})
+        mock_cache = MagicMock()
+        mock_cache.get.side_effect = [None, stale]  # fresh miss, stale hit
+        mock_get_cache.return_value = mock_cache
+
+        with patch(
+            "data.weather_client._fetch_forecast_endpoint",
+            side_effect=requests.Timeout("forecast down"),
+        ):
+            result = fetch_weather("ERCOT")
+
+        pd.testing.assert_frame_equal(result, stale)
+        assert mock_cache.get.call_count == 2
+        assert mock_cache.get.call_args_list[1][1] == {"allow_stale": True}


### PR DESCRIPTION
**Closes #161** — the proper fix behind the 2026-05-29 forecast outage. Mitigation (A, #162) restored service by imputing sparse weather; (C) fixes the root cause: source deep history from Open-Meteo's **archive (ERA5)** endpoint instead of `/forecast?past_days=92`, which is the path that degraded.

## What changed

`fetch_weather` now stitches two endpoints:

| Endpoint | Window | Order | On failure |
|---|---|---|---|
| `/forecast` | recent (`past_days=7`) + `forecast_days` horizon | **first** | stale-cache → GCS → empty (existing chain) |
| archive (ERA5) | deep `[today-92d, today-5d]` | **second** (enrichment) | graceful → forecast-only |

Stitched on a timestamp boundary (archive ≤ boundary, forecast after), deduped, archive preferred in the overlap (reanalysis beats forecast-model backfill for past hours).

**Lean helpers** `_fetch_forecast_endpoint` / `_fetch_archive_endpoint` do bare HTTP+parse with no cache/fallback — deliberately **not** reusing the public `fetch_historical_weather`, whose own `cache.get` path would pollute the exact cache-call accounting the fallback tests assert on.

## Verified against the live degraded feed (FPL + ERCOT)

| Metric | pre-C (degraded) | post-C |
|---|---|---|
| weather vars ≥90% historical coverage | ~0 (only recent ~478 rows had any) | **14/17, full ~2592-row span** |
| feature rows after engineering | 103 (sub-threshold → outage) | **2009** |

The 3 vars ERA5 lacks (`wind_speed_80m`/`120m`, `soil_temperature_0cm`) are present for recent+forecast and imputed on deep history by mitigation A — as designed.

**The bigger win is training:** it now learns from *real* historical weather instead of the smeared ffill/bfill imputation A leaves behind. Scoring was already fine post-A (it consumes recent+future, which is real); training is where real history matters.

## Test plan

- ✅ `TestStitchWeather` — boundary split, archive-None, empty inputs
- ✅ `TestFetchWeatherStitchOrchestration` — archive-failure → forecast-only; archive+forecast combine; forecast-failure → fallback chain
- ✅ `test_calls_both_endpoints_with_correct_params` — updated for the two-endpoint contract
- ✅ All existing fallback/success tests still green (forecast-first preserves the contract)
- ✅ Full suite: **1760 passed**; lint clean
- ⏳ Post-merge: CI-gated deploy → manual scoring run → `/health?deep=1` stays `ok`, and `weather_cached` logs show `archive_rows` populated

## Deferred (Option 3, in #161)

If a feature-importance ablation later confirms `wind_speed_80m/120m` + `soil_temperature_0cm` are deadweight, drop them + retrain so *all* features are archive-stable. Not bundled here — that's a model-contract change needing a retrain, and shouldn't ride a P0 follow-up.

## Cost note

Doubles Open-Meteo calls per region per fetch (archive + forecast) → ~2.4k calls/day across 51 regions hourly, well within the free tier. Combined result is cached (24h TTL) as before.