### PR TITLE
docs: align stale feature count, ERCOT reference, BA-coverage % with CANONICAL_FACTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Four role-based personas (Grid Ops, Renewables Analyst, Trader, Data Scientist) 
 
 ## Models
 
-- **XGBoost** — 43 engineered features, TimeSeriesSplit CV, SHAP explanations. Reference run: 3.13% MAPE on ERCOT 21-day holdout (Feb 2026).
+- **XGBoost** — 49 engineered features, TimeSeriesSplit CV, SHAP explanations. Best base model for 48 of 51 BAs; reference run 0.98% MAPE on ERCOT (168-hour holdout, 2026-06-19).
 - **Prophet** — weather regressors with logistic growth + floor=0 (structurally prevents negative forecasts). Daily / weekly / yearly seasonality.
 - **SARIMAX** — auto-order selection via `pmdarima` on cold runs; cached `(p,d,q)(P,D,Q,m)` order on warm runs (skips the auto-select stepwise search, ~10× speedup on daily refresh).
 - **Ensemble** — inverse-MAPE weighted combination (self-correcting; underperforming models lose weight automatically).

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -189,7 +189,7 @@ Pulled from [`CANONICAL_FACTS.md`](CANONICAL_FACTS.md):
 - 51 US balancing authorities (~100% of contiguous-US lower-48 load)
 - 3 base ML models (Prophet, SARIMAX, XGBoost) + 1 inverse-MAPE weighted ensemble
 - 4 user-selectable forecasts in the UI (the 3 base + the ensemble)
-- 43 features (17 raw weather + 26 derived)
+- 49 features (17 raw weather + 32 derived)
 - Hourly scoring + daily training at 04:00 UTC
 - Redis-only reads in the web tier; degraded warming state when cold
-- 63 EIA-930 BAs in the contiguous US — we cover 51 of them (~80% by BA count, ~100% by demand-weighted load)
+- 63 EIA-930 BAs in the contiguous US — we cover 51 of them (~81% by BA count, ~100% by demand-weighted load)


### PR DESCRIPTION
Brings two consumer docs back into agreement with `docs/CANONICAL_FACTS.md` (the cross-doc source of truth) after the post-audit refresh in #180. **Documentation-only — no code or canonical values change.**

## What changed

**`docs/HOW_IT_WORKS.md`** — the "Anchor numbers (verbatim recall)" list (explicitly *"Pulled from CANONICAL_FACTS.md"*) had drifted from its source:
- `43 features (17 raw + 26 derived)` → `49 (17 raw + 32 derived)` — matches CANONICAL_FACTS.md and the model diagram in the same file
- `~80% by BA count` → `~81%` (51 / 63 = 80.95%) — matches CANONICAL_FACTS.md

**`README.md`** (Models section):
- `43 engineered features` → `49`
- Replaced the stale pre-leakage-fix reference run `3.13% MAPE on ERCOT 21-day holdout (Feb 2026)` with the current `0.98% MAPE on ERCOT (168-hour holdout, 2026-06-19)` plus "best base model for 48 of 51 BAs" — consistent with the 168h-holdout methodology the README already describes two lines down, and with the canonical accuracy table.

## Why

The feature count (49) and current ERCOT accuracy (0.98%) are already canonical; these two files were the last consumers still citing the old `43`-feature figure and a superseded pre-leakage MAPE. A repo-wide scan now confirms **zero** remaining `43 features` / `26 derived` / `43 engineered` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpchhQvdbi57Xo476A9F54

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpchhQvdbi57Xo476A9F54)_