### PR TITLE
feat(ops): Cloud Monitoring alert on Cloud Run Job failures (PR-G10, closes #150)

### DIFF
--- a/docs/SCHEDULED_JOBS.md
+++ b/docs/SCHEDULED_JOBS.md
@@ -321,13 +321,53 @@ gcloud run jobs update gridpulse-training-job \
 | Backtest tab empty | `gridpulse:backtest:{exog_mode}:{region}:{horizon}` not populated — needs training tick (daily) or force-execute |
 | Model accuracy card SHOWS numbers but charts are empty | Expected: MAPE/RMSE/MAE/R² come from GCS `meta.json` (persisted at training time, independent of Redis). The card is reading from the durable source while the live data flows from Redis are still warming. Not a bug. |
 
+## Alerting + incident response (PR-G10 / #150)
+
+A Cloud Monitoring alert policy (`GridPulse — Cloud Run Job failed
+execution`, live since 2026-05-29) fires on a failed execution of either
+job and emails `kristen.e.martino@gmail.com`. Policy-as-code +
+re-apply commands live in [`docs/monitoring/`](monitoring/README.md).
+
+This closes the gap behind two 2026-05 incidents that were found by
+manual check rather than alert: the silent training-scheduler miss
+(#141) and the all-region forecast outage (#161).
+
+**One-time:** the email channel needs a verification click (sent on
+creation) — confirm `gcloud beta monitoring channels describe <id>
+--format='value(verificationStatus)'` reads `VERIFIED`.
+
+### When the job-failure alert fires
+
+1. **Identify**: `bash scripts/audit/check_overnight_training.sh`
+   (training) or `gcloud run jobs executions list --job=gridpulse-scoring-job
+   --region=us-east1` (scoring) — find the failed execution.
+2. **Diagnose**: tail the failed execution's logs for the per-region
+   cause (`scoring_job_region_crashed`, `job_insufficient_feature_rows`,
+   `all_models_failed`, etc.).
+3. **Mitigate**:
+   - Training miss → trigger a make-up run:
+     `gcloud run jobs execute gridpulse-training-job --region=us-east1`.
+   - Scoring miss → the next hourly tick self-heals; force one now if
+     urgent: `gcloud run jobs execute gridpulse-scoring-job --region=us-east1`.
+   - Systemic (all regions) → check `/health?deep=1`, suspect a
+     data-source or feature-pipeline fault (cf. #161), roll back the
+     image via `latest.json` if code-caused.
+4. **Confirm recovery**: `curl "$PROD_URL/health?deep=1"` →
+   `status: healthy`, `forecast_sample: ok`.
+
+Known follow-ups (see `docs/monitoring/README.md`): a Cloud Scheduler
+error alert (catches a scheduler-side miss even when no execution is
+created) and a deep-`/health` degraded uptime alert (would catch a
+#161-style outage where infra is healthy but no forecasts exist).
+
 ## Operations
 
 - **Redis staleness**: `gridpulse:meta:last_scored.updated_at` should be
-  within the last ~90 minutes. Consider a Cloud Monitoring alert on
-  absence.
+  within the last ~90 minutes. Surfaced by `/health` `last_scored` check;
+  a dedicated absence alert is a documented follow-up (above).
 - **Job failure**: Cloud Run Jobs exit non-zero only when every region
-  fails. Watch the per-execution logs for per-region
+  fails — but the alert policy (above) fires on ANY failed execution.
+  Watch per-execution logs for per-region
   `scoring_job_region_crashed` / `training_job_region_crashed` entries.
 - **Model promotion**: the training job updates
   `gs://.../cache/models/latest.json` last — this is the atomic pointer.

--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -1,0 +1,72 @@
+# Cloud Monitoring — alerting (PR-G10 / #150)
+
+Policy-as-code for GridPulse's production alerting. These close the
+observability gap that let two 2026-05 incidents (the silent training
+miss and the all-region forecast outage) go undetected until a manual
+`/health` / log check found them.
+
+## What's here
+
+| File | Alert |
+|---|---|
+| `cloud_run_job_failure_alert.json` | Fires when `gridpulse-training-job` or `gridpulse-scoring-job` records a **failed execution** (`run.googleapis.com/job/completed_execution_count{result="failed"}` > 0, summed hourly per job). |
+
+## Notification channel
+
+One email channel (`GridPulse ops (Kristen)` →
+`kristen.e.martino@gmail.com`), id
+`projects/nextera-portfolio/notificationChannels/7265334362271951327`.
+
+```bash
+# (re)create the channel
+gcloud beta monitoring channels create \
+  --project=nextera-portfolio \
+  --display-name="GridPulse ops (Kristen)" \
+  --type=email \
+  --channel-labels=email_address=YOUR_EMAIL
+```
+
+> ⚠ **Email channels require a one-time verification click.** After
+> creation Google sends a verification email; until it's clicked, the
+> policy evaluates + creates incidents but does NOT deliver email.
+> Confirm status: `gcloud beta monitoring channels describe <id>
+> --format='value(verificationStatus)'` → should read `VERIFIED`.
+
+## Apply / re-apply a policy
+
+```bash
+gcloud beta monitoring policies create \
+  --project=nextera-portfolio \
+  --policy-from-file=docs/monitoring/cloud_run_job_failure_alert.json \
+  --notification-channels="projects/nextera-portfolio/notificationChannels/7265334362271951327"
+```
+
+Live as of 2026-05-29: policy
+`projects/nextera-portfolio/alertPolicies/5965243952275624431` (enabled).
+
+## Verification (one manual step)
+
+CLI confirms the policy is enabled, correctly filtered, and channel-bound.
+What can't be checked from the CLI (no clean `incidents list`; email is
+verification-gated) is end-to-end **fire + deliver**. To confirm once:
+
+```bash
+# Throwaway failing execution → produces a `failed` execution metric.
+# Overrides the command so it exits non-zero WITHOUT running real scoring
+# (no Redis writes). Leaves one fake "failed" row in the job history.
+gcloud run jobs execute gridpulse-scoring-job --region=us-east1 \
+  --command=python --args=-c,"import sys; sys.exit(1)"
+# Then: wait ~10-15 min, confirm an incident appears in the Cloud
+# Monitoring console (Alerting → Incidents) and an email arrives.
+```
+
+## Follow-ups (not yet implemented)
+
+- **Cloud Scheduler error alert** — fiddlier (no clean error metric; alert
+  on `cloudscheduler.googleapis.com/job/attempt_count` filtered to
+  non-2xx `response_code`). Would catch a scheduler-side miss like the
+  2026-05-21 503 even when no execution is created. Tracked in #150.
+- **Deep-`/health` degraded alert** — an uptime check hitting
+  `/health?deep=1` and alerting on `status != healthy` would have caught
+  the 2026-05-29 forecast outage directly (it had healthy infra but no
+  forecast payloads). Strong complement to the job-failure alert.

--- a/docs/monitoring/cloud_run_job_failure_alert.json
+++ b/docs/monitoring/cloud_run_job_failure_alert.json
@@ -1,0 +1,29 @@
+{
+  "displayName": "GridPulse — Cloud Run Job failed execution",
+  "documentation": {
+    "mimeType": "text/markdown",
+    "content": "A GridPulse Cloud Run Job recorded a **failed execution**.\n\nThis fires on `run.googleapis.com/job/completed_execution_count{result=\"failed\"}` > 0 for `gridpulse-training-job` or `gridpulse-scoring-job`, summed hourly per job.\n\n**Runbook:** see `docs/SCHEDULED_JOBS.md` → \"Alerting + incident response\". TL;DR:\n1. `bash scripts/audit/check_overnight_training.sh` for training; check `gcloud run jobs executions list` for scoring.\n2. Tail the failed execution's logs for the per-region cause.\n3. Training miss → trigger a make-up run (`gcloud run jobs execute ...`). Scoring miss → next hourly tick self-heals; force one if urgent.\n4. If a real data/code fault, file an issue and roll back the image if needed."
+  },
+  "combiner": "OR",
+  "conditions": [
+    {
+      "displayName": "training or scoring job failed execution (hourly)",
+      "conditionThreshold": {
+        "filter": "resource.type = \"cloud_run_job\" AND metric.type = \"run.googleapis.com/job/completed_execution_count\" AND metric.labels.result = \"failed\" AND (resource.labels.job_name = \"gridpulse-training-job\" OR resource.labels.job_name = \"gridpulse-scoring-job\")",
+        "comparison": "COMPARISON_GT",
+        "thresholdValue": 0,
+        "duration": "0s",
+        "trigger": { "count": 1 },
+        "aggregations": [
+          {
+            "alignmentPeriod": "3600s",
+            "perSeriesAligner": "ALIGN_SUM",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "groupByFields": ["resource.labels.job_name"]
+          }
+        ]
+      }
+    }
+  ],
+  "alertStrategy": { "autoClose": "604800s" }
+}


### PR DESCRIPTION
Closes #150. **Final Phase 2 item.** Closes the observability gap behind two 2026-05 incidents that were found by *manual check, not alert*: the silent training-scheduler miss (#141) and the all-region forecast outage (#161).

## Live in GCP (2026-05-29)

- **Email notification channel** `GridPulse ops (Kristen)` → `kristen.e.martino@gmail.com` (`...7265334362271951327`)
- **Alert policy** `GridPulse — Cloud Run Job failed execution` (`...5965243952275624431`, enabled) — fires on `run.googleapis.com/job/completed_execution_count{result="failed"}` > 0 for `gridpulse-training-job` or `gridpulse-scoring-job`, summed hourly per job, runbook inline as policy documentation.

## Policy-as-code

Committed under `docs/monitoring/` (JSON + re-apply commands) so the policy is **reviewable + reproducible**, not just console state. Plus an "Alerting + incident response" runbook in `SCHEDULED_JOBS.md`.

## Verification — what I could and couldn't confirm

✅ **CLI-verified:** policy enabled, correct standard metric + filter, notification channel bound (`gcloud beta monitoring policies describe`).

⚠️ **Inherently manual (documented, not done):**
- **Email channel verification** — Google sends a one-click verify email on creation; until clicked, the policy creates incidents but doesn't *deliver* email. You complete this.
- **End-to-end fire-test** — gcloud has no clean `incidents list`, and email is verification-gated, so I couldn't *observe* a fire autonomously. I deliberately did **not** run a throwaway failing execution: it'd leave a fake `failed` row in the job history whose alert result I can't even see. The fire-test procedure is documented in `docs/monitoring/README.md` for a deliberate run.

This is the honest line: I shipped the alerting that would've caught both incidents and verified everything CLI-checkable, but didn't manufacture false confidence about delivery I can't observe.

## Follow-ups (documented in `docs/monitoring/README.md`)

- **Cloud Scheduler error alert** — catches a scheduler-side miss (like #141's 503) even when no execution is created. Fiddlier metric (`attempt_count` filtered to non-2xx).
- **Deep-`/health` degraded uptime alert** — would catch a #161-style outage directly (healthy infra, no forecasts). Strong complement.

## Scope

Docs + policy-as-code only — **no application code changed**.

## Phase 2 complete after this 🎉

| Issue | PR | State |
|---|---|---|
| #146 PR-G2 — gate deploys behind CI | #159 | ✅ merged + prod-verified |
| #147 PR-G3 — deep /health | #160 | ✅ merged + caught #161 |
| **#150 PR-G10 — job-failure alerting** | this PR | ⏳ |